### PR TITLE
fix: align readiness_score columns with Drizzle schema

### DIFF
--- a/pulsecoach/CHANGELOG.md
+++ b/pulsecoach/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.15.2] — 2026-04-14
+
+### Fixed
+- **readiness_score schema mismatch** — metrics-compute.py column names (`readiness_zone`, `readiness_explanation`) didn't match Drizzle schema (`zone`, `explanation`); aligned all references
+- **Conditional migration** — uses `information_schema.columns` check to safely rename only if old columns exist
+- **Matview aliases** — `rs.zone AS readiness_zone`, `rs.explanation AS readiness_explanation`
+
 ## [0.15.1] — 2026-04-14
 
 ### Fixed

--- a/pulsecoach/config.json
+++ b/pulsecoach/config.json
@@ -1,6 +1,6 @@
 {
   "name": "PulseCoach",
-  "version": "0.15.1",
+  "version": "0.15.2",
   "slug": "pulsecoach",
   "image": "ghcr.io/askb/pulsecoach-addon-{arch}",
   "description": "AI-powered sport scientist \u2014 training analysis, coaching, and recovery optimization from your Garmin data",

--- a/pulsecoach/rootfs/app/scripts/metrics-compute.py
+++ b/pulsecoach/rootfs/app/scripts/metrics-compute.py
@@ -89,14 +89,15 @@ def ensure_advanced_metric_table(cur):
     """)
 
     # Ensure readiness_score table exists for computed readiness
+    # NOTE: Drizzle schema is authoritative — columns: score, zone, explanation
     cur.execute("""
         CREATE TABLE IF NOT EXISTS readiness_score (
             id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
             user_id TEXT NOT NULL,
             date DATE NOT NULL,
             score INTEGER,
-            readiness_zone TEXT,
-            readiness_explanation TEXT,
+            zone VARCHAR(20),
+            explanation TEXT,
             computed_at TIMESTAMP DEFAULT NOW(),
             UNIQUE(user_id, date)
         );
@@ -402,13 +403,13 @@ def upsert_readiness_scores(cur, user_id: str, readiness_data: dict):
     for d_str, data in sorted(readiness_data.items()):
         cur.execute("""
             INSERT INTO readiness_score (
-                user_id, date, score, readiness_zone,
-                readiness_explanation, computed_at
+                user_id, date, score, zone,
+                explanation, computed_at
             ) VALUES (%s, %s, %s, %s, %s, NOW())
             ON CONFLICT (user_id, date) DO UPDATE SET
                 score = EXCLUDED.score,
-                readiness_zone = EXCLUDED.readiness_zone,
-                readiness_explanation = EXCLUDED.readiness_explanation,
+                zone = EXCLUDED.zone,
+                explanation = EXCLUDED.explanation,
                 computed_at = NOW()
         """, (
             user_id, d_str, data["score"], data["zone"],

--- a/pulsecoach/rootfs/app/sql/create_daily_athlete_summary.sql
+++ b/pulsecoach/rootfs/app/sql/create_daily_athlete_summary.sql
@@ -72,8 +72,8 @@ SELECT
 
     -- Readiness score (from metrics-compute.py Buchheit/Garmin hybrid)
     rs.score AS readiness_score,
-    rs.readiness_zone,
-    rs.readiness_explanation,
+    rs.zone AS readiness_zone,
+    rs.explanation AS readiness_explanation,
 
     -- VO2max (best source per date: official > computed)
     ve.value AS vo2max_value,

--- a/pulsecoach/rootfs/etc/s6-overlay/s6-rc.d/pulsecoach/run
+++ b/pulsecoach/rootfs/etc/s6-overlay/s6-rc.d/pulsecoach/run
@@ -197,12 +197,35 @@ psql -h 127.0.0.1 -U postgres -d pulsecoach -c \
 psql -h 127.0.0.1 -U postgres -d pulsecoach -c \
   "ALTER TABLE daily_metric ADD COLUMN IF NOT EXISTS body_fat_pct DOUBLE PRECISION;" 2>/dev/null
 
-# Fix readiness_score table: rename column readiness_score→score (v0.14.0 bug)
-psql -h 127.0.0.1 -U postgres -d pulsecoach -c \
-  "ALTER TABLE readiness_score RENAME COLUMN readiness_score TO score;" 2>/dev/null
-# Ensure score column exists (for fresh installs or if rename was a no-op)
-psql -h 127.0.0.1 -U postgres -d pulsecoach -c \
-  "ALTER TABLE readiness_score ADD COLUMN IF NOT EXISTS score INTEGER;" 2>/dev/null
+# Fix readiness_score table: align columns with Drizzle schema (v0.14.0 bug)
+# Drizzle uses: score, zone, explanation
+# Old metrics-compute.py used: readiness_score, readiness_zone, readiness_explanation
+psql -h 127.0.0.1 -U postgres -d pulsecoach -c "
+DO \$\$
+BEGIN
+    -- Rename readiness_score → score if old column exists
+    IF EXISTS (
+        SELECT 1 FROM information_schema.columns
+        WHERE table_name = 'readiness_score' AND column_name = 'readiness_score'
+    ) THEN
+        ALTER TABLE readiness_score RENAME COLUMN readiness_score TO score;
+    END IF;
+    -- Rename readiness_zone → zone if old column exists
+    IF EXISTS (
+        SELECT 1 FROM information_schema.columns
+        WHERE table_name = 'readiness_score' AND column_name = 'readiness_zone'
+    ) THEN
+        ALTER TABLE readiness_score RENAME COLUMN readiness_zone TO zone;
+    END IF;
+    -- Rename readiness_explanation → explanation if old column exists
+    IF EXISTS (
+        SELECT 1 FROM information_schema.columns
+        WHERE table_name = 'readiness_score' AND column_name = 'readiness_explanation'
+    ) THEN
+        ALTER TABLE readiness_score RENAME COLUMN readiness_explanation TO explanation;
+    END IF;
+END \$\$;
+" 2>/dev/null || true
 
 bashio::log.info "Creating daily_athlete_summary materialized view..."
 psql -h 127.0.0.1 -U postgres -d pulsecoach -f /app/sql/create_daily_athlete_summary.sql 2>&1 || bashio::log.warning "Matview creation had warnings (tables may not exist yet)"

--- a/pulsecoach/rootfs/etc/s6-overlay/s6-rc.d/pulsecoach/run
+++ b/pulsecoach/rootfs/etc/s6-overlay/s6-rc.d/pulsecoach/run
@@ -206,21 +206,21 @@ BEGIN
     -- Rename readiness_score → score if old column exists
     IF EXISTS (
         SELECT 1 FROM information_schema.columns
-        WHERE table_name = 'readiness_score' AND column_name = 'readiness_score'
+        WHERE table_schema = 'public' AND table_name = 'readiness_score' AND column_name = 'readiness_score'
     ) THEN
         ALTER TABLE readiness_score RENAME COLUMN readiness_score TO score;
     END IF;
     -- Rename readiness_zone → zone if old column exists
     IF EXISTS (
         SELECT 1 FROM information_schema.columns
-        WHERE table_name = 'readiness_score' AND column_name = 'readiness_zone'
+        WHERE table_schema = 'public' AND table_name = 'readiness_score' AND column_name = 'readiness_zone'
     ) THEN
         ALTER TABLE readiness_score RENAME COLUMN readiness_zone TO zone;
     END IF;
     -- Rename readiness_explanation → explanation if old column exists
     IF EXISTS (
         SELECT 1 FROM information_schema.columns
-        WHERE table_name = 'readiness_score' AND column_name = 'readiness_explanation'
+        WHERE table_schema = 'public' AND table_name = 'readiness_score' AND column_name = 'readiness_explanation'
     ) THEN
         ALTER TABLE readiness_score RENAME COLUMN readiness_explanation TO explanation;
     END IF;


### PR DESCRIPTION
## Root Cause

The Drizzle schema (app) creates `readiness_score` table with columns: `score`, `zone`, `explanation`.

metrics-compute.py was using: `readiness_score`, `readiness_zone`, `readiness_explanation` — causing INSERT/matview failures on HAOS where Drizzle creates the table first via `drizzle-kit push`.

v0.15.1 only renamed the `readiness_score` column but missed `readiness_zone` and `readiness_explanation`.

## Changes
- **metrics-compute.py**: Aligned CREATE TABLE and UPSERT to use `score`, `zone`, `explanation`
- **create_daily_athlete_summary.sql**: Updated matview to `rs.zone AS readiness_zone`, `rs.explanation AS readiness_explanation`
- **pulsecoach/run**: Conditional migration using `information_schema.columns` — safely renames all 3 old columns if they exist
- **config.json**: v0.15.2
- **CHANGELOG.md**: Added 0.15.2 entry

## Testing
- 27/27 tests pass