### PR TITLE
chore: bump to v0.8.0 for smart workout recommendations

### DIFF
--- a/garmincoach/CHANGELOG.md
+++ b/garmincoach/CHANGELOG.md
@@ -5,6 +5,38 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.8.0] — 2026-04-03
+
+### Fixed
+
+- **Smart workout recommendations** — replaced unconditional "Rest Day"
+  for poor readiness with evidence-based decision logic. Complete rest now
+  only prescribed for critical signals (ACWR >1.5, TSB <-25, Body Battery
+  <20, sleep debt >3h). Otherwise suggests Active Recovery with
+  sport-specific guidance.
+- **VO2max trend filtering** — low-confidence VO2max sources (Uth method)
+  excluded from trend calculations to prevent non-workout-day data from
+  skewing improving/declining detection.
+
+### Added
+
+- **RecoveryContext type** — ACWR, TSB, body battery, sleep debt, and
+  stress score passed from database to coaching engine for evidence-based
+  workout modulation.
+- **Active Recovery workout type** — new workout category with structured
+  warmup/main/cooldown phases, sport-specific descriptions (running:
+  conversational jog, cycling: easy spin, strength: mobility work).
+- **Comprehensive vitest coverage** — VO2max trend source filtering and
+  coaching modulation tests (20+ test cases covering all critical triggers).
+
+### References
+
+- Hulin BT et al. (2016) Br J Sports Med — ACWR >1.5 injury risk
+- Meeusen R et al. (2013) Eur J Sport Sci — overreaching indicators
+- Mah CD et al. (2011) Sleep — sleep debt impact on performance
+- Barnett A (2006) Sports Med — active recovery modalities
+- Uth N et al. (2004) Eur J Appl Physiol — VO2max HR ratio accuracy
+
 ## [0.7.0] — 2026-04-03
 
 ### Fixed

--- a/garmincoach/Dockerfile
+++ b/garmincoach/Dockerfile
@@ -89,4 +89,4 @@ LABEL \
     io.hass.description="AI-powered sport scientist for Garmin athletes" \
     io.hass.arch="${BUILD_ARCH}" \
     io.hass.type="addon" \
-    io.hass.version="0.7.0"
+    io.hass.version="0.8.0"

--- a/garmincoach/config.json
+++ b/garmincoach/config.json
@@ -1,6 +1,6 @@
 {
   "name": "GarminCoach",
-  "version": "0.7.0",
+  "version": "0.8.0",
   "slug": "garmincoach",
   "image": "ghcr.io/askb/garmincoach-addon-{arch}",
   "description": "AI-powered sport scientist \u2014 training analysis, coaching, and recovery optimization from your Garmin data",


### PR DESCRIPTION
## Summary
Version bump to pick up app changes merged in askb/ha-garmin-fitness-coach-app#50:
- Evidence-based workout modulation (replaces unconditional rest day for poor readiness)
- VO2max trend source filtering (excludes low-confidence Uth estimates)
- RecoveryContext type and Active Recovery workout category
- Comprehensive test coverage (20+ vitest cases)

## Test plan
- [ ] Docker build succeeds (amd64, aarch64)
- [ ] Pre-commit hooks pass
- [ ] After merge + tag v0.8.0, GHCR images pushed and addon updates on HAOS

Signed-off-by: Anil Belur <askb23@gmail.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)