### PR TITLE
feat: weight sync, Strava OAuth, v0.15.0

### DIFF
--- a/pulsecoach/CHANGELOG.md
+++ b/pulsecoach/CHANGELOG.md
@@ -5,6 +5,22 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.15.0] — 2026-04-14
+
+### Added
+- **Garmin weight/body composition sync** — auto-syncs weight (kg) and body fat % from Garmin daily
+- **New HA sensor**: `sensor.pulsecoach_weight` with body fat attribute
+- **Strava OAuth2 integration** — sync activities from Strava as secondary data source
+  - Config options: `strava_client_id`, `strava_client_secret`, `strava_refresh_token`
+  - Activities stored alongside Garmin with `source_platform` tracking
+  - TRIMP computation for Strava activities (Banister simplified)
+  - Incremental sync (7-day window) after initial full sync
+- Weight and body fat columns in materialized view for dashboard access
+
+### Changed
+- Data quality score now includes weight as a quality indicator
+- Activity table extended with `strava_activity_id` and `source_platform` columns
+
 ## [0.14.0] — 2026-04-14
 
 ### Added

--- a/pulsecoach/Dockerfile
+++ b/pulsecoach/Dockerfile
@@ -56,7 +56,7 @@ RUN apk add --no-cache \
 RUN mkdir -p /data/postgresql && chown -R postgres:postgres /data/postgresql
 
 # Install garminconnect Python package for direct Garmin API sync
-RUN pip3 install --break-system-packages garminconnect garth flask psycopg2-binary
+RUN pip3 install --break-system-packages garminconnect garth flask psycopg2-binary requests
 
 WORKDIR /app
 

--- a/pulsecoach/config.json
+++ b/pulsecoach/config.json
@@ -1,6 +1,6 @@
 {
   "name": "PulseCoach",
-  "version": "0.14.0",
+  "version": "0.15.0",
   "slug": "pulsecoach",
   "image": "ghcr.io/askb/pulsecoach-addon-{arch}",
   "description": "AI-powered sport scientist \u2014 training analysis, coaching, and recovery optimization from your Garmin data",
@@ -27,6 +27,9 @@
   "options": {
     "garmin_email": "",
     "garmin_password": "",
+    "strava_client_id": "",
+    "strava_client_secret": "",
+    "strava_refresh_token": "",
     "ai_backend": "none",
     "sync_interval_minutes": 60,
     "user_timezone": "UTC"
@@ -34,6 +37,9 @@
   "schema": {
     "garmin_email": "str?",
     "garmin_password": "password?",
+    "strava_client_id": "str?",
+    "strava_client_secret": "password?",
+    "strava_refresh_token": "password?",
     "ai_backend": "list(ha_conversation|ollama|none)",
     "ollama_url": "str?",
     "sync_interval_minutes": "int(5,1440)?",

--- a/pulsecoach/rootfs/app/scripts/garmin-sync.py
+++ b/pulsecoach/rootfs/app/scripts/garmin-sync.py
@@ -237,9 +237,10 @@ def sync_daily_stats(client, db, date_str):
         hrv = client.get_hrv_data(date_str)
         stress = client.get_stress_data(date_str)
 
-        # Fetch SpO2 and respiration data (gracefully handle API errors)
+        # Fetch SpO2, respiration, and body composition (gracefully handle API errors)
         spo2_data = None
         respiration_data = None
+        body_comp_data = None
         try:
             spo2_data = client.get_spo2_data(date_str)
         except Exception as e:
@@ -248,6 +249,10 @@ def sync_daily_stats(client, db, date_str):
             respiration_data = client.get_respiration_data(date_str)
         except Exception as e:
             print(f"  Respiration data unavailable for {date_str}: {e}")
+        try:
+            body_comp_data = client.get_body_composition(date_str)
+        except Exception as e:
+            print(f"  Body composition data unavailable for {date_str}: {e}")
 
         # Debug: log stress field names so we can verify data extraction
         stress_val = None
@@ -276,13 +281,25 @@ def sync_daily_stats(client, db, date_str):
         if respiration_val is None and stats:
             respiration_val = stats.get("respirationAvg")
 
+        # Extract weight (kg) from body composition data
+        weight_kg = None
+        body_fat_pct = None
+        if body_comp_data:
+            # Garmin returns weight in grams; convert to kg
+            weight_g = body_comp_data.get("weight")
+            if weight_g and weight_g > 0:
+                weight_kg = round(weight_g / 1000.0, 1)
+            body_fat_pct = body_comp_data.get("bodyFat")
+            if weight_kg:
+                print(f"  Weight for {date_str}: {weight_kg} kg")
+
         # Compute data quality flag (percentage of key fields present)
         quality_fields = [
             stats.get("totalSteps"), stats.get("restingHeartRate"),
             _safe_sleep_minutes(sleep_dto, "sleepTimeSeconds"),
             sleep_dto.get("sleepScores", {}).get("overall", {}).get("value"),
             hrv.get("hrvSummary", {}).get("weeklyAvg") if hrv else None,
-            stress_val, spo2_val,
+            stress_val, spo2_val, weight_kg,
         ]
         present = sum(1 for f in quality_fields if f is not None)
         data_quality = round(present / len(quality_fields) * 100)
@@ -310,8 +327,9 @@ def sync_daily_stats(client, db, date_str):
                 floors_climbed, intensity_minutes,
                 sleep_start_time, sleep_end_time, sleep_need_minutes, sleep_debt_minutes,
                 spo2, respiration_rate,
+                weight_kg, body_fat_pct,
                 synced_at, data_quality
-            ) VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s)
+            ) VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s)
             ON CONFLICT (user_id, date) DO UPDATE SET
                 steps = EXCLUDED.steps,
                 calories = EXCLUDED.calories,
@@ -335,6 +353,8 @@ def sync_daily_stats(client, db, date_str):
                 sleep_debt_minutes = COALESCE(EXCLUDED.sleep_debt_minutes, daily_metric.sleep_debt_minutes),
                 spo2 = COALESCE(EXCLUDED.spo2, daily_metric.spo2),
                 respiration_rate = COALESCE(EXCLUDED.respiration_rate, daily_metric.respiration_rate),
+                weight_kg = COALESCE(EXCLUDED.weight_kg, daily_metric.weight_kg),
+                body_fat_pct = COALESCE(EXCLUDED.body_fat_pct, daily_metric.body_fat_pct),
                 synced_at = EXCLUDED.synced_at,
                 data_quality = EXCLUDED.data_quality
         """, (
@@ -362,6 +382,8 @@ def sync_daily_stats(client, db, date_str):
             _compute_sleep_debt(sleep_dto),
             spo2_val,
             respiration_val,
+            weight_kg,
+            body_fat_pct,
             datetime.now(timezone.utc).isoformat(),
             data_quality,
         ))

--- a/pulsecoach/rootfs/app/scripts/ha-notify.py
+++ b/pulsecoach/rootfs/app/scripts/ha-notify.py
@@ -487,6 +487,17 @@ def run_notifications(user_id: str):
                         "load_focus": dm.get('garmin_load_focus') if dm else None,
                     })
 
+        # sensor.pulsecoach_weight
+        weight = dm.get('weight_kg') if dm else None
+        push_sensor("sensor.pulsecoach_weight",
+                    round(weight, 1) if weight else "unknown",
+                    {
+                        "friendly_name": "PulseCoach Weight",
+                        "unit_of_measurement": "kg",
+                        "icon": "mdi:scale-bathroom",
+                        "body_fat_pct": dm.get('body_fat_pct') if dm else None,
+                    })
+
         # sensor.pulsecoach_workout_recommendation
         # AI-informed workout suggestion using readiness + all recovery signals
         hard_days = data["consecutive_hard_days"]

--- a/pulsecoach/rootfs/app/scripts/strava-sync.py
+++ b/pulsecoach/rootfs/app/scripts/strava-sync.py
@@ -1,0 +1,267 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: 2026 Anil Belur
+"""Strava OAuth2 activity sync for PulseCoach.
+
+Syncs activities from Strava API v3 into the shared activity table.
+Uses OAuth2 refresh tokens for authentication. Activities are deduped
+by strava_activity_id to coexist with Garmin-sourced activities.
+"""
+
+import json
+import os
+import sys
+import time
+from datetime import datetime, timezone
+from pathlib import Path
+
+import psycopg2
+import requests
+
+# ── Configuration ────────────────────────────────────────────────────────────
+DATABASE_URL = os.environ.get("DATABASE_URL", "postgresql://postgres@127.0.0.1:5432/pulsecoach")
+TOKEN_DIR = Path("/data/strava-tokens")
+TOKEN_FILE = TOKEN_DIR / "strava_tokens.json"
+STRAVA_API_BASE = "https://www.strava.com/api/v3"
+STRAVA_TOKEN_URL = "https://www.strava.com/api/v3/oauth/token"
+
+USER_ID = "default"
+
+
+def _load_tokens():
+    """Load Strava tokens from disk."""
+    if TOKEN_FILE.exists():
+        return json.loads(TOKEN_FILE.read_text())
+    return None
+
+
+def _save_tokens(tokens):
+    """Save Strava tokens to disk."""
+    TOKEN_DIR.mkdir(parents=True, exist_ok=True)
+    TOKEN_FILE.write_text(json.dumps(tokens, indent=2))
+
+
+def refresh_access_token(client_id, client_secret, refresh_token):
+    """Exchange refresh token for a new access token."""
+    resp = requests.post(STRAVA_TOKEN_URL, data={
+        "client_id": client_id,
+        "client_secret": client_secret,
+        "grant_type": "refresh_token",
+        "refresh_token": refresh_token,
+    }, timeout=30)
+    resp.raise_for_status()
+    data = resp.json()
+    tokens = {
+        "access_token": data["access_token"],
+        "refresh_token": data["refresh_token"],
+        "expires_at": data["expires_at"],
+        "athlete_id": data.get("athlete", {}).get("id"),
+    }
+    _save_tokens(tokens)
+    return tokens
+
+
+def get_valid_token(client_id, client_secret, refresh_token):
+    """Return a valid access token, refreshing if expired."""
+    tokens = _load_tokens()
+    if tokens and tokens.get("expires_at", 0) > time.time() + 60:
+        return tokens["access_token"]
+    return refresh_access_token(client_id, client_secret, refresh_token)["access_token"]
+
+
+def fetch_activities(access_token, after_epoch=None, per_page=100):
+    """Fetch activities from Strava API."""
+    params = {"per_page": per_page}
+    if after_epoch:
+        params["after"] = int(after_epoch)
+
+    all_activities = []
+    page = 1
+    while True:
+        params["page"] = page
+        resp = requests.get(
+            f"{STRAVA_API_BASE}/athlete/activities",
+            headers={"Authorization": f"Bearer {access_token}"},
+            params=params,
+            timeout=30,
+        )
+        resp.raise_for_status()
+        batch = resp.json()
+        if not batch:
+            break
+        all_activities.extend(batch)
+        if len(batch) < per_page:
+            break
+        page += 1
+        time.sleep(1)  # Rate limiting
+
+    return all_activities
+
+
+def _map_sport_type(strava_type):
+    """Map Strava activity type to normalized sport type."""
+    mapping = {
+        "Run": "running", "Trail Run": "trail_running",
+        "Walk": "walking", "Hike": "hiking",
+        "Ride": "cycling", "VirtualRide": "cycling",
+        "Swim": "swimming", "Yoga": "yoga",
+        "WeightTraining": "strength", "Workout": "other",
+        "Rowing": "rowing", "Elliptical": "elliptical",
+    }
+    return mapping.get(strava_type, "other")
+
+
+def _compute_trimp(duration_min, avg_hr, max_hr=None):
+    """Estimate TRIMP from Strava activity (Banister simplified)."""
+    if not avg_hr or not duration_min:
+        return None
+    resting_hr = 60  # Default estimate
+    max_hr_est = max_hr or 190
+    if max_hr_est <= resting_hr:
+        return None
+    hr_reserve = (avg_hr - resting_hr) / (max_hr_est - resting_hr)
+    hr_reserve = max(0, min(1, hr_reserve))
+    # Gender-neutral coefficient (1.67 avg of male 1.92 / female 1.67)
+    return round(duration_min * hr_reserve * 1.67 * pow(2.718, 1.67 * hr_reserve), 1)
+
+
+def ensure_strava_column(db):
+    """Add strava_activity_id column to activity table if missing."""
+    cur = db.cursor()
+    cur.execute("""
+        DO $$ BEGIN
+            ALTER TABLE activity ADD COLUMN IF NOT EXISTS strava_activity_id BIGINT;
+        EXCEPTION WHEN OTHERS THEN NULL;
+        END $$;
+    """)
+    cur.execute("""
+        DO $$ BEGIN
+            IF NOT EXISTS (
+                SELECT 1 FROM pg_constraint
+                WHERE conname = 'activity_strava_id_uq'
+            ) THEN
+                ALTER TABLE activity
+                    ADD CONSTRAINT activity_strava_id_uq
+                    UNIQUE (strava_activity_id);
+            END IF;
+        EXCEPTION WHEN duplicate_object THEN NULL;
+        END $$;
+    """)
+    # Add source_platform column for multi-source tracking
+    cur.execute("""
+        ALTER TABLE activity ADD COLUMN IF NOT EXISTS source_platform TEXT DEFAULT 'garmin';
+    """)
+    db.commit()
+
+
+def sync_activities(db, activities):
+    """Upsert Strava activities into the activity table."""
+    cur = db.cursor()
+    synced = 0
+    for act in activities:
+        strava_id = act["id"]
+        sport = _map_sport_type(act.get("type", "Workout"))
+        started_at = act.get("start_date")  # ISO 8601 UTC
+        duration_min = round(act.get("elapsed_time", 0) / 60, 1)
+        distance_m = act.get("distance", 0)
+        avg_hr = act.get("average_heartrate")
+        max_hr = act.get("max_heartrate")
+        calories = act.get("calories") or act.get("kilojoules")
+
+        avg_pace = None
+        if distance_m and distance_m > 0 and duration_min > 0:
+            avg_pace = round((duration_min * 60) / (distance_m / 1000), 1)
+
+        trimp = _compute_trimp(duration_min, avg_hr, max_hr)
+
+        try:
+            cur.execute("""
+                INSERT INTO activity (
+                    user_id, strava_activity_id, sport_type,
+                    started_at, duration_minutes, distance_meters,
+                    avg_hr, max_hr, calories,
+                    avg_pace_sec_per_km, trimp_score,
+                    avg_power, avg_cadence,
+                    source_platform, synced_at
+                ) VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s)
+                ON CONFLICT (strava_activity_id) DO UPDATE SET
+                    sport_type = EXCLUDED.sport_type,
+                    duration_minutes = EXCLUDED.duration_minutes,
+                    distance_meters = EXCLUDED.distance_meters,
+                    avg_hr = EXCLUDED.avg_hr,
+                    max_hr = EXCLUDED.max_hr,
+                    calories = EXCLUDED.calories,
+                    avg_pace_sec_per_km = EXCLUDED.avg_pace_sec_per_km,
+                    trimp_score = EXCLUDED.trimp_score,
+                    avg_power = EXCLUDED.avg_power,
+                    avg_cadence = EXCLUDED.avg_cadence,
+                    synced_at = EXCLUDED.synced_at
+            """, (
+                USER_ID, strava_id, sport,
+                started_at, duration_min, distance_m,
+                avg_hr, max_hr, calories,
+                avg_pace, trimp,
+                act.get("average_watts"), act.get("average_cadence"),
+                "strava", datetime.now(timezone.utc).isoformat(),
+            ))
+            synced += 1
+        except Exception as e:
+            print(f"  [strava-sync] Error syncing activity {strava_id}: {e}")
+            db.rollback()
+            continue
+
+    db.commit()
+    return synced
+
+
+def main():
+    """Main Strava sync entry point."""
+    client_id = os.environ.get("STRAVA_CLIENT_ID", "").strip()
+    client_secret = os.environ.get("STRAVA_CLIENT_SECRET", "").strip()
+    refresh_token = os.environ.get("STRAVA_REFRESH_TOKEN", "").strip()
+
+    if not all([client_id, client_secret, refresh_token]):
+        print("[strava-sync] Strava credentials not configured, skipping.")
+        return
+
+    print("[strava-sync] Starting Strava activity sync...")
+
+    try:
+        access_token = get_valid_token(client_id, client_secret, refresh_token)
+    except Exception as e:
+        print(f"[strava-sync] Authentication failed: {e}")
+        return
+
+    db = psycopg2.connect(DATABASE_URL)
+    try:
+        ensure_strava_column(db)
+
+        # Determine sync window: last 7 days for incremental, full history for first sync
+        marker = TOKEN_DIR / ".strava_initial_sync_done"
+        if marker.exists():
+            after_epoch = time.time() - (7 * 86400)
+            print("[strava-sync] Incremental sync (last 7 days)")
+        else:
+            after_epoch = None
+            print("[strava-sync] Full initial sync")
+
+        activities = fetch_activities(access_token, after_epoch)
+        print(f"[strava-sync] Fetched {len(activities)} activities from Strava")
+
+        if activities:
+            count = sync_activities(db, activities)
+            print(f"[strava-sync] Synced {count} activities to database")
+
+        if not marker.exists():
+            marker.touch()
+
+    except Exception as e:
+        print(f"[strava-sync] Sync error: {e}")
+    finally:
+        db.close()
+
+    print("[strava-sync] Strava sync complete.")
+
+
+if __name__ == "__main__":
+    main()

--- a/pulsecoach/rootfs/app/sql/create_daily_athlete_summary.sql
+++ b/pulsecoach/rootfs/app/sql/create_daily_athlete_summary.sql
@@ -43,6 +43,10 @@ SELECT
     dm.garmin_training_load,
     dm.data_quality,
 
+    -- Body composition (from Garmin body composition API)
+    dm.weight_kg,
+    dm.body_fat_pct,
+
     -- Garmin Training Readiness (native scores from Garmin API)
     dm.garmin_training_readiness,
     dm.garmin_training_readiness_level,

--- a/pulsecoach/rootfs/app/tests/test_sync.py
+++ b/pulsecoach/rootfs/app/tests/test_sync.py
@@ -52,6 +52,9 @@ class TestSyncDailyStats:
         client.get_sleep_data.return_value = sample_sleep
         client.get_hrv_data.return_value = sample_hrv
         client.get_stress_data.return_value = {}
+        client.get_spo2_data.return_value = None
+        client.get_respiration_data.return_value = None
+        client.get_body_composition.return_value = {"weight": 75000, "bodyFat": 18.5}
 
         module = _load_sync_module()
 
@@ -70,6 +73,9 @@ class TestSyncDailyStats:
         client.get_sleep_data.return_value = {}  # empty sleep response
         client.get_hrv_data.return_value = {}
         client.get_stress_data.return_value = {}
+        client.get_spo2_data.return_value = None
+        client.get_respiration_data.return_value = None
+        client.get_body_composition.return_value = None
 
         module = _load_sync_module()
 

--- a/pulsecoach/rootfs/etc/s6-overlay/s6-rc.d/pulsecoach/run
+++ b/pulsecoach/rootfs/etc/s6-overlay/s6-rc.d/pulsecoach/run
@@ -94,12 +94,16 @@ trap cleanup EXIT INT TERM
 # ─── Read addon configuration ─────────────────────────────────────────────────
 GARMIN_EMAIL=$(bashio::config 'garmin_email')
 GARMIN_PASSWORD=$(bashio::config 'garmin_password')
+STRAVA_CLIENT_ID=$(bashio::config 'strava_client_id' || echo "")
+STRAVA_CLIENT_SECRET=$(bashio::config 'strava_client_secret' || echo "")
+STRAVA_REFRESH_TOKEN=$(bashio::config 'strava_refresh_token' || echo "")
 AI_BACKEND=$(bashio::config 'ai_backend' || echo "none")
 OLLAMA_URL=$(bashio::config 'ollama_url' || echo "")
 SYNC_INTERVAL=$(bashio::config 'sync_interval_minutes' || echo "60")
 USER_TIMEZONE=$(bashio::config 'user_timezone' || echo "UTC")
 
 export GARMIN_EMAIL GARMIN_PASSWORD
+export STRAVA_CLIENT_ID STRAVA_CLIENT_SECRET STRAVA_REFRESH_TOKEN
 export AI_BACKEND
 export OLLAMA_URL
 export OLLAMA_MODEL="${OLLAMA_MODEL:-gpt-oss:20b}"
@@ -187,6 +191,12 @@ psql -h 127.0.0.1 -U postgres -d pulsecoach -c \
 psql -h 127.0.0.1 -U postgres -d pulsecoach -c \
   "ALTER TABLE daily_metric ADD COLUMN IF NOT EXISTS garmin_recovery_hours DOUBLE PRECISION;" 2>/dev/null
 
+# Add body composition columns
+psql -h 127.0.0.1 -U postgres -d pulsecoach -c \
+  "ALTER TABLE daily_metric ADD COLUMN IF NOT EXISTS weight_kg DOUBLE PRECISION;" 2>/dev/null
+psql -h 127.0.0.1 -U postgres -d pulsecoach -c \
+  "ALTER TABLE daily_metric ADD COLUMN IF NOT EXISTS body_fat_pct DOUBLE PRECISION;" 2>/dev/null
+
 bashio::log.info "Creating daily_athlete_summary materialized view..."
 psql -h 127.0.0.1 -U postgres -d pulsecoach -f /app/sql/create_daily_athlete_summary.sql 2>&1 || bashio::log.warning "Matview creation had warnings (tables may not exist yet)"
 
@@ -218,6 +228,23 @@ elif [ -f "${TOKEN_DIR}/garmin_tokens.json" ] || { [ -f "${TOKEN_DIR}/oauth1_tok
 else
     bashio::log.warning "No Garmin credentials or saved tokens — skipping auto-sync"
     bashio::log.info "Use Settings page to log in, or run scripts/generate-garmin-tokens.py locally"
+fi
+
+# ─── Start Strava sync in background (if configured) ─────────────────────────
+if [ -n "${STRAVA_CLIENT_ID}" ] && [ -n "${STRAVA_CLIENT_SECRET}" ] && [ -n "${STRAVA_REFRESH_TOKEN}" ]; then
+    bashio::log.info "Starting Strava sync (every ${SYNC_INTERVAL} minutes)..."
+    (
+        sleep 30
+        while true; do
+            bashio::log.info "Syncing Strava activities..."
+            python3 /app/scripts/strava-sync.py 2>&1 || bashio::log.warning "Strava sync failed"
+            backup_to_share
+            sleep "$((SYNC_INTERVAL * 60))"
+        done
+    ) &
+    STRAVA_SYNC_PID=$!
+else
+    bashio::log.info "No Strava credentials configured — skipping Strava sync"
 fi
 
 # ─── Start metrics compute in background ─────────────────────────────────────


### PR DESCRIPTION
## Changes

### Garmin Weight/Body Composition Sync
- Sync weight (kg) and body fat % from `get_body_composition()` API
- New HA sensor: `sensor.pulsecoach_weight` with body fat attribute
- Added `weight_kg` and `body_fat_pct` columns to daily_metric + matview
- Weight included in data quality scoring

### Strava OAuth2 Integration
- New `strava-sync.py` for activity sync from Strava API v3
- Config options: `strava_client_id`, `strava_client_secret`, `strava_refresh_token`
- Activities stored with `source_platform` tracking (garmin/strava)
- TRIMP computation for Strava activities (Banister simplified)
- Incremental sync (7-day window) after initial full sync
- Background sync loop in s6 orchestrator

### Infrastructure
- Added `requests` Python package to Dockerfile
- s6 run script exports Strava env vars and manages sync PID
- Database migrations for new columns (ALTER TABLE IF NOT EXISTS)

Closes: weight sync and Strava integration todos