### PR TITLE
chore: bump version to 0.16.5

### DIFF
--- a/pulsecoach/config.json
+++ b/pulsecoach/config.json
@@ -1,6 +1,6 @@
 {
   "name": "PulseCoach",
-  "version": "0.16.4",
+  "version": "0.16.5",
   "slug": "pulsecoach",
   "image": "ghcr.io/askb/pulsecoach-addon-{arch}",
   "description": "AI-powered sport scientist \u2014 training analysis, coaching, and recovery optimization from your Garmin data",


### PR DESCRIPTION
Version bump for release v0.16.5.

### Changes in v0.16.5
- fix: clean up stale OpenClaw options on startup (#99)
  - Uses Supervisor API for persistent config updates
  - Atomic write to prevent corruption
  - Removes `openclaw_agent_id`, `openclaw_api_key`, `openclaw_url` if present