### PR TITLE
feat: add /auth/recompute endpoint for on-demand metrics compute

### DIFF
--- a/pulsecoach/rootfs/app/scripts/garmin-auth-server.py
+++ b/pulsecoach/rootfs/app/scripts/garmin-auth-server.py
@@ -289,5 +289,56 @@ def logout() -> tuple[Response, int] | Response:
         return jsonify(success=False, message=str(exc)), 500
 
 
+@app.route("/auth/recompute", methods=["POST"])
+def trigger_recompute() -> tuple[Response, int] | Response:
+    """Trigger an immediate metrics recomputation in the background."""
+    import subprocess
+
+    status_file = os.path.join(TOKEN_DIR, ".recompute_status")
+    try:
+        if os.path.exists(status_file):
+            with open(status_file) as f:
+                data = json.load(f)
+            if data.get("running"):
+                return jsonify(success=False, message="Recompute already running"), 409
+    except Exception:
+        pass
+
+    try:
+        # Write running status
+        with open(status_file, "w") as f:
+            json.dump({"running": True, "started": __import__("time").time()}, f)
+
+        env = os.environ.copy()
+        env["DATABASE_URL"] = os.environ.get(
+            "DATABASE_URL",
+            "postgresql://postgres@127.0.0.1:5432/pulsecoach",
+        )
+        subprocess.Popen(
+            ["python3", "/app/scripts/metrics-compute.py", "--once"],
+            env=env,
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL,
+        )
+        log.info("Manual recompute triggered")
+        return jsonify(success=True, message="Recompute started")
+    except Exception as exc:
+        log.error("Failed to trigger recompute: %s", exc)
+        return jsonify(success=False, message=f"Failed: {exc}"), 500
+
+
+@app.route("/auth/recompute-status", methods=["GET"])
+def recompute_status() -> Response:
+    """Check if metrics recompute is currently running."""
+    status_file = os.path.join(TOKEN_DIR, ".recompute_status")
+    try:
+        if os.path.exists(status_file):
+            with open(status_file) as f:
+                return jsonify(json.load(f))
+    except Exception:
+        pass
+    return jsonify({"running": False})
+
+
 if __name__ == "__main__":
     app.run(host="127.0.0.1", port=8099)

--- a/pulsecoach/rootfs/app/scripts/garmin-auth-server.py
+++ b/pulsecoach/rootfs/app/scripts/garmin-auth-server.py
@@ -293,6 +293,7 @@ def logout() -> tuple[Response, int] | Response:
 def trigger_recompute() -> tuple[Response, int] | Response:
     """Trigger an immediate metrics recomputation in the background."""
     import subprocess
+    import time
 
     status_file = os.path.join(TOKEN_DIR, ".recompute_status")
     try:
@@ -307,7 +308,7 @@ def trigger_recompute() -> tuple[Response, int] | Response:
     try:
         # Write running status
         with open(status_file, "w") as f:
-            json.dump({"running": True, "started": __import__("time").time()}, f)
+            json.dump({"running": True, "started": time.time()}, f)
 
         env = os.environ.copy()
         env["DATABASE_URL"] = os.environ.get(
@@ -323,6 +324,12 @@ def trigger_recompute() -> tuple[Response, int] | Response:
         log.info("Manual recompute triggered")
         return jsonify(success=True, message="Recompute started")
     except Exception as exc:
+        # Clean up status file on Popen failure
+        try:
+            with open(status_file, "w") as f:
+                json.dump({"running": False, "error": str(exc)}, f)
+        except OSError:
+            pass
         log.error("Failed to trigger recompute: %s", exc)
         return jsonify(success=False, message=f"Failed: {exc}"), 500
 

--- a/pulsecoach/rootfs/app/scripts/metrics-compute.py
+++ b/pulsecoach/rootfs/app/scripts/metrics-compute.py
@@ -561,6 +561,23 @@ def run_compute(user_id: str):
     finally:
         cur.close()
         db.close()
+        # Clear recompute status file so UI knows we're done
+        _clear_recompute_status()
+
+
+def _clear_recompute_status():
+    """Remove the recompute lock file after completion."""
+    status_file = os.path.join(
+        os.environ.get("TOKEN_DIR", "/data/garmin-tokens"),
+        ".recompute_status",
+    )
+    try:
+        if os.path.exists(status_file):
+            import json as _json
+            with open(status_file, "w") as f:
+                _json.dump({"running": False, "completed": time.time()}, f)
+    except Exception:
+        pass
 
 
 def main():

--- a/pulsecoach/rootfs/app/scripts/metrics-compute.py
+++ b/pulsecoach/rootfs/app/scripts/metrics-compute.py
@@ -566,7 +566,7 @@ def run_compute(user_id: str):
 
 
 def _clear_recompute_status():
-    """Remove the recompute lock file after completion."""
+    """Mark the recompute status file as completed (running=False)."""
     status_file = os.path.join(
         os.environ.get("TOKEN_DIR", "/data/garmin-tokens"),
         ".recompute_status",
@@ -576,8 +576,8 @@ def _clear_recompute_status():
             import json as _json
             with open(status_file, "w") as f:
                 _json.dump({"running": False, "completed": time.time()}, f)
-    except Exception:
-        pass
+    except Exception as exc:
+        print(f"[metrics-compute] WARN: failed to update recompute status: {exc}", file=sys.stderr)
 
 
 def main():


### PR DESCRIPTION
## Changes
New Flask routes on the Garmin auth server (:8099):
- `POST /auth/recompute` — triggers `metrics-compute.py --once` in background with mutex lock
- `GET /auth/recompute-status` — returns running/completed status

`metrics-compute.py` now clears the recompute lock file on completion so the app UI can track progress.

## Context
Part of P4 (Recompute Button). The companion app PR (ha-garmin-fitness-coach-app#79) adds the UI button in Settings that calls this endpoint.