### PR TITLE
chore(release): bump pulsecoach config to v0.16.6

### DIFF
--- a/pulsecoach/CHANGELOG.md
+++ b/pulsecoach/CHANGELOG.md
@@ -5,6 +5,32 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.16.6] — 2026-05-13
+
+### Added
+- **HA sensor surface** — expose Garmin recovery hours, HRV, and load focus
+  as Home Assistant sensors via the ha-notify bridge (#110).
+- **HACS install docs** — README now documents adding the repo as a HACS
+  custom repository (#105). Earlier incorrect instructions removed (#106).
+- **Download tracking + release badges** — README badges show GHCR pulls
+  and release counts (#104).
+
+### Tests
+- Phase 3 coverage for `sync_training_*` jobs and ha-notify sensor
+  helpers (#111).
+- Metrics-compute readiness scoring + load fetching covered (#109).
+
+### Maintenance
+- Bump `github/gh-aw` 0.67.4 → 0.73.0 (#79, #102, #107).
+- Bump `node` 22-alpine → 26-alpine (#81, #108).
+- Bump `softprops/action-gh-release` 2 → 3 (#80).
+
+## [0.16.5] — 2026-04-19
+
+### Fixed
+- Hotfix following 0.16.4 release plumbing; container build pipeline
+  hardening.
+
 ## [0.16.4] — 2026-04-17
 
 ### Fixed

--- a/pulsecoach/config.json
+++ b/pulsecoach/config.json
@@ -1,6 +1,6 @@
 {
   "name": "PulseCoach",
-  "version": "0.16.5",
+  "version": "0.16.6",
   "slug": "pulsecoach",
   "image": "ghcr.io/askb/pulsecoach-addon-{arch}",
   "description": "AI-powered sport scientist \u2014 training analysis, coaching, and recovery optimization from your Garmin data",


### PR DESCRIPTION
## Why

The GitHub release [`v0.16.6`](https://github.com/askb/ha-garmin-fitness-coach-addon/releases/tag/v0.16.6) was published and the Build & Publish workflow pushed GHCR images successfully (run 25829208530), but `pulsecoach/config.json` on `main` still points at `0.16.5`.

Home Assistant Supervisor reads the **`version` field in `config.json`** from the repository to determine whether an addon update is available. Because the file lags the GitHub release, HAOS users never see v0.16.6 in their update list.

## Change

- Bump `pulsecoach/config.json` → `0.16.6`
- Backfill `pulsecoach/CHANGELOG.md` with 0.16.5 + 0.16.6 sections

## After merge

HAOS users can refresh:
**Settings → Add-ons → ⋮ menu → Check for updates** (or wait for the periodic refresh ~few hours).