### PR TITLE
docs: add HACS custom repository installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,6 +115,16 @@ Click the button at the top of this README, or:
 
 Then install **PulseCoach** from the add-on store and start it.
 
+### Via HACS (Custom Repository)
+
+1. Open HACS in your Home Assistant instance.
+2. Click the **⋮** menu (top right) → **Custom repositories**.
+3. Add this URL and select category **Add-on**:
+   ```
+   https://github.com/askb/ha-garmin-fitness-coach-addon
+   ```
+4. Click **Add**, then find **PulseCoach** in HACS and install.
+
 ### Manual Install
 
 1. In Home Assistant go to **Settings → Add-ons → Add-on Store → ⋮ →


### PR DESCRIPTION
Add a 'Via HACS (Custom Repository)' section to the Installation guide.

Users can now discover and install PulseCoach through HACS by adding it as a custom repository (category: Add-on), in addition to the existing direct Supervisor method and one-click badge.

### Changes
- Added HACS custom repository install steps between 'One-Click Install' and 'Manual Install' sections