### PR TITLE
test(phase3): cover sync_training_* + ha-notify sensor helpers

### DIFF
--- a/pulsecoach/rootfs/app/scripts/ha-notify.py
+++ b/pulsecoach/rootfs/app/scripts/ha-notify.py
@@ -11,6 +11,7 @@ import os
 import sys
 import time
 from datetime import datetime, timezone
+from typing import Any, Mapping, Optional, Sequence, Tuple, Union
 from zoneinfo import ZoneInfo
 
 try:
@@ -87,13 +88,16 @@ def create_notification(title: str, message: str, notification_id: str) -> bool:
     }) is not None
 
 
-def _compute_hrv_trend(rows):
+def _compute_hrv_trend(
+    rows: Sequence[Mapping[str, Any]],
+) -> Tuple[Optional[str], Optional[float]]:
     """Return (trend_label, avg) from a list of {'hrv': float} rows ordered ASC.
 
-    NOTE: `daily_metric.hrv` is populated from Garmin's `hrvSummary.weeklyAvg`
+    NOTE: ``daily_metric.hrv`` is populated from Garmin's ``hrvSummary.weeklyAvg``
     (see garmin-sync.py), so this trend tracks day-over-day movement of the
     weekly-average value, not raw nightly HRV. Needs at least 3 datapoints
-    to emit a label.
+    to emit a label. Returns ``(None, None)`` when there is insufficient data;
+    otherwise ``trend_label`` is one of ``"rising"`` / ``"falling"`` / ``"stable"``.
     """
     if not rows or len(rows) < 3:
         return None, None
@@ -107,13 +111,18 @@ def _compute_hrv_trend(rows):
     return "stable", avg
 
 
-def _derive_load_focus_label(payload):
-    """Reduce Garmin `garmin_load_focus` JSON to a single label.
+def _derive_load_focus_label(
+    payload: Union[str, Mapping[str, Any], None],
+) -> str:
+    """Reduce Garmin ``garmin_load_focus`` JSON to a single label.
 
     The synced JSON can contain either percentage keys
     (``*TrainingLoadPercentage``) or absolute load keys
     (``*TrainingLoad``). Prefer percentages when present.
-    Returns 'anaerobic' / 'high_aerobic' / 'low_aerobic' / 'unknown'.
+
+    Accepts a pre-resolved label string, a dict payload, or ``None``.
+    Returns one of ``"anaerobic"`` / ``"high_aerobic"`` / ``"low_aerobic"`` /
+    ``"unknown"``.
     """
     if not payload:
         return "unknown"

--- a/pulsecoach/rootfs/app/scripts/ha-notify.py
+++ b/pulsecoach/rootfs/app/scripts/ha-notify.py
@@ -87,27 +87,69 @@ def create_notification(title: str, message: str, notification_id: str) -> bool:
     }) is not None
 
 
+def _compute_hrv_trend(rows):
+    """Return (trend_label, avg) from a list of {'hrv': float} rows ordered ASC.
+
+    NOTE: `daily_metric.hrv` is populated from Garmin's `hrvSummary.weeklyAvg`
+    (see garmin-sync.py), so this trend tracks day-over-day movement of the
+    weekly-average value, not raw nightly HRV. Needs at least 3 datapoints
+    to emit a label.
+    """
+    if not rows or len(rows) < 3:
+        return None, None
+    vals = [float(r["hrv"]) for r in rows]
+    avg = round(sum(vals) / len(vals), 1)
+    latest = vals[-1]
+    if latest > avg * 1.05:
+        return "rising", avg
+    if latest < avg * 0.95:
+        return "falling", avg
+    return "stable", avg
+
+
+def _derive_load_focus_label(payload):
+    """Reduce Garmin `garmin_load_focus` JSON to a single label.
+
+    The synced JSON can contain either percentage keys
+    (``*TrainingLoadPercentage``) or absolute load keys
+    (``*TrainingLoad``). Prefer percentages when present.
+    Returns 'anaerobic' / 'high_aerobic' / 'low_aerobic' / 'unknown'.
+    """
+    if not payload:
+        return "unknown"
+    if isinstance(payload, str):
+        return payload.lower()
+    if not isinstance(payload, dict):
+        return "unknown"
+
+    pct_keys = (
+        "highAerobicTrainingLoadPercentage",
+        "lowAerobicTrainingLoadPercentage",
+        "anaerobicTrainingLoadPercentage",
+    )
+    abs_keys = (
+        "highAerobicTrainingLoad",
+        "lowAerobicTrainingLoad",
+        "anaerobicTrainingLoad",
+    )
+    keys = pct_keys if any(payload.get(k) is not None for k in pct_keys) else abs_keys
+    aerobic_high = payload.get(keys[0], 0) or 0
+    aerobic_low = payload.get(keys[1], 0) or 0
+    anaerobic = payload.get(keys[2], 0) or 0
+    if max(aerobic_high, aerobic_low, anaerobic) <= 0:
+        return "unknown"
+    if anaerobic > aerobic_high and anaerobic > aerobic_low:
+        return "anaerobic"
+    if aerobic_high > aerobic_low:
+        return "high_aerobic"
+    return "low_aerobic"
+
+
 def get_latest_metrics(cur, user_id: str) -> dict:
     """Get latest metrics from daily_athlete_summary materialized view.
 
     Falls back to separate table queries if the matview doesn't exist yet.
     """
-    # Helper to compute HRV trend from a list of (date, hrv) rows ordered ASC.
-    # NOTE: `daily_metric.hrv` is populated from Garmin's weeklyAvg
-    # (see garmin-sync.py — `hrvSummary.weeklyAvg`), so this trend
-    # tracks day-over-day movement of the weekly-average value, not
-    # raw nightly HRV.
-    def _compute_hrv_trend(rows):
-        if not rows or len(rows) < 3:
-            return None, None
-        vals = [float(r["hrv"]) for r in rows]
-        avg = round(sum(vals) / len(vals), 1)
-        latest = vals[-1]
-        if latest > avg * 1.05:
-            return "rising", avg
-        if latest < avg * 0.95:
-            return "falling", avg
-        return "stable", avg
 
     # Inclusive 7-day window: CURRENT_DATE - 6 days .. CURRENT_DATE = 7 rows.
     hrv_history_sql = """
@@ -573,37 +615,8 @@ def run_notifications(user_id: str):
         #   - absolute load keys (highAerobicTrainingLoad, ...).
         # Prefer percentages when present; fall back to absolutes otherwise.
         load_focus_raw = dm.get('garmin_load_focus') if dm else None
-        load_focus_label = "unknown"
-        load_focus_attrs = {}
-        if load_focus_raw:
-            if isinstance(load_focus_raw, dict):
-                load_focus_attrs = load_focus_raw
-                pct_keys = (
-                    "highAerobicTrainingLoadPercentage",
-                    "lowAerobicTrainingLoadPercentage",
-                    "anaerobicTrainingLoadPercentage",
-                )
-                abs_keys = (
-                    "highAerobicTrainingLoad",
-                    "lowAerobicTrainingLoad",
-                    "anaerobicTrainingLoad",
-                )
-                if any(load_focus_raw.get(k) is not None for k in pct_keys):
-                    keys = pct_keys
-                else:
-                    keys = abs_keys
-                aerobic_high = load_focus_raw.get(keys[0], 0) or 0
-                aerobic_low = load_focus_raw.get(keys[1], 0) or 0
-                anaerobic = load_focus_raw.get(keys[2], 0) or 0
-                if max(aerobic_high, aerobic_low, anaerobic) > 0:
-                    if anaerobic > aerobic_high and anaerobic > aerobic_low:
-                        load_focus_label = "anaerobic"
-                    elif aerobic_high > aerobic_low:
-                        load_focus_label = "high_aerobic"
-                    else:
-                        load_focus_label = "low_aerobic"
-            elif isinstance(load_focus_raw, str):
-                load_focus_label = load_focus_raw.lower()
+        load_focus_label = _derive_load_focus_label(load_focus_raw)
+        load_focus_attrs = load_focus_raw if isinstance(load_focus_raw, dict) else {}
         push_sensor("sensor.pulsecoach_load_focus",
                     load_focus_label,
                     {

--- a/tests/unit/test_garmin_sync.py
+++ b/tests/unit/test_garmin_sync.py
@@ -347,3 +347,211 @@ class TestDbPath:
                 "DATABASE_URL", "file:/data/pulsecoach.db"
             ).replace("file:", "")
             assert result == "/data/pulsecoach.db"
+
+
+# ── Training readiness sync ──────────────────────────────────────────────────
+
+
+@pytest.mark.unit
+class TestSyncTrainingReadiness:
+    """Tests for sync_training_readiness()."""
+
+    @staticmethod
+    def _make_client(payload):
+        client = MagicMock()
+        client.get_training_readiness.return_value = payload
+        return client
+
+    def test_inserts_readiness_when_score_present(self, garmin_sync, mock_pg_db):
+        """A payload with a score triggers an INSERT + UPDATE."""
+        conn, cursor = mock_pg_db
+        client = self._make_client({
+            "score": 72,
+            "level": "GOOD",
+            "sleepScore": 80,
+            "recoveryTime": 12,
+            "hrvStatus": "BALANCED",
+        })
+        garmin_sync.sync_training_readiness(client, conn, days=1)
+
+        assert cursor.execute.called
+        assert conn.commit.called
+        # Ensure the UPDATE was issued and persisted the rounded score
+        update_calls = [
+            c for c in cursor.execute.call_args_list
+            if "UPDATE daily_metric" in c.args[0]
+            and "garmin_training_readiness" in c.args[0]
+        ]
+        assert update_calls, "expected an UPDATE daily_metric SET garmin_training_readiness ..."
+        params = update_calls[0].args[1]
+        assert params[0] == 72  # rounded score
+        assert params[1] == "good"  # level lower-cased
+        # Factors JSON contains the contributing-factor keys we sent
+        factors = json.loads(params[2])
+        assert factors["sleepScore"] == 80
+        assert factors["recoveryTime"] == 12
+        assert factors["hrvStatus"] == "BALANCED"
+
+    def test_skips_when_score_missing(self, garmin_sync, mock_pg_db):
+        """Payload without a score is skipped — no UPDATE issued."""
+        conn, cursor = mock_pg_db
+        client = self._make_client({"level": "POOR"})  # no score / readinessScore
+        garmin_sync.sync_training_readiness(client, conn, days=1)
+
+        update_calls = [
+            c for c in cursor.execute.call_args_list
+            if "UPDATE daily_metric" in c.args[0]
+            and "garmin_training_readiness" in c.args[0]
+        ]
+        assert not update_calls
+
+    def test_skips_when_payload_empty(self, garmin_sync, mock_pg_db):
+        """Empty payload (None / falsy) is silently skipped."""
+        conn, cursor = mock_pg_db
+        client = self._make_client(None)
+        garmin_sync.sync_training_readiness(client, conn, days=1)
+
+        update_calls = [
+            c for c in cursor.execute.call_args_list
+            if "garmin_training_readiness" in c.args[0]
+        ]
+        assert not update_calls
+
+    def test_accepts_readinessscore_alias(self, garmin_sync, mock_pg_db):
+        """Garmin sometimes returns `readinessScore` instead of `score`."""
+        conn, cursor = mock_pg_db
+        client = self._make_client({"readinessScore": 55, "readinessLevel": "FAIR"})
+        garmin_sync.sync_training_readiness(client, conn, days=1)
+
+        update_calls = [
+            c for c in cursor.execute.call_args_list
+            if "UPDATE daily_metric" in c.args[0]
+            and "garmin_training_readiness" in c.args[0]
+        ]
+        assert update_calls
+        assert update_calls[0].args[1][0] == 55
+
+    def test_continues_on_per_day_exception(self, garmin_sync, mock_pg_db):
+        """If one date raises, the loop continues for the remaining days."""
+        conn, cursor = mock_pg_db
+        client = MagicMock()
+        # First call fails, second succeeds
+        client.get_training_readiness.side_effect = [
+            Exception("API rate-limited"),
+            {"score": 60, "level": "GOOD"},
+        ]
+        garmin_sync.sync_training_readiness(client, conn, days=2)
+
+        assert client.get_training_readiness.call_count == 2
+        # Only one UPDATE should be issued (for the day that succeeded)
+        update_calls = [
+            c for c in cursor.execute.call_args_list
+            if "UPDATE daily_metric" in c.args[0]
+            and "garmin_training_readiness" in c.args[0]
+        ]
+        assert len(update_calls) == 1
+
+
+# ── Training status sync ─────────────────────────────────────────────────────
+
+
+@pytest.mark.unit
+class TestSyncTrainingStatus:
+    """Tests for sync_training_status()."""
+
+    @staticmethod
+    def _make_client(payload):
+        client = MagicMock()
+        client.get_training_status.return_value = payload
+        return client
+
+    def test_inserts_status_and_load_focus(self, garmin_sync, mock_pg_db):
+        """Status + load distribution + recovery hours are all persisted."""
+        conn, cursor = mock_pg_db
+        client = self._make_client({
+            "trainingStatus": "productive",
+            "trainingLoadFocus": "low_aerobic",
+            "lowAerobicTrainingLoadPercentage": 60,
+            "highAerobicTrainingLoadPercentage": 30,
+            "anaerobicTrainingLoadPercentage": 10,
+            "recoveryTimeInMinutes": 180,  # 3 hours
+        })
+        garmin_sync.sync_training_status(client, conn, days=1)
+
+        update_calls = [
+            c for c in cursor.execute.call_args_list
+            if "UPDATE daily_metric" in c.args[0]
+            and "garmin_training_status" in c.args[0]
+        ]
+        assert update_calls, "expected an UPDATE daily_metric SET garmin_training_status ..."
+        params = update_calls[0].args[1]
+        # Status is upper-cased
+        assert params[0] == "PRODUCTIVE"
+        # Load focus JSON contains the percentage keys we sent
+        load_dist = json.loads(params[1])
+        assert load_dist["lowAerobicTrainingLoadPercentage"] == 60
+        assert load_dist["anaerobicTrainingLoadPercentage"] == 10
+        # 180 minutes → 3.0 hours
+        assert params[2] == 3.0
+
+    def test_converts_recovery_minutes_to_hours(self, garmin_sync, mock_pg_db):
+        """recoveryTimeInMinutes is rounded to 1dp hours."""
+        conn, cursor = mock_pg_db
+        client = self._make_client({
+            "trainingStatus": "maintaining",
+            "recoveryTimeInMinutes": 95,  # 1.5833... → 1.6
+        })
+        garmin_sync.sync_training_status(client, conn, days=1)
+
+        update_calls = [
+            c for c in cursor.execute.call_args_list
+            if "UPDATE daily_metric" in c.args[0]
+            and "garmin_training_status" in c.args[0]
+        ]
+        assert update_calls
+        assert update_calls[0].args[1][2] == 1.6
+
+    def test_skips_when_all_fields_missing(self, garmin_sync, mock_pg_db):
+        """Payload with no status / load_focus / recovery is skipped."""
+        conn, cursor = mock_pg_db
+        client = self._make_client({"someUnrelatedField": 1})
+        garmin_sync.sync_training_status(client, conn, days=1)
+
+        update_calls = [
+            c for c in cursor.execute.call_args_list
+            if "UPDATE daily_metric" in c.args[0]
+            and "garmin_training_status" in c.args[0]
+        ]
+        assert not update_calls
+
+    def test_accepts_status_alias(self, garmin_sync, mock_pg_db):
+        """Garmin sometimes returns `status` instead of `trainingStatus`."""
+        conn, cursor = mock_pg_db
+        client = self._make_client({"status": "peaking"})
+        garmin_sync.sync_training_status(client, conn, days=1)
+
+        update_calls = [
+            c for c in cursor.execute.call_args_list
+            if "UPDATE daily_metric" in c.args[0]
+            and "garmin_training_status" in c.args[0]
+        ]
+        assert update_calls
+        assert update_calls[0].args[1][0] == "PEAKING"
+
+    def test_continues_on_per_day_exception(self, garmin_sync, mock_pg_db):
+        """Per-day exceptions are swallowed so the loop continues."""
+        conn, cursor = mock_pg_db
+        client = MagicMock()
+        client.get_training_status.side_effect = [
+            Exception("network error"),
+            {"trainingStatus": "productive", "recoveryTimeInMinutes": 60},
+        ]
+        garmin_sync.sync_training_status(client, conn, days=2)
+
+        assert client.get_training_status.call_count == 2
+        update_calls = [
+            c for c in cursor.execute.call_args_list
+            if "UPDATE daily_metric" in c.args[0]
+            and "garmin_training_status" in c.args[0]
+        ]
+        assert len(update_calls) == 1

--- a/tests/unit/test_ha_notify_sensors.py
+++ b/tests/unit/test_ha_notify_sensors.py
@@ -1,0 +1,158 @@
+# SPDX-FileCopyrightText: 2026 Anil Belur <askb23@gmail.com>
+# SPDX-License-Identifier: Apache-2.0
+"""Tests for ha-notify.py sensor helpers introduced in Phase 3.
+
+Covers the pure helpers that feed the new HA sensors:
+  - ``_compute_hrv_trend`` — 7-day HRV trend label + average
+  - ``_derive_load_focus_label`` — load-focus heuristic over Garmin's JSONB
+
+Both helpers were extracted from inline code so they can be unit-tested
+without standing up a database or HA Supervisor.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+import types
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+SCRIPTS_DIR = Path(__file__).resolve().parents[2] / "pulsecoach" / "rootfs" / "app" / "scripts"
+
+
+def _load_ha_notify() -> types.ModuleType:
+    mock_psycopg2 = MagicMock()
+    mock_psycopg2.extras = MagicMock()
+    with patch.dict(sys.modules, {
+        "psycopg2": mock_psycopg2,
+        "psycopg2.extras": mock_psycopg2.extras,
+    }):
+        spec = importlib.util.spec_from_file_location("ha_notify", SCRIPTS_DIR / "ha-notify.py")
+        mod = importlib.util.module_from_spec(spec)
+        spec.loader.exec_module(mod)
+    return mod
+
+
+@pytest.fixture(scope="module")
+def ha_notify():
+    return _load_ha_notify()
+
+
+# ── HRV trend ────────────────────────────────────────────────────────────────
+
+
+@pytest.mark.unit
+class TestComputeHrvTrend:
+    """Pure-function tests for ``_compute_hrv_trend``."""
+
+    def test_returns_none_for_empty_input(self, ha_notify):
+        assert ha_notify._compute_hrv_trend([]) == (None, None)
+        assert ha_notify._compute_hrv_trend(None) == (None, None)
+
+    def test_requires_at_least_three_rows(self, ha_notify):
+        """Fewer than 3 datapoints → no trend (insufficient signal)."""
+        rows = [{"hrv": 50}, {"hrv": 52}]
+        assert ha_notify._compute_hrv_trend(rows) == (None, None)
+
+    def test_rising_when_latest_above_5pct_band(self, ha_notify):
+        rows = [{"hrv": 50}, {"hrv": 50}, {"hrv": 60}]
+        # avg = (50+50+60)/3 ≈ 53.3; latest 60 > 53.3*1.05 (≈56.0) → rising
+        trend, avg = ha_notify._compute_hrv_trend(rows)
+        assert trend == "rising"
+        assert avg == pytest.approx(53.3, abs=0.1)
+
+    def test_falling_when_latest_below_5pct_band(self, ha_notify):
+        rows = [{"hrv": 60}, {"hrv": 60}, {"hrv": 50}]
+        trend, _ = ha_notify._compute_hrv_trend(rows)
+        assert trend == "falling"
+
+    def test_stable_within_band(self, ha_notify):
+        rows = [{"hrv": 50}, {"hrv": 51}, {"hrv": 50}]
+        trend, avg = ha_notify._compute_hrv_trend(rows)
+        assert trend == "stable"
+        assert avg == pytest.approx(50.3, abs=0.1)
+
+    def test_accepts_string_hrv_values(self, ha_notify):
+        """psycopg2 sometimes returns Decimal/str — helper coerces to float."""
+        rows = [{"hrv": "50"}, {"hrv": "50"}, {"hrv": "60"}]
+        trend, _ = ha_notify._compute_hrv_trend(rows)
+        assert trend == "rising"
+
+
+# ── Load focus heuristic ─────────────────────────────────────────────────────
+
+
+@pytest.mark.unit
+class TestDeriveLoadFocusLabel:
+    """Pure-function tests for ``_derive_load_focus_label``."""
+
+    def test_unknown_for_none(self, ha_notify):
+        assert ha_notify._derive_load_focus_label(None) == "unknown"
+
+    def test_unknown_for_empty_dict(self, ha_notify):
+        assert ha_notify._derive_load_focus_label({}) == "unknown"
+
+    def test_unknown_for_non_dict_non_string(self, ha_notify):
+        assert ha_notify._derive_load_focus_label(42) == "unknown"
+        assert ha_notify._derive_load_focus_label([1, 2]) == "unknown"
+
+    def test_string_payload_lowercased(self, ha_notify):
+        assert ha_notify._derive_load_focus_label("HIGH_AEROBIC") == "high_aerobic"
+
+    def test_anaerobic_dominates_via_percentages(self, ha_notify):
+        payload = {
+            "lowAerobicTrainingLoadPercentage": 10,
+            "highAerobicTrainingLoadPercentage": 20,
+            "anaerobicTrainingLoadPercentage": 70,
+        }
+        assert ha_notify._derive_load_focus_label(payload) == "anaerobic"
+
+    def test_high_aerobic_dominates_via_percentages(self, ha_notify):
+        payload = {
+            "lowAerobicTrainingLoadPercentage": 20,
+            "highAerobicTrainingLoadPercentage": 60,
+            "anaerobicTrainingLoadPercentage": 20,
+        }
+        assert ha_notify._derive_load_focus_label(payload) == "high_aerobic"
+
+    def test_low_aerobic_dominates_via_percentages(self, ha_notify):
+        payload = {
+            "lowAerobicTrainingLoadPercentage": 70,
+            "highAerobicTrainingLoadPercentage": 20,
+            "anaerobicTrainingLoadPercentage": 10,
+        }
+        assert ha_notify._derive_load_focus_label(payload) == "low_aerobic"
+
+    def test_falls_back_to_absolute_keys(self, ha_notify):
+        """When only absolute keys are present, the heuristic still works."""
+        payload = {
+            "lowAerobicTrainingLoad": 100,
+            "highAerobicTrainingLoad": 50,
+            "anaerobicTrainingLoad": 200,
+        }
+        assert ha_notify._derive_load_focus_label(payload) == "anaerobic"
+
+    def test_prefers_percentages_when_both_present(self, ha_notify):
+        """If both pct and abs keys exist, percentage values win."""
+        payload = {
+            # Percentages say anaerobic dominates
+            "lowAerobicTrainingLoadPercentage": 10,
+            "highAerobicTrainingLoadPercentage": 20,
+            "anaerobicTrainingLoadPercentage": 70,
+            # Absolute values would say low_aerobic — should be ignored
+            "lowAerobicTrainingLoad": 500,
+            "highAerobicTrainingLoad": 100,
+            "anaerobicTrainingLoad": 50,
+        }
+        assert ha_notify._derive_load_focus_label(payload) == "anaerobic"
+
+    def test_unknown_when_all_zero(self, ha_notify):
+        payload = {
+            "lowAerobicTrainingLoadPercentage": 0,
+            "highAerobicTrainingLoadPercentage": 0,
+            "anaerobicTrainingLoadPercentage": 0,
+        }
+        assert ha_notify._derive_load_focus_label(payload) == "unknown"


### PR DESCRIPTION
Closes the `phase3-tests` todo from issue #78 (Phase 3 — surface missing Garmin metrics).

## Coverage added

### `tests/unit/test_garmin_sync.py` (+10 tests)
- **`TestSyncTrainingReadiness`** — UPDATE issued when score present, skipped when missing/empty, accepts `readinessScore` alias, per-day exception swallowed.
- **`TestSyncTrainingStatus`** — UPDATE persists upper-cased status + JSON load distribution + recovery hours; `recoveryTimeInMinutes` correctly converted to 1dp hours; skip-when-empty; `status` alias; per-day exception swallowed.

### `tests/unit/test_ha_notify_sensors.py` (+16 tests, NEW file)
Refactored two pure helpers out of inline code in `ha-notify.py` so they can be unit-tested without a database / HA Supervisor:
- `_compute_hrv_trend(rows)` — 7-day HRV trend label + average
- `_derive_load_focus_label(payload)` — load-focus heuristic over the JSONB payload

Tests cover: <3 datapoint guard, rising / falling / stable bands, str-Decimal coercion, percentage vs. absolute key fallback, percentage preference when both are present, all-zero → unknown, etc.

## Verification
`91/91` pass across `test_metrics_compute`, `test_coaching_engine`, `test_ai_trends`, `test_ha_notify_sensors` and the new `TestSyncTraining*` classes.

Signed-off-by: Anil Belur <askb23@gmail.com>