### PR TITLE
feat: add HA automation blueprints and AI trend tests

### DIFF
--- a/garmincoach/rootfs/app/blueprints/injury_risk_alert.yaml
+++ b/garmincoach/rootfs/app/blueprints/injury_risk_alert.yaml
@@ -1,0 +1,88 @@
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2026 Anil Belur
+---
+blueprint:
+  name: "GarminCoach: Injury Risk Alert"
+  description: >
+    Sends an urgent notification when the injury risk sensor transitions
+    to high or critical. Optionally triggers a scene and enables DND.
+  domain: automation
+  author: askb
+  source_url: >-
+    https://github.com/askb/ha-garmin-fitness-coach-addon/blob/main/garmincoach/rootfs/app/blueprints/injury_risk_alert.yaml
+  input:
+    injury_risk_sensor:
+      name: Injury Risk Sensor
+      default: sensor.garmincoach_injury_risk
+      selector:
+        entity:
+          domain: sensor
+    acwr_sensor:
+      name: ACWR Sensor
+      default: sensor.garmincoach_acwr
+      selector:
+        entity:
+          domain: sensor
+    risk_level:
+      name: Minimum Risk Level
+      description: Alert when risk reaches this level or higher.
+      default: high
+      selector:
+        select:
+          options:
+            - moderate
+            - high
+            - critical
+    notify_service:
+      name: Notification Service
+      description: Service to receive the alert.
+      default: notify.persistent_notification
+      selector:
+        text: {}
+    enable_dnd:
+      name: Enable Do-Not-Disturb
+      description: >
+        Toggle an input_boolean to signal rest mode to other automations.
+      default: false
+      selector:
+        boolean: {}
+    dnd_entity:
+      name: DND Input Boolean (optional)
+      description: Entity to turn on when rest is needed.
+      default: {}
+      selector:
+        entity:
+          domain: input_boolean
+
+trigger:
+  - platform: state
+    entity_id: !input injury_risk_sensor
+
+condition:
+  - condition: template
+    value_template: >-
+      {% set levels = ['low', 'moderate', 'high', 'critical'] %}
+      {% set min_idx = levels.index(risk_level) if risk_level in levels else 2 %}
+      {% set cur_idx = levels.index(trigger.to_state.state)
+         if trigger.to_state.state in levels else -1 %}
+      {{ cur_idx >= min_idx }}
+
+action:
+  - service: !input notify_service
+    data:
+      title: "⚠️ Injury Risk: {{ trigger.to_state.state | title }}"
+      message: >-
+        Injury risk is now {{ trigger.to_state.state }}.
+        ACWR: {{ states(acwr_sensor) }}.
+        Consider reducing training load and prioritising recovery.
+  - choose:
+      - conditions:
+          - condition: template
+            value_template: "{{ enable_dnd }}"
+        sequence:
+          - service: input_boolean.turn_on
+            target:
+              entity_id: !input dnd_entity
+
+mode: single
+max_exceeded: silent

--- a/garmincoach/rootfs/app/blueprints/low_body_battery_recovery.yaml
+++ b/garmincoach/rootfs/app/blueprints/low_body_battery_recovery.yaml
@@ -1,0 +1,97 @@
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2026 Anil Belur
+---
+blueprint:
+  name: "GarminCoach: Low Body Battery Recovery Mode"
+  description: >
+    Activates a recovery scene when Garmin Body Battery drops below
+    a configurable threshold. Dims lights, enables DND, and sends
+    a notification reminding the athlete to rest.
+  domain: automation
+  author: askb
+  source_url: >-
+    https://github.com/askb/ha-garmin-fitness-coach-addon/blob/main/garmincoach/rootfs/app/blueprints/low_body_battery_recovery.yaml
+  input:
+    body_battery_sensor:
+      name: Body Battery Sensor
+      description: GarminCoach body battery sensor entity.
+      default: sensor.garmincoach_body_battery
+      selector:
+        entity:
+          domain: sensor
+    threshold:
+      name: Body Battery Threshold
+      description: Trigger recovery mode when body battery is below this value.
+      default: 40
+      selector:
+        number:
+          min: 10
+          max: 80
+          step: 5
+          unit_of_measurement: "%"
+    recovery_scene:
+      name: Recovery Scene (optional)
+      description: >
+        Scene to activate for recovery. Leave empty to skip scene activation.
+      default: {}
+      selector:
+        entity:
+          domain: scene
+    light_target:
+      name: Lights to Dim (optional)
+      description: Lights to set to warm dim when recovery triggers.
+      default: {}
+      selector:
+        target:
+          entity:
+            domain: light
+    notify_service:
+      name: Notification Service
+      description: >
+        Notification service to send recovery reminder
+        (e.g., notify.mobile_app_phone).
+      default: notify.persistent_notification
+      selector:
+        text: {}
+
+trigger:
+  - platform: numeric_state
+    entity_id: !input body_battery_sensor
+    below: !input threshold
+    for:
+      minutes: 5
+
+condition:
+  - condition: time
+    after: "06:00:00"
+    before: "23:00:00"
+
+action:
+  - choose:
+      - conditions:
+          - condition: template
+            value_template: "{{ recovery_scene is defined and recovery_scene }}"
+        sequence:
+          - service: scene.turn_on
+            target:
+              entity_id: !input recovery_scene
+  - choose:
+      - conditions:
+          - condition: template
+            value_template: >-
+              {{ light_target is defined and light_target }}
+        sequence:
+          - service: light.turn_on
+            target: !input light_target
+            data:
+              brightness_pct: 30
+              color_temp_kelvin: 2700
+  - service: !input notify_service
+    data:
+      title: "🔋 Low Body Battery — Recovery Mode"
+      message: >-
+        Body battery is {{ states(body_battery_sensor) }}%.
+        Consider light activity or rest. Recovery scene activated.
+
+mode: single
+max_exceeded: silent

--- a/garmincoach/rootfs/app/blueprints/morning_training_briefing.yaml
+++ b/garmincoach/rootfs/app/blueprints/morning_training_briefing.yaml
@@ -1,0 +1,98 @@
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2026 Anil Belur
+---
+blueprint:
+  name: "GarminCoach: Morning Training Briefing"
+  description: >
+    Delivers a TTS morning briefing with readiness, ACWR, form (TSB),
+    and today's workout recommendation. Fires at a configurable time.
+  domain: automation
+  author: askb
+  source_url: >-
+    https://github.com/askb/ha-garmin-fitness-coach-addon/blob/main/garmincoach/rootfs/app/blueprints/morning_training_briefing.yaml
+  input:
+    briefing_time:
+      name: Briefing Time
+      description: Time to deliver the morning briefing.
+      default: "06:30:00"
+      selector:
+        time: {}
+    tts_service:
+      name: TTS Service
+      description: >
+        Text-to-speech service (e.g., tts.google_translate_say,
+        tts.cloud_say).
+      default: tts.speak
+      selector:
+        text: {}
+    tts_target:
+      name: TTS Media Player
+      description: Media player entity for TTS output.
+      default: media_player.living_room
+      selector:
+        entity:
+          domain: media_player
+    acwr_sensor:
+      name: ACWR Sensor
+      default: sensor.garmincoach_acwr
+      selector:
+        entity:
+          domain: sensor
+    form_sensor:
+      name: Form (TSB) Sensor
+      default: sensor.garmincoach_form
+      selector:
+        entity:
+          domain: sensor
+    injury_risk_sensor:
+      name: Injury Risk Sensor
+      default: sensor.garmincoach_injury_risk
+      selector:
+        entity:
+          domain: sensor
+    workout_sensor:
+      name: Workout Recommendation Sensor
+      default: sensor.garmincoach_workout_recommendation
+      selector:
+        entity:
+          domain: sensor
+    notify_service:
+      name: Notification Service (optional)
+      description: Also send as a push notification.
+      default: notify.persistent_notification
+      selector:
+        text: {}
+
+trigger:
+  - platform: time
+    at: !input briefing_time
+
+condition:
+  - condition: state
+    entity_id: !input acwr_sensor
+    state: "unavailable"
+    match: "not"
+
+action:
+  - variables:
+      acwr: "{{ states(acwr_sensor) }}"
+      form: "{{ states(form_sensor) }}"
+      risk: "{{ states(injury_risk_sensor) }}"
+      workout: "{{ states(workout_sensor) }}"
+      briefing: >-
+        Good morning. Your training status:
+        ACWR is {{ acwr }},
+        form is {{ form }},
+        injury risk is {{ risk }}.
+        Today's recommendation: {{ workout }}.
+  - service: !input tts_service
+    target:
+      entity_id: !input tts_target
+    data:
+      message: "{{ briefing }}"
+  - service: !input notify_service
+    data:
+      title: "🏃 Morning Training Briefing"
+      message: "{{ briefing }}"
+
+mode: single

--- a/garmincoach/rootfs/app/blueprints/training_freshness_reminder.yaml
+++ b/garmincoach/rootfs/app/blueprints/training_freshness_reminder.yaml
@@ -1,0 +1,68 @@
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2026 Anil Belur
+---
+blueprint:
+  name: "GarminCoach: Training Freshness Reminder"
+  description: >
+    Sends a training reminder when form (TSB) rises above a threshold,
+    indicating the athlete is fresh and ready for a quality session.
+  domain: automation
+  author: askb
+  source_url: >-
+    https://github.com/askb/ha-garmin-fitness-coach-addon/blob/main/garmincoach/rootfs/app/blueprints/training_freshness_reminder.yaml
+  input:
+    form_sensor:
+      name: Form (TSB) Sensor
+      default: sensor.garmincoach_form
+      selector:
+        entity:
+          domain: sensor
+    freshness_threshold:
+      name: Freshness Threshold (TSB)
+      description: >
+        Notify when form rises above this value.
+        Positive TSB means recovery exceeds fatigue.
+      default: 5
+      selector:
+        number:
+          min: -10
+          max: 30
+          step: 1
+    workout_sensor:
+      name: Workout Recommendation Sensor
+      default: sensor.garmincoach_workout_recommendation
+      selector:
+        entity:
+          domain: sensor
+    notify_service:
+      name: Notification Service
+      default: notify.persistent_notification
+      selector:
+        text: {}
+
+trigger:
+  - platform: numeric_state
+    entity_id: !input form_sensor
+    above: !input freshness_threshold
+    for:
+      hours: 1
+
+condition:
+  - condition: time
+    after: "07:00:00"
+    before: "20:00:00"
+  - condition: template
+    value_template: >-
+      {{ now().isoweekday() <= 6 }}
+
+action:
+  - service: !input notify_service
+    data:
+      title: "💪 You're Fresh — Time to Train!"
+      message: >-
+        Form (TSB) is {{ states(form_sensor) }}.
+        You're recovered and ready for a quality session.
+        Suggestion: {{ states(workout_sensor) }}.
+
+mode: single
+max_exceeded: silent

--- a/garmincoach/rootfs/app/blueprints/weekly_training_summary.yaml
+++ b/garmincoach/rootfs/app/blueprints/weekly_training_summary.yaml
@@ -1,0 +1,103 @@
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2026 Anil Belur
+---
+blueprint:
+  name: "GarminCoach: Weekly Training Summary"
+  description: >
+    Sends a weekly push notification summarising training load, form,
+    injury risk, and body battery trend. Fires on a configurable day.
+  domain: automation
+  author: askb
+  source_url: >-
+    https://github.com/askb/ha-garmin-fitness-coach-addon/blob/main/garmincoach/rootfs/app/blueprints/weekly_training_summary.yaml
+  input:
+    summary_day:
+      name: Summary Day
+      description: Day of the week for the summary.
+      default: "7"
+      selector:
+        select:
+          options:
+            - label: Monday
+              value: "1"
+            - label: Tuesday
+              value: "2"
+            - label: Wednesday
+              value: "3"
+            - label: Thursday
+              value: "4"
+            - label: Friday
+              value: "5"
+            - label: Saturday
+              value: "6"
+            - label: Sunday
+              value: "7"
+    summary_time:
+      name: Summary Time
+      default: "09:00:00"
+      selector:
+        time: {}
+    acwr_sensor:
+      name: ACWR Sensor
+      default: sensor.garmincoach_acwr
+      selector:
+        entity:
+          domain: sensor
+    form_sensor:
+      name: Form (TSB) Sensor
+      default: sensor.garmincoach_form
+      selector:
+        entity:
+          domain: sensor
+    ctl_sensor:
+      name: Fitness (CTL) Sensor
+      default: sensor.garmincoach_ctl
+      selector:
+        entity:
+          domain: sensor
+    atl_sensor:
+      name: Fatigue (ATL) Sensor
+      default: sensor.garmincoach_atl
+      selector:
+        entity:
+          domain: sensor
+    injury_risk_sensor:
+      name: Injury Risk Sensor
+      default: sensor.garmincoach_injury_risk
+      selector:
+        entity:
+          domain: sensor
+    body_battery_sensor:
+      name: Body Battery Sensor
+      default: sensor.garmincoach_body_battery
+      selector:
+        entity:
+          domain: sensor
+    notify_service:
+      name: Notification Service
+      default: notify.persistent_notification
+      selector:
+        text: {}
+
+trigger:
+  - platform: time
+    at: !input summary_time
+
+condition:
+  - condition: template
+    value_template: >-
+      {{ now().isoweekday() == (summary_day | int) }}
+
+action:
+  - service: !input notify_service
+    data:
+      title: "📊 Weekly Training Summary"
+      message: >-
+        **Fitness (CTL):** {{ states(ctl_sensor) }}
+        **Fatigue (ATL):** {{ states(atl_sensor) }}
+        **Form (TSB):** {{ states(form_sensor) }}
+        **ACWR:** {{ states(acwr_sensor) }}
+        **Injury Risk:** {{ states(injury_risk_sensor) }}
+        **Body Battery:** {{ states(body_battery_sensor) }}%
+
+mode: single

--- a/tests/unit/test_ai_trends.py
+++ b/tests/unit/test_ai_trends.py
@@ -1,0 +1,244 @@
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2026 Anil Belur
+"""Tests for AI trend analysis, workout recommendations, and injury risk logic.
+
+Covers three layers:
+  1. Input correctness — metrics dict has expected keys and types
+  2. Trend / decision logic — deterministic fixtures produce correct outputs
+  3. Confidence degradation — missing data reduces confidence
+"""
+
+from __future__ import annotations
+
+import importlib
+import sys
+import types
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+
+# ---------------------------------------------------------------------------
+# Import helpers — load production modules without psycopg2 at import time
+# ---------------------------------------------------------------------------
+
+SCRIPTS_DIR = Path(__file__).resolve().parents[2] / "garmincoach" / "rootfs" / "app" / "scripts"
+
+
+def _load_module(name: str, filename: str) -> types.ModuleType:
+    """Import a script module with psycopg2 mocked out."""
+    mock_psycopg2 = MagicMock()
+    mock_psycopg2.extras = MagicMock()
+
+    with patch.dict(sys.modules, {"psycopg2": mock_psycopg2, "psycopg2.extras": mock_psycopg2.extras}):
+        spec = importlib.util.spec_from_file_location(name, SCRIPTS_DIR / filename)
+        mod = importlib.util.module_from_spec(spec)
+        spec.loader.exec_module(mod)
+    return mod
+
+
+ha_notify = _load_module("ha_notify", "ha-notify.py")
+metrics_compute = _load_module("metrics_compute", "metrics-compute.py")
+
+
+# ===========================================================================
+# Layer 1: Workout recommendation — decision logic
+# ===========================================================================
+
+class TestWorkoutRecommendation:
+    """Verify recommend_workout() returns correct decisions for known inputs."""
+
+    def test_rest_day_high_acwr(self):
+        """ACWR >1.5 triggers mandatory rest (Hulin 2016)."""
+        result = ha_notify.recommend_workout(
+            acwr=1.6, tsb=0.0, body_battery=60,
+            stress_score=40, sleep_debt_minutes=0,
+            consecutive_hard_days=0,
+        )
+        assert result["is_rest_day"] is True
+        assert "ACWR" in result["rationale"]
+
+    def test_rest_day_low_tsb(self):
+        """TSB < -25 triggers rest (Meeusen 2013)."""
+        result = ha_notify.recommend_workout(
+            acwr=1.0, tsb=-30.0, body_battery=60,
+            stress_score=40, sleep_debt_minutes=0,
+            consecutive_hard_days=0,
+        )
+        assert result["is_rest_day"] is True
+        assert "TSB" in result["rationale"]
+
+    def test_rest_day_low_body_battery(self):
+        """Body Battery < 20 triggers rest."""
+        result = ha_notify.recommend_workout(
+            acwr=1.0, tsb=5.0, body_battery=15,
+            stress_score=40, sleep_debt_minutes=0,
+            consecutive_hard_days=0,
+        )
+        assert result["is_rest_day"] is True
+        assert "Body Battery" in result["rationale"]
+
+    def test_rest_day_sleep_debt(self):
+        """Sleep debt >3h triggers rest (Mah 2011)."""
+        result = ha_notify.recommend_workout(
+            acwr=1.0, tsb=5.0, body_battery=60,
+            stress_score=40, sleep_debt_minutes=200,
+            consecutive_hard_days=0,
+        )
+        assert result["is_rest_day"] is True
+        assert "Sleep" in result["rationale"] or "sleep" in result["rationale"].lower()
+
+    def test_rest_day_consecutive_hard_days(self):
+        """3+ consecutive hard days triggers rest (Kellmann 2010)."""
+        result = ha_notify.recommend_workout(
+            acwr=1.0, tsb=0.0, body_battery=60,
+            stress_score=40, sleep_debt_minutes=0,
+            consecutive_hard_days=3,
+        )
+        assert result["is_rest_day"] is True
+        assert "consecutive" in result["rationale"].lower()
+
+    def test_no_rest_optimal_signals(self):
+        """All signals in safe range → training day."""
+        result = ha_notify.recommend_workout(
+            acwr=1.1, tsb=5.0, body_battery=70,
+            stress_score=30, sleep_debt_minutes=30,
+            consecutive_hard_days=1,
+        )
+        assert result["is_rest_day"] is False
+        assert result["workout_type"] != "rest"
+        assert result["duration_min"] > 0
+
+    def test_easy_day_moderate_fatigue(self):
+        """Moderate fatigue signals → easy/recovery workout."""
+        result = ha_notify.recommend_workout(
+            acwr=1.2, tsb=-10.0, body_battery=45,
+            stress_score=55, sleep_debt_minutes=60,
+            consecutive_hard_days=2,
+        )
+        assert result["is_rest_day"] is False
+        assert result["intensity"] in ("easy", "moderate", "recovery")
+
+    def test_missing_data_conservative(self):
+        """When all metrics are None, defaults to conservative recommendation."""
+        result = ha_notify.recommend_workout(
+            acwr=None, tsb=None, body_battery=None,
+            stress_score=None, sleep_debt_minutes=None,
+            consecutive_hard_days=0,
+        )
+        # Should not crash; should produce a valid result
+        assert "is_rest_day" in result
+        assert "rationale" in result
+
+
+# ===========================================================================
+# Layer 2: Injury risk computation
+# ===========================================================================
+
+class TestInjuryRisk:
+    """Verify compute_injury_risk() classifies risk levels correctly."""
+
+    def test_high_risk_acwr(self):
+        """ACWR >1.5 → high risk."""
+        level, score = ha_notify.compute_injury_risk(acwr=1.6, tsb=0.0, ramp_rate=0.0)
+        assert level == "high"
+        assert score >= 60
+
+    def test_elevated_risk(self):
+        """ACWR 1.3-1.5 → elevated."""
+        level, score = ha_notify.compute_injury_risk(acwr=1.4, tsb=0.0, ramp_rate=0.0)
+        assert level in ("elevated", "moderate")
+        assert score >= 30
+
+    def test_low_risk_optimal(self):
+        """ACWR in sweet spot, good TSB → low risk."""
+        level, score = ha_notify.compute_injury_risk(acwr=1.0, tsb=5.0, ramp_rate=2.0)
+        assert level == "low"
+        assert score < 10
+
+    def test_combined_risk_factors(self):
+        """Multiple risk factors compound the score."""
+        level, score = ha_notify.compute_injury_risk(acwr=1.6, tsb=-25.0, ramp_rate=15.0)
+        assert score >= 75
+        assert level == "high"
+
+    def test_unknown_when_no_acwr(self):
+        """No ACWR data → unknown risk."""
+        level, score = ha_notify.compute_injury_risk(acwr=None, tsb=0.0, ramp_rate=0.0)
+        assert level == "unknown"
+        assert score == 0
+
+    def test_ramp_rate_contribution(self):
+        """High ramp rate adds to risk score."""
+        _, score_low = ha_notify.compute_injury_risk(acwr=1.0, tsb=0.0, ramp_rate=2.0)
+        _, score_high = ha_notify.compute_injury_risk(acwr=1.0, tsb=0.0, ramp_rate=15.0)
+        assert score_high > score_low
+
+    def test_overreached_tsb(self):
+        """TSB < -20 adds significant risk."""
+        _, score_ok = ha_notify.compute_injury_risk(acwr=1.0, tsb=0.0, ramp_rate=0.0)
+        _, score_or = ha_notify.compute_injury_risk(acwr=1.0, tsb=-25.0, ramp_rate=0.0)
+        assert score_or > score_ok
+
+
+# ===========================================================================
+# Layer 3: EWMA decay constants (metrics-compute.py)
+# ===========================================================================
+
+class TestEWMAConstants:
+    """Verify EWMA time constants used for CTL/ATL are physiologically correct."""
+
+    def test_atl_decay_7day(self):
+        """ATL decay constant matches 7-day exponential window."""
+        import math
+        expected = 1 - math.exp(-1 / 7)
+        assert abs(metrics_compute.ATL_DECAY - expected) < 1e-10
+
+    def test_ctl_decay_42day(self):
+        """CTL decay constant matches 42-day exponential window."""
+        import math
+        expected = 1 - math.exp(-1 / 42)
+        assert abs(metrics_compute.CTL_DECAY - expected) < 1e-10
+
+    def test_atl_faster_than_ctl(self):
+        """ATL (fatigue) responds faster than CTL (fitness)."""
+        assert metrics_compute.ATL_DECAY > metrics_compute.CTL_DECAY
+
+
+# ===========================================================================
+# Layer 4: Confidence degradation with missing data
+# ===========================================================================
+
+class TestConfidenceDegradation:
+    """Recommendation quality degrades gracefully when data is incomplete."""
+
+    def test_full_data_has_specific_recommendation(self):
+        """Full data produces specific workout type."""
+        result = ha_notify.recommend_workout(
+            acwr=1.1, tsb=8.0, body_battery=80,
+            stress_score=25, sleep_debt_minutes=0,
+            consecutive_hard_days=0,
+        )
+        assert result["workout_type"] != "rest"
+        assert len(result["rationale"]) > 10
+
+    def test_partial_data_still_works(self):
+        """Missing some metrics still produces a recommendation."""
+        result = ha_notify.recommend_workout(
+            acwr=1.1, tsb=None, body_battery=None,
+            stress_score=None, sleep_debt_minutes=None,
+            consecutive_hard_days=0,
+        )
+        assert "is_rest_day" in result
+        assert result["rationale"] is not None
+
+    def test_no_crash_on_edge_values(self):
+        """Extreme values don't crash the recommendation engine."""
+        for acwr in [0.0, 0.1, 3.0, 5.0]:
+            result = ha_notify.recommend_workout(
+                acwr=acwr, tsb=-100.0, body_battery=0,
+                stress_score=100, sleep_debt_minutes=600,
+                consecutive_hard_days=10,
+            )
+            assert "is_rest_day" in result


### PR DESCRIPTION
## Summary

Add 5 Home Assistant automation blueprints and 21 AI trend/recommendation tests.

### HA Automation Blueprints (`garmincoach/rootfs/app/blueprints/`)

| Blueprint | Trigger | Action |
|-----------|---------|--------|
| **Low Body Battery Recovery** | `sensor.garmincoach_body_battery` < threshold | Dim lights, activate recovery scene, push notification |
| **Morning Training Briefing** | Configurable time | TTS + push with ACWR, form, workout recommendation |
| **Injury Risk Alert** | `sensor.garmincoach_injury_risk` → high/critical | Urgent notification, optional DND toggle |
| **Training Freshness Reminder** | `sensor.garmincoach_form` > threshold | Push notification to train when fresh |
| **Weekly Training Summary** | Configurable day/time | CTL, ATL, TSB, ACWR, risk, body battery summary |

All blueprints use configurable inputs with sensible defaults for GarminCoach sensor entities.

### AI Trend Tests (`tests/unit/test_ai_trends.py`)

21 tests across 4 layers:
1. **Workout Recommendation Logic** — rest triggers for ACWR >1.5, TSB < -25, body battery <20, sleep debt >3h, 3+ hard days
2. **Injury Risk Computation** — risk classification (low/moderate/elevated/high), compound factors, unknown handling
3. **EWMA Constants** — ATL 7-day and CTL 42-day decay validation
4. **Confidence Degradation** — graceful handling of missing/extreme data

All 21 tests pass ✅