### PR TITLE
fix: sync SpO2 and respiration data from Garmin API (#73)

### DIFF
--- a/pulsecoach/CHANGELOG.md
+++ b/pulsecoach/CHANGELOG.md
@@ -5,6 +5,16 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.11.4] — 2026-04-13
+
+### Fixed
+
+- **AI agent cannot query SpO2 data (#73)** — `garmin-sync.py` now fetches
+  SpO2 (pulse oximetry) and respiration rate from the Garmin Connect API and
+  writes them to the `daily_metric` table. SpO2 cascades through three sources:
+  dedicated `get_spo2_data()` API → `stats.avgSpo2` → `sleep.averageSpO2Value`.
+  Respiration cascades: `get_respiration_data()` → `stats.respirationAvg`.
+
 ## [0.11.2] — 2026-04-11
 
 ### Fixed

--- a/pulsecoach/config.json
+++ b/pulsecoach/config.json
@@ -1,6 +1,6 @@
 {
   "name": "PulseCoach",
-  "version": "0.11.3",
+  "version": "0.11.4",
   "slug": "pulsecoach",
   "image": "ghcr.io/askb/pulsecoach-addon-{arch}",
   "description": "AI-powered sport scientist \u2014 training analysis, coaching, and recovery optimization from your Garmin data",

--- a/pulsecoach/rootfs/app/scripts/garmin-sync.py
+++ b/pulsecoach/rootfs/app/scripts/garmin-sync.py
@@ -199,6 +199,18 @@ def sync_daily_stats(client, db, date_str):
         hrv = client.get_hrv_data(date_str)
         stress = client.get_stress_data(date_str)
 
+        # Fetch SpO2 and respiration data (gracefully handle API errors)
+        spo2_data = None
+        respiration_data = None
+        try:
+            spo2_data = client.get_spo2_data(date_str)
+        except Exception as e:
+            print(f"  SpO2 data unavailable for {date_str}: {e}")
+        try:
+            respiration_data = client.get_respiration_data(date_str)
+        except Exception as e:
+            print(f"  Respiration data unavailable for {date_str}: {e}")
+
         # Debug: log stress field names so we can verify data extraction
         stress_val = None
         if stress:
@@ -209,6 +221,22 @@ def sync_daily_stats(client, db, date_str):
             print(f"  Stress score for {date_str}: {stress_val}")
 
         sleep_dto = sleep_data.get("dailySleepDTO", {}) if sleep_data else {}
+
+        # Extract SpO2: prefer dedicated API, fall back to stats/sleep
+        spo2_val = None
+        if spo2_data:
+            spo2_val = spo2_data.get("averageSpO2") or spo2_data.get("averageSpo2")
+        if spo2_val is None and stats:
+            spo2_val = stats.get("avgSpo2") or stats.get("averageSpo2")
+        if spo2_val is None:
+            spo2_val = sleep_dto.get("averageSpO2Value") if sleep_data else None
+
+        # Extract respiration rate
+        respiration_val = None
+        if respiration_data:
+            respiration_val = respiration_data.get("avgWakingRespirationValue") or respiration_data.get("avgSleepRespirationValue")
+        if respiration_val is None and stats:
+            respiration_val = stats.get("respirationAvg")
 
         # Ensure unique constraint exists for upsert
         cur.execute("""
@@ -232,8 +260,9 @@ def sync_daily_stats(client, db, date_str):
                 hrv, stress_score, body_battery_start, body_battery_end,
                 floors_climbed, intensity_minutes,
                 sleep_start_time, sleep_end_time, sleep_need_minutes, sleep_debt_minutes,
+                spo2, respiration_rate,
                 synced_at
-            ) VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s)
+            ) VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s)
             ON CONFLICT (user_id, date) DO UPDATE SET
                 steps = EXCLUDED.steps,
                 calories = EXCLUDED.calories,
@@ -255,6 +284,8 @@ def sync_daily_stats(client, db, date_str):
                 sleep_end_time = COALESCE(EXCLUDED.sleep_end_time, daily_metric.sleep_end_time),
                 sleep_need_minutes = COALESCE(EXCLUDED.sleep_need_minutes, daily_metric.sleep_need_minutes),
                 sleep_debt_minutes = COALESCE(EXCLUDED.sleep_debt_minutes, daily_metric.sleep_debt_minutes),
+                spo2 = COALESCE(EXCLUDED.spo2, daily_metric.spo2),
+                respiration_rate = COALESCE(EXCLUDED.respiration_rate, daily_metric.respiration_rate),
                 synced_at = EXCLUDED.synced_at
         """, (
             USER_ID,
@@ -279,6 +310,8 @@ def sync_daily_stats(client, db, date_str):
             _extract_sleep_time(sleep_dto, "sleepEndTimestampLocal"),
             sleep_dto.get("sleepNeedInMinutes"),
             _compute_sleep_debt(sleep_dto),
+            spo2_val,
+            respiration_val,
             datetime.now(timezone.utc).isoformat(),
         ))
         db.commit()


### PR DESCRIPTION
## Summary

Fixes #73 — AI agent cannot query pulse oxygen saturation data.

### Root Cause
`garmin-sync.py` was not syncing SpO2 or respiration rate data from the Garmin API, even though the database schema already supports these fields.

### Changes
- Added calls to `client.get_spo2_data()` and `client.get_respiration_data()` with graceful error handling
- SpO2 sourced from: dedicated API → `stats.avgSpo2` → `sleep.averageSpO2Value` (cascade)
- Respiration sourced from: dedicated API → `stats.respirationAvg` (cascade)
- Added `spo2` and `respiration_rate` columns to INSERT/UPDATE
- Version bump: 0.11.3 → 0.11.4

### Companion PR
App repo: askb/ha-garmin-fitness-coach-app (adds SpO2 to AI data context)

### Testing
All 17 relevant tests pass. 7 pre-existing failures (unrelated).