### PR TITLE
chore: bump version to 0.11.3

### DIFF
--- a/pulsecoach/config.json
+++ b/pulsecoach/config.json
@@ -1,6 +1,6 @@
 {
   "name": "PulseCoach",
-  "version": "0.11.2",
+  "version": "0.11.3",
   "slug": "pulsecoach",
   "image": "ghcr.io/askb/pulsecoach-addon-{arch}",
   "description": "AI-powered sport scientist \u2014 training analysis, coaching, and recovery optimization from your Garmin data",


### PR DESCRIPTION
## v0.11.3 Release

### User-facing changes:
- **fix:** Insights page bg-black for visual consistency
- **fix:** Cross-check HRV recovery state before ACWR build insight (fixes insights/readiness contradiction)
- **feat:** Separate VO2 Max into Garmin official vs UTH estimate charts
- **fix:** AI backend config cleanup, default to `none`

### CI/infra:
- chore: bump actions/github-script v8→v9
- fix: PR review agent prompt output instructions
- chore: bump github/gh-aw 0.67.1→0.67.4