### PR TITLE
chore: release v0.16.1

### DIFF
--- a/pulsecoach/CHANGELOG.md
+++ b/pulsecoach/CHANGELOG.md
@@ -5,6 +5,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.16.1] — 2026-04-15
+
+### Fixed
+- **Today tab scores showing 0/100** — metrics-compute.py now writes component
+  breakdowns (sleep, HRV, load, stress, resting HR) to the readiness_score table.
+  Previously only the composite score was stored; individual components were discarded.
+  Existing data is backfilled automatically on the next metrics-compute run.
+
 ## [0.16.0] — 2026-04-15
 
 ### Added

--- a/pulsecoach/config.json
+++ b/pulsecoach/config.json
@@ -1,6 +1,6 @@
 {
   "name": "PulseCoach",
-  "version": "0.16.0",
+  "version": "0.16.1",
   "slug": "pulsecoach",
   "image": "ghcr.io/askb/pulsecoach-addon-{arch}",
   "description": "AI-powered sport scientist \u2014 training analysis, coaching, and recovery optimization from your Garmin data",


### PR DESCRIPTION
Bump version to 0.16.1 — fix Today tab readiness component scores.