### PR TITLE
fix: ensure readiness_score UNIQUE constraint for ON CONFLICT

### DIFF
--- a/pulsecoach/CHANGELOG.md
+++ b/pulsecoach/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.15.3] — 2026-04-14
+
+### Fixed
+- **readiness_score UNIQUE constraint missing** — Drizzle creates the table without the `UNIQUE(user_id, date)` constraint that `ON CONFLICT` requires; added `CREATE UNIQUE INDEX IF NOT EXISTS` to ensure it exists
+
 ## [0.15.2] — 2026-04-14
 
 ### Fixed

--- a/pulsecoach/config.json
+++ b/pulsecoach/config.json
@@ -1,6 +1,6 @@
 {
   "name": "PulseCoach",
-  "version": "0.15.2",
+  "version": "0.15.3",
   "slug": "pulsecoach",
   "image": "ghcr.io/askb/pulsecoach-addon-{arch}",
   "description": "AI-powered sport scientist \u2014 training analysis, coaching, and recovery optimization from your Garmin data",

--- a/pulsecoach/rootfs/app/scripts/metrics-compute.py
+++ b/pulsecoach/rootfs/app/scripts/metrics-compute.py
@@ -102,10 +102,29 @@ def ensure_advanced_metric_table(cur):
             UNIQUE(user_id, date)
         );
     """)
-    # Drizzle may create the table without our UNIQUE constraint — ensure it exists
+    # If the table was created by Drizzle push (without the constraint),
+    # CREATE TABLE IF NOT EXISTS won't add it. Ensure it exists separately.
     cur.execute("""
-        CREATE UNIQUE INDEX IF NOT EXISTS readiness_score_user_id_date_idx
-        ON readiness_score (user_id, date);
+        DO $$
+        BEGIN
+            IF NOT EXISTS (
+                SELECT 1 FROM pg_constraint
+                WHERE conname = 'readiness_score_user_date_unique'
+                  AND conrelid = 'readiness_score'::regclass
+            ) AND NOT EXISTS (
+                SELECT 1 FROM pg_constraint
+                WHERE conname = 'readiness_score_user_id_date_key'
+                  AND conrelid = 'readiness_score'::regclass
+            ) AND NOT EXISTS (
+                SELECT 1 FROM pg_indexes
+                WHERE tablename = 'readiness_score'
+                  AND indexname = 'readiness_score_user_id_date_idx'
+            ) THEN
+                ALTER TABLE readiness_score
+                    ADD CONSTRAINT readiness_score_user_date_unique
+                    UNIQUE (user_id, date);
+            END IF;
+        END $$;
     """)
 
 

--- a/pulsecoach/rootfs/app/scripts/metrics-compute.py
+++ b/pulsecoach/rootfs/app/scripts/metrics-compute.py
@@ -102,6 +102,11 @@ def ensure_advanced_metric_table(cur):
             UNIQUE(user_id, date)
         );
     """)
+    # Drizzle may create the table without our UNIQUE constraint — ensure it exists
+    cur.execute("""
+        CREATE UNIQUE INDEX IF NOT EXISTS readiness_score_user_id_date_idx
+        ON readiness_score (user_id, date);
+    """)
 
 
 def fetch_daily_loads(cur, user_id):


### PR DESCRIPTION
## Error
```
there is no unique or exclusion constraint matching the ON CONFLICT specification
```

## Root Cause
Drizzle creates the `readiness_score` table via `drizzle-kit push` before metrics-compute.py runs. So `CREATE TABLE IF NOT EXISTS` is a no-op and the `UNIQUE(user_id, date)` constraint is never applied. The `ON CONFLICT (user_id, date)` upsert then fails.

## Fix
Added `CREATE UNIQUE INDEX IF NOT EXISTS readiness_score_user_id_date_idx ON readiness_score (user_id, date)` — idempotent, works whether Drizzle or metrics-compute.py creates the table first.

Same pattern already used for `advanced_metric` table.