### PR TITLE
feat: coaching engine with Garmin readiness and training status v0.14.0

### DIFF
--- a/pulsecoach/CHANGELOG.md
+++ b/pulsecoach/CHANGELOG.md
@@ -5,6 +5,48 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.14.0] — 2026-04-14
+
+### Added
+
+- **Garmin Training Readiness sync** — Syncs Garmin's native Training
+  Readiness score (0-100) and 6-factor breakdown (HRV status, sleep,
+  recovery time, acute load, stress history, Body Battery) via
+  `get_training_readiness()` API.
+
+- **Garmin Training Status sync** — Syncs Training Status
+  (Productive/Peaking/Overreaching/Recovery/Unproductive), Load Focus
+  distribution (low/high aerobic + anaerobic %), and recovery time
+  via `get_training_status()` API.
+
+- **Readiness HA sensor** — New `sensor.pulsecoach_readiness` (0-100)
+  with zone and source attributes. Prefers Garmin native readiness,
+  falls back to Buchheit composite computation.
+
+- **Training Status HA sensor** — New `sensor.pulsecoach_training_status`
+  showing Garmin's official training status with recovery hours and
+  load focus attributes.
+
+- **Buchheit readiness engine** — Computed readiness score using weighted
+  HRV (35%), sleep (25%), Body Battery (20%), resting HR (10%), and
+  stress (10%) with 14-day rolling baseline normalization.
+
+- **Enhanced workout recommendation** — Coaching engine now uses
+  readiness score and Garmin training status for decisions. Low
+  readiness (<25) and OVERREACHING status trigger rest; PEAKING and
+  PRODUCTIVE enable quality sessions.
+
+- **15 coaching engine tests** — Comprehensive test coverage for rest
+  triggers, active recovery, quality sessions, aerobic workouts, and
+  edge cases.
+
+### Changed
+
+- Workout recommendation rationale now includes readiness score context
+- Recovery signal threshold includes readiness < 40 as additional signal
+- Quality session eligibility considers readiness >= 70 and Garmin
+  PEAKING/PRODUCTIVE status alongside TSB and Body Battery
+
 ## [0.13.0] — 2026-04-14
 
 ### Added

--- a/pulsecoach/config.json
+++ b/pulsecoach/config.json
@@ -1,6 +1,6 @@
 {
   "name": "PulseCoach",
-  "version": "0.13.0",
+  "version": "0.14.0",
   "slug": "pulsecoach",
   "image": "ghcr.io/askb/pulsecoach-addon-{arch}",
   "description": "AI-powered sport scientist \u2014 training analysis, coaching, and recovery optimization from your Garmin data",

--- a/pulsecoach/rootfs/app/scripts/garmin-sync.py
+++ b/pulsecoach/rootfs/app/scripts/garmin-sync.py
@@ -820,6 +820,135 @@ def sync_vo2max(client, db, days=7):
         cur.close()
 
 
+def sync_training_readiness(client, db, days=7):
+    """Sync Garmin Training Readiness score and contributing factors."""
+    cur = db.cursor()
+    try:
+        today = _user_today()
+        synced = 0
+        for days_ago in range(days):
+            date_str = (today - timedelta(days=days_ago)).isoformat()
+            try:
+                data = client.get_training_readiness(date_str)
+                if not data:
+                    continue
+
+                score = data.get("score") or data.get("readinessScore")
+                level = data.get("level") or data.get("readinessLevel", "")
+                if score is None:
+                    continue
+
+                # Extract contributing factors (Garmin's 6-factor breakdown)
+                factors = {}
+                for key in [
+                    "sleepScore", "recoveryTime", "hrvStatus", "acuteLoad",
+                    "stressHistory", "bodyBattery", "sleepHistory",
+                ]:
+                    val = data.get(key)
+                    if val is not None:
+                        factors[key] = val
+
+                cur.execute("""
+                    INSERT INTO daily_metric (user_id, date)
+                    VALUES (%s, %s)
+                    ON CONFLICT (user_id, date) DO NOTHING
+                """, (USER_ID, date_str))
+
+                cur.execute("""
+                    UPDATE daily_metric SET
+                        garmin_training_readiness = %s,
+                        garmin_training_readiness_level = %s,
+                        garmin_readiness_factors = %s
+                    WHERE user_id = %s AND date = %s
+                """, (
+                    round(score),
+                    level.lower() if isinstance(level, str) else str(level),
+                    json.dumps(factors) if factors else None,
+                    USER_ID, date_str,
+                ))
+                synced += 1
+            except Exception as e:
+                print(f"  Training readiness unavailable for {date_str}: {e}")
+                continue
+
+        db.commit()
+        if synced:
+            print(f"  Synced training readiness for {synced} days")
+    except Exception as e:
+        db.rollback()
+        print(f"  Failed to sync training readiness: {e}", file=sys.stderr)
+    finally:
+        cur.close()
+
+
+def sync_training_status(client, db, days=7):
+    """Sync Garmin Training Status (Productive/Peaking/Overreaching etc)."""
+    cur = db.cursor()
+    try:
+        today = _user_today()
+        synced = 0
+        for days_ago in range(days):
+            date_str = (today - timedelta(days=days_ago)).isoformat()
+            try:
+                data = client.get_training_status(date_str)
+                if not data:
+                    continue
+
+                # Training status fields
+                status = data.get("trainingStatus") or data.get("status", "")
+                load_focus = data.get("trainingLoadFocus") or data.get("loadFocus")
+
+                # Extract load distribution (low/high aerobic + anaerobic)
+                load_dist = {}
+                for key in [
+                    "lowAerobicTrainingLoad", "highAerobicTrainingLoad",
+                    "anaerobicTrainingLoad", "lowAerobicTrainingLoadPercentage",
+                    "highAerobicTrainingLoadPercentage", "anaerobicTrainingLoadPercentage",
+                ]:
+                    val = data.get(key)
+                    if val is not None:
+                        load_dist[key] = val
+
+                recovery_hrs = data.get("recoveryTimeInMinutes")
+                if recovery_hrs is not None:
+                    recovery_hrs = round(recovery_hrs / 60, 1)
+
+                if not status and not load_focus and not recovery_hrs:
+                    continue
+
+                cur.execute("""
+                    INSERT INTO daily_metric (user_id, date)
+                    VALUES (%s, %s)
+                    ON CONFLICT (user_id, date) DO NOTHING
+                """, (USER_ID, date_str))
+
+                cur.execute("""
+                    UPDATE daily_metric SET
+                        garmin_training_status = %s,
+                        garmin_load_focus = %s,
+                        garmin_recovery_hours = %s
+                    WHERE user_id = %s AND date = %s
+                """, (
+                    str(status).upper() if status else None,
+                    json.dumps(load_dist) if load_dist else None,
+                    recovery_hrs,
+                    USER_ID, date_str,
+                ))
+                synced += 1
+            except Exception as e:
+                print(f"  Training status unavailable for {date_str}: {e}")
+                continue
+
+        db.commit()
+        if synced:
+            print(f"  Synced training status for {synced} days")
+    except Exception as e:
+        db.rollback()
+        print(f"  Failed to sync training status: {e}", file=sys.stderr)
+    finally:
+        cur.close()
+
+
 def main():
     has_tokens = (
         os.path.exists(os.path.join(TOKEN_DIR, "oauth1_token.json"))
@@ -872,6 +1001,11 @@ def main():
 
     _write_sync_status("vo2max", "Computing VO2max estimates...", 90)
     sync_vo2max(client, db, days=sync_days)
+
+    # Sync Garmin Training Readiness + Training Status (native scores)
+    _write_sync_status("readiness", "Syncing training readiness...", 93)
+    sync_training_readiness(client, db, days=min(sync_days, 30))
+    sync_training_status(client, db, days=min(sync_days, 30))
 
     # Refresh materialized view so all downstream queries see fresh data
     _write_sync_status("refresh", "Refreshing summary view...", 95)

--- a/pulsecoach/rootfs/app/scripts/ha-notify.py
+++ b/pulsecoach/rootfs/app/scripts/ha-notify.py
@@ -165,6 +165,8 @@ def recommend_workout(
     stress_score: int | None,
     sleep_debt_minutes: int | None,
     consecutive_hard_days: int,
+    readiness_score: int | None = None,
+    garmin_training_status: str | None = None,
 ) -> dict:
     """Generate an AI-informed workout recommendation based on readiness signals.
 
@@ -185,9 +187,24 @@ def recommend_workout(
     bb = body_battery if body_battery is not None else 50
     sd_hrs = (sleep_debt_minutes / 60) if sleep_debt_minutes else 0
     stress = stress_score if stress_score is not None else 50
+    readiness = readiness_score if readiness_score is not None else 50
+    g_status = garmin_training_status.upper() if garmin_training_status else ""
+    tsb_str = f"{tsb:+.0f}" if tsb is not None else "N/A"
 
     # --- Rest day triggers (any one is sufficient) ---
     rest_reasons: list[str] = []
+
+    if readiness < 25:
+        rest_reasons.append(
+            f"Readiness critically low ({readiness}/100) — "
+            "body needs recovery before quality training"
+        )
+
+    if g_status == "OVERREACHING":
+        rest_reasons.append(
+            "Garmin Training Status: OVERREACHING — "
+            "active recovery or rest recommended"
+        )
 
     if consecutive_hard_days >= 3:
         rest_reasons.append(
@@ -243,6 +260,8 @@ def recommend_workout(
         recovery_signals += 1
     if acwr is not None and acwr > 1.3:
         recovery_signals += 1
+    if readiness < 40:
+        recovery_signals += 1
 
     if recovery_signals >= 3:
         return {
@@ -253,15 +272,20 @@ def recommend_workout(
             "hr_zone_target": 1,
             "rationale": (
                 "Active recovery day — easy effort only. "
-                f"Multiple recovery signals detected (TSB: {tsb}, "
-                f"BB: {bb}%, stress: {stress})."
+                f"Readiness: {readiness}, TSB: {tsb}, "
+                f"BB: {bb}%, stress: {stress}."
             ),
             "all_factors": [],
         }
 
-    # --- Normal training day: select intensity based on form ---
-    if tsb is not None and tsb > 5 and bb >= 70 and (acwr is None or acwr <= 1.2):
+    # --- Normal training day: select intensity based on form + readiness ---
+    is_fresh = tsb is not None and tsb > 5
+    high_readiness = readiness >= 70
+    peaking = g_status in ("PEAKING", "PRODUCTIVE")
+
+    if (is_fresh or high_readiness or peaking) and bb >= 60 and (acwr is None or acwr <= 1.2):
         # Fresh and ready — quality session
+        status_note = f", Garmin: {g_status}" if g_status else ""
         return {
             "is_rest_day": False,
             "workout_type": "quality",
@@ -269,13 +293,15 @@ def recommend_workout(
             "duration_min": 60,
             "hr_zone_target": 4,
             "rationale": (
-                f"Great day for intensity — TSB +{tsb:.0f} (fresh), "
-                f"Body Battery {bb}%. Tempo, intervals, or race-pace work."
+                f"Great day for intensity — Readiness {readiness}, "
+                f"TSB {tsb_str} (fresh), "
+                f"Body Battery {bb}%{status_note}. "
+                "Tempo, intervals, or race-pace work."
             ),
             "all_factors": [],
         }
 
-    if tsb is not None and tsb >= -10 and bb >= 50:
+    if (readiness >= 50 or (tsb is not None and tsb >= -10)) and bb >= 45:
         # Moderate form — aerobic development
         return {
             "is_rest_day": False,
@@ -284,7 +310,8 @@ def recommend_workout(
             "duration_min": 45,
             "hr_zone_target": 2,
             "rationale": (
-                f"Steady aerobic session — TSB {tsb:.0f}, Body Battery {bb}%. "
+                f"Steady aerobic session — Readiness {readiness}, "
+                f"TSB {tsb_str}, Body Battery {bb}%. "
                 "Zone 2 base building or moderate tempo."
             ),
             "all_factors": [],
@@ -427,8 +454,41 @@ def run_notifications(user_id: str):
                     round(sleep_debt / 60, 1) if sleep_debt else 0,
                     {"friendly_name": "PulseCoach Sleep Debt", "unit_of_measurement": "h", "icon": "mdi:sleep"})
 
+        # sensor.pulsecoach_readiness
+        readiness_val = None
+        readiness_zone = None
+        readiness_src = None
+        if dm:
+            # Prefer Garmin native readiness, fall back to computed
+            garmin_r = dm.get('garmin_training_readiness')
+            readiness_val = garmin_r if garmin_r is not None else dm.get('readiness_score')
+            garmin_rl = dm.get('garmin_training_readiness_level')
+            readiness_zone = garmin_rl if garmin_rl is not None else dm.get('readiness_zone')
+            readiness_src = "garmin" if garmin_r is not None else "computed"
+        push_sensor("sensor.pulsecoach_readiness",
+                    readiness_val if readiness_val is not None else "unknown",
+                    {
+                        "friendly_name": "PulseCoach Readiness",
+                        "unit_of_measurement": "/100",
+                        "icon": "mdi:heart-pulse",
+                        "zone": readiness_zone or "unknown",
+                        "source": readiness_src or "unknown",
+                    })
+
+        # sensor.pulsecoach_training_status
+        g_training_status = dm.get('garmin_training_status') if dm else None
+        g_recovery_hrs = dm.get('garmin_recovery_hours') if dm else None
+        push_sensor("sensor.pulsecoach_training_status",
+                    g_training_status if g_training_status else "unknown",
+                    {
+                        "friendly_name": "PulseCoach Training Status",
+                        "icon": "mdi:run-fast",
+                        "recovery_hours": g_recovery_hrs,
+                        "load_focus": dm.get('garmin_load_focus') if dm else None,
+                    })
+
         # sensor.pulsecoach_workout_recommendation
-        # AI-informed workout suggestion replacing PulseCoach rest-day logic
+        # AI-informed workout suggestion using readiness + all recovery signals
         hard_days = data["consecutive_hard_days"]
         workout = recommend_workout(
             acwr=acwr,
@@ -437,6 +497,8 @@ def run_notifications(user_id: str):
             stress_score=dm['stress_score'] if dm else None,
             sleep_debt_minutes=dm['sleep_debt_minutes'] if dm else None,
             consecutive_hard_days=hard_days,
+            readiness_score=readiness_val,
+            garmin_training_status=g_training_status,
         )
         push_sensor("sensor.pulsecoach_workout_recommendation",
                     workout["workout_type"],

--- a/pulsecoach/rootfs/app/scripts/metrics-compute.py
+++ b/pulsecoach/rootfs/app/scripts/metrics-compute.py
@@ -88,6 +88,20 @@ def ensure_advanced_metric_table(cur):
         END $$;
     """)
 
+    # Ensure readiness_score table exists for computed readiness
+    cur.execute("""
+        CREATE TABLE IF NOT EXISTS readiness_score (
+            id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+            user_id TEXT NOT NULL,
+            date DATE NOT NULL,
+            readiness_score INTEGER,
+            readiness_zone TEXT,
+            readiness_explanation TEXT,
+            computed_at TIMESTAMP DEFAULT NOW(),
+            UNIQUE(user_id, date)
+        );
+    """)
+
 
 def fetch_daily_loads(cur, user_id):
     """Fetch training load scores per date.
@@ -259,6 +273,149 @@ def compute_critical_power(cur, user_id) -> dict:
     return result
 
 
+def compute_readiness_score(cur, user_id: str) -> dict:
+    """Compute Buchheit-style readiness score per day.
+
+    Uses Garmin's native training readiness when available, otherwise
+    computes a weighted composite from HRV, sleep, load, stress, resting HR.
+
+    Weights (Buchheit 2014 adapted):
+      HRV: 35%, Sleep: 25%, Training Load: 20%, Resting HR: 10%, Stress: 10%
+
+    Returns {date_str: {score, zone, explanation, source}}.
+    """
+    cur.execute("""
+        SELECT date, hrv, sleep_score, stress_score, resting_hr,
+               body_battery_end, garmin_training_readiness,
+               garmin_training_readiness_level
+        FROM daily_metric
+        WHERE user_id = %s
+        ORDER BY date
+    """, (user_id,))
+    rows = cur.fetchall()
+    if not rows:
+        return {}
+
+    # Build rolling averages for z-score-like normalization
+    hrv_history = []
+    rhr_history = []
+    results = {}
+
+    for row in rows:
+        d = str(row["date"])
+        garmin_readiness = row.get("garmin_training_readiness")
+
+        # If Garmin native readiness exists, use it directly
+        if garmin_readiness is not None:
+            score = int(garmin_readiness)
+            zone = _readiness_zone(score)
+            results[d] = {
+                "score": score,
+                "zone": zone,
+                "explanation": f"Garmin Training Readiness: {score}/100 ({zone})",
+                "source": "garmin_native",
+            }
+        else:
+            # Compute Buchheit-style composite
+            hrv_val = row.get("hrv")
+            sleep_val = row.get("sleep_score")
+            stress_val = row.get("stress_score")
+            rhr_val = row.get("resting_hr")
+            bb_val = row.get("body_battery_end")
+
+            if hrv_val:
+                hrv_history.append(hrv_val)
+            if rhr_val:
+                rhr_history.append(rhr_val)
+
+            components = []
+            total_weight = 0
+
+            # HRV component (35%): higher is better, z-score vs 14-day avg
+            if hrv_val and len(hrv_history) >= 7:
+                avg_hrv = sum(hrv_history[-14:]) / len(hrv_history[-14:])
+                hrv_pct = min(100, max(0, (hrv_val / max(1, avg_hrv)) * 50 + 25))
+                components.append(("hrv", hrv_pct, 0.35))
+                total_weight += 0.35
+
+            # Sleep component (25%): direct score 0-100
+            if sleep_val is not None:
+                components.append(("sleep", min(100, sleep_val), 0.25))
+                total_weight += 0.25
+
+            # Training load component (20%): Body Battery as proxy
+            if bb_val is not None:
+                components.append(("load", min(100, bb_val), 0.20))
+                total_weight += 0.20
+
+            # Resting HR component (10%): lower is better vs baseline
+            if rhr_val and len(rhr_history) >= 7:
+                avg_rhr = sum(rhr_history[-14:]) / len(rhr_history[-14:])
+                rhr_pct = min(100, max(0, (2 - rhr_val / max(1, avg_rhr)) * 50 + 25))
+                components.append(("rhr", rhr_pct, 0.10))
+                total_weight += 0.10
+
+            # Stress component (10%): lower is better (invert)
+            if stress_val is not None:
+                stress_pct = max(0, 100 - stress_val)
+                components.append(("stress", stress_pct, 0.10))
+                total_weight += 0.10
+
+            if total_weight > 0:
+                score = round(sum(v * w for _, v, w in components) / total_weight)
+                score = min(100, max(0, score))
+                zone = _readiness_zone(score)
+                parts = ", ".join(f"{n}={v:.0f}" for n, v, _ in components)
+                results[d] = {
+                    "score": score,
+                    "zone": zone,
+                    "explanation": f"Buchheit composite: {score}/100 ({parts})",
+                    "source": "buchheit_composite",
+                }
+            else:
+                continue
+
+        # Update HRV/RHR history regardless
+        if row.get("hrv") and garmin_readiness is not None:
+            hrv_history.append(row["hrv"])
+        if row.get("resting_hr") and garmin_readiness is not None:
+            rhr_history.append(row["resting_hr"])
+
+    return results
+
+
+def _readiness_zone(score: int) -> str:
+    """Map readiness score to zone label."""
+    if score >= 80:
+        return "prime"
+    elif score >= 60:
+        return "good"
+    elif score >= 40:
+        return "moderate"
+    elif score >= 20:
+        return "low"
+    return "poor"
+
+
+def upsert_readiness_scores(cur, user_id: str, readiness_data: dict):
+    """Upsert readiness scores into readiness_score table."""
+    for d_str, data in sorted(readiness_data.items()):
+        cur.execute("""
+            INSERT INTO readiness_score (
+                user_id, date, readiness_score, readiness_zone,
+                readiness_explanation, computed_at
+            ) VALUES (%s, %s, %s, %s, %s, NOW())
+            ON CONFLICT (user_id, date) DO UPDATE SET
+                readiness_score = EXCLUDED.readiness_score,
+                readiness_zone = EXCLUDED.readiness_zone,
+                readiness_explanation = EXCLUDED.readiness_explanation,
+                computed_at = NOW()
+        """, (
+            user_id, d_str, data["score"], data["zone"],
+            data["explanation"],
+        ))
+
+
 def upsert_advanced_metrics(
     cur, user_id: str, load_metrics: dict, vo2max_by_date: dict, cp_data: dict
 ):
@@ -320,6 +477,12 @@ def run_compute(user_id: str):
         cp_data = compute_critical_power(cur, user_id)
 
         upsert_advanced_metrics(cur, user_id, load_metrics, vo2max_by_date, cp_data)
+
+        # Compute and upsert readiness scores
+        readiness_data = compute_readiness_score(cur, user_id)
+        if readiness_data:
+            upsert_readiness_scores(cur, user_id, readiness_data)
+
         db.commit()
 
         dates_computed = len(load_metrics)
@@ -353,6 +516,7 @@ def run_compute(user_id: str):
         print(
             f"[metrics-compute] Done — {dates_computed} dates, "
             f"{len(vo2max_by_date)} VO2max points, "
+            f"{len(readiness_data)} readiness scores, "
             f"{'CP computed' if cp_data else 'no CP data'}"
         )
 

--- a/pulsecoach/rootfs/app/sql/create_daily_athlete_summary.sql
+++ b/pulsecoach/rootfs/app/sql/create_daily_athlete_summary.sql
@@ -43,6 +43,16 @@ SELECT
     dm.garmin_training_load,
     dm.data_quality,
 
+    -- Garmin Training Readiness (native scores from Garmin API)
+    dm.garmin_training_readiness,
+    dm.garmin_training_readiness_level,
+    dm.garmin_readiness_factors,
+
+    -- Garmin Training Status (Productive/Peaking/Overreaching etc)
+    dm.garmin_training_status,
+    dm.garmin_load_focus,
+    dm.garmin_recovery_hours,
+
     -- Advanced metrics (from metrics-compute.py EWMA)
     am.ctl,
     am.atl,
@@ -56,16 +66,10 @@ SELECT
     am.tte,
     am.effective_vo2max,
 
-    -- Readiness score (from app readiness engine)
-    rs.score AS readiness_score,
-    rs.zone AS readiness_zone,
-    rs.hrv_component,
-    rs.sleep_quantity_component,
-    rs.sleep_quality_component,
-    rs.training_load_component,
-    rs.stress_component,
-    rs.resting_hr_component,
-    rs.explanation AS readiness_explanation,
+    -- Readiness score (from metrics-compute.py Buchheit/Garmin hybrid)
+    rs.readiness_score,
+    rs.readiness_zone,
+    rs.readiness_explanation,
 
     -- VO2max (best source per date: official > computed)
     ve.value AS vo2max_value,
@@ -74,7 +78,7 @@ SELECT
     -- Metadata for debugging / staleness detection
     dm.synced_at AS daily_metric_synced_at,
     am.computed_at AS advanced_metric_computed_at,
-    rs.created_at AS readiness_computed_at
+    rs.computed_at AS readiness_computed_at
 
 FROM daily_metric dm
 LEFT JOIN advanced_metric am

--- a/pulsecoach/rootfs/etc/s6-overlay/s6-rc.d/pulsecoach/run
+++ b/pulsecoach/rootfs/etc/s6-overlay/s6-rc.d/pulsecoach/run
@@ -171,6 +171,22 @@ psql -h 127.0.0.1 -U postgres -d pulsecoach -c \
 psql -h 127.0.0.1 -U postgres -d pulsecoach -c \
   "ALTER TABLE daily_metric ADD COLUMN IF NOT EXISTS garmin_training_load DOUBLE PRECISION;" 2>/dev/null
 
+# Add Garmin Training Readiness columns
+psql -h 127.0.0.1 -U postgres -d pulsecoach -c \
+  "ALTER TABLE daily_metric ADD COLUMN IF NOT EXISTS garmin_training_readiness INTEGER;" 2>/dev/null
+psql -h 127.0.0.1 -U postgres -d pulsecoach -c \
+  "ALTER TABLE daily_metric ADD COLUMN IF NOT EXISTS garmin_training_readiness_level TEXT;" 2>/dev/null
+psql -h 127.0.0.1 -U postgres -d pulsecoach -c \
+  "ALTER TABLE daily_metric ADD COLUMN IF NOT EXISTS garmin_readiness_factors JSONB;" 2>/dev/null
+
+# Add Garmin Training Status columns
+psql -h 127.0.0.1 -U postgres -d pulsecoach -c \
+  "ALTER TABLE daily_metric ADD COLUMN IF NOT EXISTS garmin_training_status TEXT;" 2>/dev/null
+psql -h 127.0.0.1 -U postgres -d pulsecoach -c \
+  "ALTER TABLE daily_metric ADD COLUMN IF NOT EXISTS garmin_load_focus JSONB;" 2>/dev/null
+psql -h 127.0.0.1 -U postgres -d pulsecoach -c \
+  "ALTER TABLE daily_metric ADD COLUMN IF NOT EXISTS garmin_recovery_hours DOUBLE PRECISION;" 2>/dev/null
+
 bashio::log.info "Creating daily_athlete_summary materialized view..."
 psql -h 127.0.0.1 -U postgres -d pulsecoach -f /app/sql/create_daily_athlete_summary.sql 2>&1 || bashio::log.warning "Matview creation had warnings (tables may not exist yet)"
 

--- a/tests/test_coaching_engine.py
+++ b/tests/test_coaching_engine.py
@@ -1,0 +1,229 @@
+# SPDX-FileCopyrightText: 2026 Anil Belur
+# SPDX-License-Identifier: Apache-2.0
+"""Tests for PulseCoach workout recommendation engine.
+
+Validates the deterministic coaching logic that produces daily
+workout recommendations based on readiness signals.
+"""
+
+import importlib
+import sys
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+# Resolve path relative to repo root (works from any cwd)
+_REPO_ROOT = Path(__file__).resolve().parent.parent
+_HA_NOTIFY_PATH = _REPO_ROOT / "pulsecoach" / "rootfs" / "app" / "scripts" / "ha-notify.py"
+
+
+@pytest.fixture
+def ha_notify():
+    """Import ha-notify module with mocked dependencies."""
+    with patch.dict("os.environ", {
+        "DATABASE_URL": "postgresql://test:test@localhost:5432/test",
+        "SUPERVISOR_TOKEN": "test-token",
+    }):
+        # Remove cached module if present
+        mod_name = "ha-notify"
+        if mod_name in sys.modules:
+            del sys.modules[mod_name]
+
+        spec = importlib.util.spec_from_file_location(
+            mod_name,
+            str(_HA_NOTIFY_PATH),
+        )
+        mod = importlib.util.module_from_spec(spec)
+        sys.modules[mod_name] = mod
+        spec.loader.exec_module(mod)
+        return mod
+
+
+class TestRestDayTriggers:
+    """Test conditions that trigger a rest day recommendation."""
+
+    def test_low_readiness_triggers_rest(self, ha_notify):
+        """Readiness < 25 should recommend rest."""
+        result = ha_notify.recommend_workout(
+            acwr=1.0, tsb=0, body_battery=50, stress_score=40,
+            sleep_debt_minutes=0, consecutive_hard_days=0,
+            readiness_score=20, garmin_training_status=None,
+        )
+        assert result["is_rest_day"] is True
+        assert result["workout_type"] == "rest"
+        assert "Readiness" in result["rationale"]
+
+    def test_overreaching_status_triggers_rest(self, ha_notify):
+        """Garmin OVERREACHING status should recommend rest."""
+        result = ha_notify.recommend_workout(
+            acwr=1.0, tsb=-5, body_battery=60, stress_score=40,
+            sleep_debt_minutes=0, consecutive_hard_days=0,
+            readiness_score=50, garmin_training_status="OVERREACHING",
+        )
+        assert result["is_rest_day"] is True
+        assert "OVERREACHING" in result["rationale"]
+
+    def test_high_acwr_triggers_rest(self, ha_notify):
+        """ACWR > 1.5 should recommend rest."""
+        result = ha_notify.recommend_workout(
+            acwr=1.7, tsb=-10, body_battery=50, stress_score=50,
+            sleep_debt_minutes=0, consecutive_hard_days=1,
+            readiness_score=50,
+        )
+        assert result["is_rest_day"] is True
+        assert "ACWR" in result["rationale"]
+
+    def test_deep_overreach_triggers_rest(self, ha_notify):
+        """TSB < -25 should recommend rest."""
+        result = ha_notify.recommend_workout(
+            acwr=1.0, tsb=-30, body_battery=50, stress_score=50,
+            sleep_debt_minutes=0, consecutive_hard_days=1,
+            readiness_score=50,
+        )
+        assert result["is_rest_day"] is True
+        assert "TSB" in result["rationale"]
+
+    def test_consecutive_hard_days_triggers_rest(self, ha_notify):
+        """3+ consecutive hard days should recommend rest."""
+        result = ha_notify.recommend_workout(
+            acwr=1.0, tsb=0, body_battery=60, stress_score=40,
+            sleep_debt_minutes=0, consecutive_hard_days=3,
+            readiness_score=60,
+        )
+        assert result["is_rest_day"] is True
+        assert "consecutive" in result["rationale"]
+
+
+class TestActiveRecovery:
+    """Test conditions that trigger active recovery."""
+
+    def test_multiple_recovery_signals(self, ha_notify):
+        """3+ recovery signals should recommend active recovery."""
+        result = ha_notify.recommend_workout(
+            acwr=1.35, tsb=-18, body_battery=35, stress_score=75,
+            sleep_debt_minutes=120, consecutive_hard_days=2,
+            readiness_score=35,
+        )
+        assert result["workout_type"] == "active_recovery"
+        assert result["intensity"] == "easy"
+        assert result["duration_min"] == 30
+
+    def test_low_readiness_adds_recovery_signal(self, ha_notify):
+        """Readiness < 40 should add to recovery signals."""
+        # Without low readiness: 2 signals (TSB=-18, consecutive=2)
+        result_high = ha_notify.recommend_workout(
+            acwr=1.0, tsb=-18, body_battery=50, stress_score=50,
+            sleep_debt_minutes=0, consecutive_hard_days=2,
+            readiness_score=60,
+        )
+        # With low readiness: 3 signals (TSB=-18, consecutive=2, readiness=35)
+        result_low = ha_notify.recommend_workout(
+            acwr=1.0, tsb=-18, body_battery=50, stress_score=50,
+            sleep_debt_minutes=0, consecutive_hard_days=2,
+            readiness_score=35,
+        )
+        # Low readiness should push toward easier workout than high readiness
+        intensity_order = {"rest": 0, "active_recovery": 1, "easy": 2, "aerobic": 3, "quality": 4}
+        low_intensity = intensity_order.get(result_low["workout_type"], 2)
+        high_intensity = intensity_order.get(result_high["workout_type"], 2)
+        assert low_intensity <= high_intensity, (
+            f"Low readiness should not recommend harder workout: "
+            f"{result_low['workout_type']} vs {result_high['workout_type']}"
+        )
+
+
+class TestQualitySession:
+    """Test conditions for quality/hard workout recommendations."""
+
+    def test_fresh_and_ready(self, ha_notify):
+        """High readiness + positive TSB + good BB = quality session."""
+        result = ha_notify.recommend_workout(
+            acwr=1.0, tsb=10, body_battery=80, stress_score=30,
+            sleep_debt_minutes=0, consecutive_hard_days=0,
+            readiness_score=85,
+        )
+        assert result["workout_type"] == "quality"
+        assert result["intensity"] == "hard"
+        assert result["hr_zone_target"] == 4
+
+    def test_peaking_status_enables_quality(self, ha_notify):
+        """Garmin PEAKING status should enable quality workout."""
+        result = ha_notify.recommend_workout(
+            acwr=1.0, tsb=0, body_battery=70, stress_score=40,
+            sleep_debt_minutes=0, consecutive_hard_days=0,
+            readiness_score=65, garmin_training_status="PEAKING",
+        )
+        assert result["workout_type"] == "quality"
+        assert "PEAKING" in result["rationale"]
+
+    def test_productive_status_enables_quality(self, ha_notify):
+        """Garmin PRODUCTIVE status should enable quality workout."""
+        result = ha_notify.recommend_workout(
+            acwr=1.1, tsb=-2, body_battery=65, stress_score=45,
+            sleep_debt_minutes=0, consecutive_hard_days=0,
+            readiness_score=60, garmin_training_status="PRODUCTIVE",
+        )
+        assert result["workout_type"] == "quality"
+
+    def test_high_readiness_overrides_neutral_tsb(self, ha_notify):
+        """High readiness (>=70) should allow quality even with neutral TSB."""
+        result = ha_notify.recommend_workout(
+            acwr=1.0, tsb=-3, body_battery=65, stress_score=40,
+            sleep_debt_minutes=0, consecutive_hard_days=0,
+            readiness_score=75,
+        )
+        assert result["workout_type"] == "quality"
+
+
+class TestAerobicSession:
+    """Test conditions for moderate/aerobic recommendations."""
+
+    def test_moderate_readiness_aerobic(self, ha_notify):
+        """Moderate readiness (50-70) should recommend aerobic work."""
+        result = ha_notify.recommend_workout(
+            acwr=1.0, tsb=-8, body_battery=55, stress_score=45,
+            sleep_debt_minutes=60, consecutive_hard_days=1,
+            readiness_score=55,
+        )
+        assert result["workout_type"] == "aerobic"
+        assert result["intensity"] == "moderate"
+        assert result["hr_zone_target"] == 2
+
+
+class TestDefaultEasyDay:
+    """Test the fallback easy day recommendation."""
+
+    def test_all_none_gives_easy(self, ha_notify):
+        """When all inputs are None, defaults give aerobic (readiness=50, BB=50)."""
+        result = ha_notify.recommend_workout(
+            acwr=None, tsb=None, body_battery=None, stress_score=None,
+            sleep_debt_minutes=None, consecutive_hard_days=0,
+            readiness_score=None,
+        )
+        assert result["is_rest_day"] is False
+        assert result["workout_type"] in ("easy", "aerobic")
+
+    def test_low_body_battery_neutral_else(self, ha_notify):
+        """Low BB but not critical + neutral everything = easy day."""
+        result = ha_notify.recommend_workout(
+            acwr=1.0, tsb=-12, body_battery=40, stress_score=50,
+            sleep_debt_minutes=30, consecutive_hard_days=0,
+            readiness_score=45,
+        )
+        assert result["workout_type"] in ("easy", "aerobic")
+
+
+class TestReadinessZone:
+    """Test readiness zone classification."""
+
+    def test_zones(self, ha_notify):
+        """Verify readiness zone helper if exposed via metrics-compute."""
+        # This tests the recommend_workout response includes zone context
+        result = ha_notify.recommend_workout(
+            acwr=1.0, tsb=15, body_battery=90, stress_score=20,
+            sleep_debt_minutes=0, consecutive_hard_days=0,
+            readiness_score=90,
+        )
+        assert result["workout_type"] == "quality"
+        assert "Readiness 90" in result["rationale"]


### PR DESCRIPTION
## Summary

Implements Phase 3 (Garmin native metrics) and enhances the coaching engine for v0.14.0.

### New Features

**Garmin Training Readiness Sync**
- Syncs native Training Readiness score (0-100) with 6-factor breakdown
- Stores `garmin_training_readiness`, `garmin_training_readiness_level`, `garmin_readiness_factors`

**Garmin Training Status Sync**
- Syncs Training Status (Productive/Peaking/Overreaching/Recovery/Unproductive)
- Stores load focus distribution (aerobic/anaerobic %) and recovery hours

**Enhanced Coaching Engine**
- Buchheit-style readiness computation (HRV 35%, sleep 25%, BB 20%, RHR 10%, stress 10%)
- Workout recommendation now uses readiness + Garmin training status
- Low readiness (<25) or OVERREACHING → rest day
- PEAKING/PRODUCTIVE + high readiness → quality session
- Readiness < 40 adds recovery signal weight

**2 New HA Sensors** (9 total)
- `sensor.pulsecoach_readiness` — 0-100 with zone and source
- `sensor.pulsecoach_training_status` — Garmin status + recovery hours

### Testing
- 15 new coaching engine tests covering all decision paths
- All 27 tests pass (15 coaching + 12 metrics)

### Schema Changes
- 6 new `daily_metric` columns (auto-migrated at startup)
- `readiness_score` table (auto-created by metrics-compute)
- Materialized view updated with new columns

### Version
0.13.0 → 0.14.0