### PR TITLE
fix: refresh insights upsert, bump v0.15.4

### DIFF
--- a/pulsecoach/CHANGELOG.md
+++ b/pulsecoach/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.15.4] — 2026-04-15
+
+### Fixed
+- **Refresh Insights button** — clicking "Refresh Insights" now correctly updates existing insights instead of silently skipping (changed `onConflictDoNothing` → `onConflictDoUpdate` in app)
+- Refreshed insights are marked as unread with updated severity, title, body, and action suggestions
+
 ## [0.15.3] — 2026-04-14
 
 ### Fixed

--- a/pulsecoach/config.json
+++ b/pulsecoach/config.json
@@ -1,6 +1,6 @@
 {
   "name": "PulseCoach",
-  "version": "0.15.3",
+  "version": "0.15.4",
   "slug": "pulsecoach",
   "image": "ghcr.io/askb/pulsecoach-addon-{arch}",
   "description": "AI-powered sport scientist \u2014 training analysis, coaching, and recovery optimization from your Garmin data",


### PR DESCRIPTION
## Changes
- Bump addon version to 0.15.4
- Picks up app fix ha-garmin-fitness-coach-app#78 at build time (Dockerfile clones main)

## App Fix Included
**Refresh Insights button** was broken — `onConflictDoNothing` silently skipped inserts when today's insights already existed. Changed to `onConflictDoUpdate` so refresh updates severity, title, body, metrics, confidence, and action suggestions. Marks refreshed insights as unread.