### PR TITLE
fix: remove incorrect HACS custom repository instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,16 +115,6 @@ Click the button at the top of this README, or:
 
 Then install **PulseCoach** from the add-on store and start it.
 
-### Via HACS (Custom Repository)
-
-1. Open HACS in your Home Assistant instance.
-2. Click the **⋮** menu (top right) → **Custom repositories**.
-3. Add this URL and select category **Add-on**:
-   ```
-   https://github.com/askb/ha-garmin-fitness-coach-addon
-   ```
-4. Click **Add**, then find **PulseCoach** in HACS and install.
-
 ### Manual Install
 
 1. In Home Assistant go to **Settings → Add-ons → Add-on Store → ⋮ →


### PR DESCRIPTION
HACS does not support an 'Add-on' category for custom repositories. This section was added in PR #105 but the Copilot reviewer correctly identified it as inaccurate.

HA addons are distributed via the **Supervisor add-on store** (one-click badge or manual repository URL), not through HACS custom repositories.

### Changes
- Removed the 'Via HACS (Custom Repository)' section from Installation

Fixes review comment: https://github.com/askb/ha-garmin-fitness-coach-addon/pull/105#discussion_r3185859428