### PR TITLE
docs: update README with blueprints, fix release workflow build-args

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -45,13 +45,22 @@ jobs:
           dockerfile: garmincoach/Dockerfile
 
   build-push:
-    name: 'Build & Push'
+    name: 'Build & Push (${{ matrix.arch }})'
     runs-on: ubuntu-latest
     needs: validate
     permissions:
       contents: read
       packages: write
     timeout-minutes: 30
+    strategy:
+      matrix:
+        include:
+          - arch: amd64
+            platform: linux/amd64
+            build_from: ghcr.io/home-assistant/amd64-base:3.21
+          - arch: aarch64
+            platform: linux/arm64
+            build_from: ghcr.io/home-assistant/aarch64-base:3.21
     steps:
       - uses: step-security/harden-runner@v2
         with:
@@ -76,15 +85,17 @@ jobs:
         id: version
         run: echo "version=${GITHUB_REF#refs/tags/v}" >> "$GITHUB_OUTPUT"
 
-      - name: 'Build and push multi-arch image'
+      - name: 'Build and push arch image'
         uses: docker/build-push-action@v7
         with:
           context: garmincoach
           push: true
-          platforms: linux/amd64,linux/arm64
+          platforms: ${{ matrix.platform }}
+          build-args: |
+            BUILD_FROM=${{ matrix.build_from }}
+            BUILD_ARCH=${{ matrix.arch }}
           tags: |
-            ghcr.io/${{ github.repository_owner }}/ha-garmin-fitness-coach-addon:${{ steps.version.outputs.version }}
-            ghcr.io/${{ github.repository_owner }}/ha-garmin-fitness-coach-addon:latest
+            ghcr.io/${{ github.repository_owner }}/ha-garmin-fitness-coach-addon:${{ steps.version.outputs.version }}-${{ matrix.arch }}
           labels: |
             org.opencontainers.image.title=GarminCoach HA Addon
             org.opencontainers.image.version=${{ steps.version.outputs.version }}
@@ -92,10 +103,49 @@ jobs:
           cache-from: type=gha
           cache-to: type=gha,mode=max
 
+  manifest:
+    name: 'Create Multi-Arch Manifest'
+    runs-on: ubuntu-latest
+    needs: build-push
+    permissions:
+      packages: write
+    timeout-minutes: 10
+    steps:
+      - uses: step-security/harden-runner@v2
+        with:
+          egress-policy: 'audit'
+
+      - name: 'Login to GHCR'
+        uses: docker/login-action@v4
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: 'Extract version from tag'
+        id: version
+        run: echo "version=${GITHUB_REF#refs/tags/v}" >> "$GITHUB_OUTPUT"
+
+      - name: 'Create and push manifest'
+        run: |
+          VERSION="${{ steps.version.outputs.version }}"
+          IMAGE="ghcr.io/${{ github.repository_owner }}/ha-garmin-fitness-coach-addon"
+
+          docker manifest create "${IMAGE}:${VERSION}" \
+            "${IMAGE}:${VERSION}-amd64" \
+            "${IMAGE}:${VERSION}-aarch64"
+
+          docker manifest create "${IMAGE}:latest" \
+            "${IMAGE}:${VERSION}-amd64" \
+            "${IMAGE}:${VERSION}-aarch64"
+
+          docker manifest push "${IMAGE}:${VERSION}"
+          docker manifest push "${IMAGE}:latest"
+
   sbom-scan:
     name: 'SBOM & Security Scan'
     runs-on: ubuntu-latest
-    needs: build-push
+    needs: manifest
     permissions:
       contents: read
       packages: read
@@ -139,7 +189,7 @@ jobs:
   release:
     name: 'Create Release'
     runs-on: ubuntu-latest
-    needs: [validate, build-push, sbom-scan]
+    needs: [validate, manifest, sbom-scan]
     permissions:
       contents: write
     timeout-minutes: 5

--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ your local network.
 - [Configuration](#configuration)
 - [Garmin Authentication](#garmin-authentication)
 - [AI Backend Options](#ai-backend-options)
+- [Automation Blueprints & Templates](#automation-blueprints--templates)
 - [Known Issues](#known-issues)
 - [Development](#development)
 - [Contributing](#contributing)
@@ -217,9 +218,28 @@ GarminCoach authenticates with Garmin Connect using a **web-based auth flow**:
 | `sensor.garmincoach_body_battery` | Current Garmin Body Battery value |
 | `sensor.garmincoach_sleep_debt` | Accumulated sleep debt (hours) |
 
-## Automation Templates
+## Automation Blueprints & Templates
 
-Seven ready-to-paste HA automations are provided in
+### HA Blueprints (importable)
+
+Five ready-to-import Home Assistant blueprints are included in
+`garmincoach/rootfs/app/blueprints/`. Import them via **Settings → Automations
+→ Blueprints → Import Blueprint** using the raw GitHub URL:
+
+| Blueprint | Trigger | What It Does |
+|-----------|---------|--------------|
+| **Low Body Battery Recovery** | Body Battery < threshold | Dims lights, activates recovery scene, sends push notification |
+| **Morning Training Briefing** | Configurable time (default 7 AM) | TTS announcement + push with ACWR, form, and workout recommendation |
+| **Injury Risk Alert** | Risk level → high or critical | Urgent push notification, optional DND toggle |
+| **Training Freshness Reminder** | TSB (form) > threshold | Push notification to train when body is fresh |
+| **Weekly Training Summary** | Configurable day/time | Weekly CTL, ATL, TSB, ACWR, risk, body battery summary |
+
+All blueprints use configurable inputs (thresholds, notification targets,
+scenes) with sensible defaults for GarminCoach sensor entities.
+
+### Copy-Paste Automations
+
+Seven additional ready-to-paste automations are provided in
 [`HA_AUTOMATIONS.md`](garmincoach/HA_AUTOMATIONS.md):
 
 1. **Low Body Battery Recovery Mode** — dim lights, enable DND
@@ -232,8 +252,15 @@ Seven ready-to-paste HA automations are provided in
 
 ## Testing
 
-- **19 pytest tests** covering Garmin auth flow, token handling, daily stats
-  sync, activity sync, TRIMP calculation, and ingress proxy path rewriting
+- **28 passing pytest tests** (+ 59 pre-existing errors in legacy sync tests)
+  covering:
+  - Garmin auth flow, token handling, daily stats sync, activity sync
+  - TRIMP calculation, ingress proxy path rewriting
+  - AI workout recommendation logic (rest triggers, optimal signals)
+  - Injury risk computation (ACWR, TSB, ramp rate thresholds)
+  - EWMA decay constant validation (7-day ATL, 42-day CTL)
+  - Confidence degradation with missing/extreme data
+  - Scientific reference accuracy (VO2max, Cooper, Riegel)
 - **CI:** GitHub Actions builds the Docker image and runs `pytest -v` on every
   PR
 


### PR DESCRIPTION
## Summary

Update documentation and fix the release workflow for v0.10.0.

### README Updates
- **New section**: "Automation Blueprints & Templates" documenting the 5 importable HA blueprints with trigger/action table
- **Updated test count**: 19 → 28 passing tests, added AI trend test categories
- **Updated ToC**: Added blueprints section link

### Release Workflow Fix
The release workflow was failing because `BUILD_FROM` arg wasn't passed to the Dockerfile's multi-stage build.

**Root cause**: `docker/build-push-action` with `platforms: linux/amd64,linux/arm64` can't pass different `BUILD_FROM` values per architecture (HA uses `amd64-base` vs `aarch64-base`).

**Fix**: Matrix strategy with per-arch builds + manifest merge:
1. `build-push` → matrix of `[amd64, aarch64]`, each with correct `BUILD_FROM`
2. New `manifest` job → creates multi-arch manifest from per-arch tags
3. Updated dependency chain: `validate → build-push → manifest → sbom → release`