### PR TITLE
fix: align release image naming with HA addon config.json

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -85,28 +85,11 @@ jobs:
           cache-from: type=gha
           cache-to: type=gha,mode=max
 
-  release:
-    name: Create Release
-    needs: build
-    if: startsWith(github.ref, 'refs/tags/v')
-    runs-on: ubuntu-latest
-    permissions:
-      contents: write
-    timeout-minutes: 10
-    steps:
-      - uses: step-security/harden-runner@v2
-        with:
-          egress-policy: audit
-
-      - uses: actions/checkout@v6
-
-      - name: Create GitHub Release
-        uses: softprops/action-gh-release@v2
-        with:
-          generate_release_notes: true
-          body: |
-            ## Installation
-            Add this repository URL to your Home Assistant addon store:
-            ```
-            https://github.com/${{ github.repository }}
-            ```
+  # NOTE: Release creation is handled by .github/workflows/release.yaml
+  # which includes SBOM scanning and per-arch image builds.
+  # This job is intentionally disabled to avoid duplicate releases.
+  # release:
+  #   name: Create Release
+  #   needs: build
+  #   if: startsWith(github.ref, 'refs/tags/v')
+  #   ...

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -95,7 +95,8 @@ jobs:
             BUILD_FROM=${{ matrix.build_from }}
             BUILD_ARCH=${{ matrix.arch }}
           tags: |
-            ghcr.io/${{ github.repository_owner }}/ha-garmin-fitness-coach-addon:${{ steps.version.outputs.version }}-${{ matrix.arch }}
+            ghcr.io/${{ github.repository_owner }}/garmincoach-addon-${{ matrix.arch }}:${{ steps.version.outputs.version }}
+            ghcr.io/${{ github.repository_owner }}/garmincoach-addon-${{ matrix.arch }}:latest
           labels: |
             org.opencontainers.image.title=GarminCoach HA Addon
             org.opencontainers.image.version=${{ steps.version.outputs.version }}
@@ -103,49 +104,10 @@ jobs:
           cache-from: type=gha
           cache-to: type=gha,mode=max
 
-  manifest:
-    name: 'Create Multi-Arch Manifest'
-    runs-on: ubuntu-latest
-    needs: build-push
-    permissions:
-      packages: write
-    timeout-minutes: 10
-    steps:
-      - uses: step-security/harden-runner@v2
-        with:
-          egress-policy: 'audit'
-
-      - name: 'Login to GHCR'
-        uses: docker/login-action@v4
-        with:
-          registry: ghcr.io
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: 'Extract version from tag'
-        id: version
-        run: echo "version=${GITHUB_REF#refs/tags/v}" >> "$GITHUB_OUTPUT"
-
-      - name: 'Create and push manifest'
-        run: |
-          VERSION="${{ steps.version.outputs.version }}"
-          IMAGE="ghcr.io/${{ github.repository_owner }}/ha-garmin-fitness-coach-addon"
-
-          docker manifest create "${IMAGE}:${VERSION}" \
-            "${IMAGE}:${VERSION}-amd64" \
-            "${IMAGE}:${VERSION}-aarch64"
-
-          docker manifest create "${IMAGE}:latest" \
-            "${IMAGE}:${VERSION}-amd64" \
-            "${IMAGE}:${VERSION}-aarch64"
-
-          docker manifest push "${IMAGE}:${VERSION}"
-          docker manifest push "${IMAGE}:latest"
-
   sbom-scan:
     name: 'SBOM & Security Scan'
     runs-on: ubuntu-latest
-    needs: manifest
+    needs: build-push
     permissions:
       contents: read
       packages: read
@@ -164,10 +126,14 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
+      - name: 'Extract version from tag'
+        id: version
+        run: echo "version=${GITHUB_REF#refs/tags/v}" >> "$GITHUB_OUTPUT"
+
       - name: 'Generate SBOM from image'
         uses: anchore/sbom-action@v0
         with:
-          image: ghcr.io/${{ github.repository_owner }}/ha-garmin-fitness-coach-addon:latest
+          image: ghcr.io/${{ github.repository_owner }}/garmincoach-addon-amd64:${{ steps.version.outputs.version }}
           format: cyclonedx-json
           output-file: sbom-cyclonedx.json
 
@@ -189,7 +155,7 @@ jobs:
   release:
     name: 'Create Release'
     runs-on: ubuntu-latest
-    needs: [validate, manifest, sbom-scan]
+    needs: [validate, build-push, sbom-scan]
     permissions:
       contents: write
     timeout-minutes: 5

--- a/garmincoach/CHANGELOG.md
+++ b/garmincoach/CHANGELOG.md
@@ -5,6 +5,27 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.10.0] — 2026-04-10
+
+### Added
+
+- **HA Automation Blueprints** — 5 ready-to-import blueprints:
+  - Low Body Battery Recovery (scene activation)
+  - Morning Training Briefing (TTS with ACWR/form/workout)
+  - Injury Risk Alert (push notification + optional DND)
+  - Training Freshness Reminder (TSB threshold notification)
+  - Weekly Training Summary (comprehensive metrics digest)
+- **AI Trend Tests** — 21 new unit tests covering workout recommendations,
+  injury risk assessment, EWMA constants, and confidence degradation.
+
+### Fixed
+
+- **Release workflow** — per-arch image naming to match HA addon conventions
+  (`garmincoach-addon-{arch}:version`). Removed unnecessary multi-arch
+  manifest job since HA handles arch selection via config.json `image` field.
+- **Hadolint config** — added `.hadolint.yaml` to suppress non-critical
+  Dockerfile lint rules (DL3018, DL3013, DL3042, DL3016, DL3003).
+
 ## [0.9.0] — 2026-04-03
 
 ### Fixed


### PR DESCRIPTION
## Problem
The release workflow pushes images to `ghcr.io/askb/ha-garmin-fitness-coach-addon:VERSION-ARCH` but `config.json` specifies `image: ghcr.io/askb/garmincoach-addon-{arch}`.

HA resolves `{arch}` at install time, expecting per-arch image repos tagged with the version (e.g., `ghcr.io/askb/garmincoach-addon-aarch64:0.10.0`).

## Changes
- Push to `garmincoach-addon-ARCH:VERSION` (matching config.json `image` field)
- Remove multi-arch manifest job (HA handles arch selection itself)
- Update SBOM scan to reference correct image name
- Add v0.10.0 CHANGELOG entry