### PR TITLE
chore: bump version to 0.11.1 — PulseCoach UI branding fix

### DIFF
--- a/pulsecoach/CHANGELOG.md
+++ b/pulsecoach/CHANGELOG.md
@@ -5,6 +5,16 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.11.1] — 2026-04-11
+
+### Fixed
+
+- **PulseCoach branding in app UI** — Frontend now shows "PulseCoach" instead
+  of "GarminCoach" in page titles, navigation menu, onboarding, and settings.
+- Scripts use `docker compose exec` instead of hardcoded container names.
+- PORT env var supports backward-compatible fallback chain
+  (`PORT → PULSECOACH_PORT → GARMINCOACH_PORT`).
+
 ## [0.11.0] — 2026-04-13
 
 ### ⚠️ Breaking Changes

--- a/pulsecoach/config.json
+++ b/pulsecoach/config.json
@@ -1,6 +1,6 @@
 {
   "name": "PulseCoach",
-  "version": "0.11.0",
+  "version": "0.11.1",
   "slug": "pulsecoach",
   "image": "ghcr.io/askb/pulsecoach-addon-{arch}",
   "description": "AI-powered sport scientist \u2014 training analysis, coaching, and recovery optimization from your Garmin data",


### PR DESCRIPTION
## Summary\n\nBump addon version to 0.11.1 to include PulseCoach UI branding from the app repo (merged in askb/ha-garmin-fitness-coach-app#60).\n\n### Changes\n- Version bump: 0.11.0 → 0.11.1\n- CHANGELOG: Document UI branding fix, docker compose exec, PORT fallback chain\n\n### Why v0.11.1?\nThe v0.11.0 images were built before the app repo rename was merged. This release picks up the updated frontend with PulseCoach branding.