### PR TITLE
chore: release v0.16.2

### DIFF
--- a/pulsecoach/CHANGELOG.md
+++ b/pulsecoach/CHANGELOG.md
@@ -5,6 +5,19 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.16.2] — 2026-04-16
+
+### Added
+- **Vitals in readiness scoring** — SpO2 (8%), respiration rate (7%), and skin
+  temperature (7%) now contribute to the Buchheit-style readiness composite.
+  All three use 14-day rolling baseline deviation scoring.
+- **New HA sensors** — `sensor.pulsecoach_spo2` (%), `sensor.pulsecoach_respiration_rate`
+  (brpm), and `sensor.pulsecoach_skin_temp` (°C) pushed to Home Assistant.
+
+### Changed
+- Readiness weight rebalance: HRV 25%, Sleep 20%, Load 15%, RHR 10%,
+  Stress 8%, SpO2 8%, RR 7%, Skin Temp 7% (was HRV 35%, Sleep 25%, Load 20%, RHR 10%, Stress 10%).
+
 ## [0.16.1] — 2026-04-15
 
 ### Fixed

--- a/pulsecoach/config.json
+++ b/pulsecoach/config.json
@@ -1,6 +1,6 @@
 {
   "name": "PulseCoach",
-  "version": "0.16.1",
+  "version": "0.16.2",
   "slug": "pulsecoach",
   "image": "ghcr.io/askb/pulsecoach-addon-{arch}",
   "description": "AI-powered sport scientist \u2014 training analysis, coaching, and recovery optimization from your Garmin data",


### PR DESCRIPTION
Bump version to 0.16.2 — vitals in readiness + new HA sensors.