### PR TITLE
fix: create ai_insight unique constraint on startup

### DIFF
--- a/pulsecoach/CHANGELOG.md
+++ b/pulsecoach/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.16.4] — 2026-04-17
+
+### Fixed
+- **Insights upsert failing** — `ai_insight` table was missing the unique
+  constraint on `(user_id, date, insight_type)` needed for ON CONFLICT upsert.
+  Startup now explicitly creates the index and deduplicates existing rows.
+
 ## [0.16.3] — 2026-04-16
 
 ### Fixed

--- a/pulsecoach/config.json
+++ b/pulsecoach/config.json
@@ -1,6 +1,6 @@
 {
   "name": "PulseCoach",
-  "version": "0.16.3",
+  "version": "0.16.4",
   "slug": "pulsecoach",
   "image": "ghcr.io/askb/pulsecoach-addon-{arch}",
   "description": "AI-powered sport scientist \u2014 training analysis, coaching, and recovery optimization from your Garmin data",

--- a/pulsecoach/rootfs/etc/s6-overlay/s6-rc.d/pulsecoach/run
+++ b/pulsecoach/rootfs/etc/s6-overlay/s6-rc.d/pulsecoach/run
@@ -227,6 +227,17 @@ BEGIN
 END \$\$;
 " 2>/dev/null || true
 
+# Ensure ai_insight unique constraint exists (needed for upsert in generateInsights)
+# First deduplicate if duplicates exist (keep newest row per user/date/type)
+psql -h 127.0.0.1 -U postgres -d pulsecoach -c "
+DELETE FROM ai_insight a USING ai_insight b
+WHERE a.id < b.id AND a.user_id = b.user_id AND a.date = b.date AND a.insight_type = b.insight_type;
+" 2>/dev/null || true
+psql -h 127.0.0.1 -U postgres -d pulsecoach -c "
+CREATE UNIQUE INDEX IF NOT EXISTS ai_insight_user_date_type_unique
+    ON ai_insight (user_id, date, insight_type);
+" 2>/dev/null || true
+
 bashio::log.info "Creating daily_athlete_summary materialized view..."
 psql -h 127.0.0.1 -U postgres -d pulsecoach -f /app/sql/create_daily_athlete_summary.sql 2>&1 || bashio::log.warning "Matview creation had warnings (tables may not exist yet)"
 


### PR DESCRIPTION
The `generateInsights` upsert fails with:
```
Failed query: insert into "ai_insight" ... on conflict ("user_id","date","insight_type") do update ...
```

**Root cause**: `drizzle-kit push` did not create the unique index defined in the schema. The `ON CONFLICT` clause requires a matching unique constraint.

**Fix**: Add explicit `CREATE UNIQUE INDEX IF NOT EXISTS` to the startup script, with deduplication of existing duplicate rows first.