### PR TITLE
chore: bump version to v0.10.0

### DIFF
--- a/garmincoach/config.json
+++ b/garmincoach/config.json
@@ -1,6 +1,6 @@
 {
   "name": "GarminCoach",
-  "version": "0.9.0",
+  "version": "0.10.0",
   "slug": "garmincoach",
   "image": "ghcr.io/askb/garmincoach-addon-{arch}",
   "description": "AI-powered sport scientist \u2014 training analysis, coaching, and recovery optimization from your Garmin data",


### PR DESCRIPTION
Bump addon version from `0.9.0` → `0.10.0` in `garmincoach/config.json` for the next release.

### Changes since v0.9.0
- **PR #48**: Upgraded gh-aw 0.63 → 0.67.1
- **PR #33**: Pinned pnpm, s6 dependencies, RealDictCursor, type hints
- **PR #54**: 5 HA automation blueprints + 21 AI trend tests

All 25 planned improvement todos are now complete.