### PR TITLE
feat(tools): add Playwright screenshot tooling for UX/AI review

### DIFF
--- a/tools/screenshots/.env.example
+++ b/tools/screenshots/.env.example
@@ -1,0 +1,12 @@
+# Copy to .env and adjust as needed.
+
+# Where the PulseCoach Next.js app is served.
+# - Local `pnpm dev` from ha-garmin-fitness-coach-app: http://localhost:3000
+# - Local addon container with exposed port:           http://localhost:3001
+BASE_URL=http://localhost:3000
+
+# Output directory (relative to tools/screenshots/).
+SCREENSHOT_DIR=screenshots
+
+# "dark" or "light"
+PULSECOACH_THEME=dark

--- a/tools/screenshots/.gitignore
+++ b/tools/screenshots/.gitignore
@@ -1,0 +1,12 @@
+# SPDX-FileCopyrightText: 2026 Anil Belur <askb23@gmail.com>
+# SPDX-License-Identifier: Apache-2.0
+
+node_modules/
+screenshots/
+artifacts/
+report/
+playwright-report/
+test-results/
+results.json
+.env
+.env.local

--- a/tools/screenshots/README.md
+++ b/tools/screenshots/README.md
@@ -1,0 +1,114 @@
+<!--
+SPDX-FileCopyrightText: 2026 Anil Belur <askb23@gmail.com>
+SPDX-License-Identifier: Apache-2.0
+-->
+
+# PulseCoach Screenshot Tooling
+
+Playwright-based capture of the PulseCoach dashboard for **AI-assisted UX
+review** and side-by-side iteration.
+
+It does **not** test the HA ingress path — it hits the underlying Next.js
+app directly, which is far simpler and avoids HA's session-scoped ingress
+tokens.
+
+## Quick start
+
+```bash
+# 1. Start the Next.js app in another terminal (from the *app* repo):
+#    cd ../ha-garmin-fitness-coach-app && pnpm dev
+#    (serves at http://localhost:3000)
+#
+# Or run the addon container locally with the port exposed:
+#    docker run -p 3001:3001 ghcr.io/askb/pulsecoach-addon-amd64:latest
+#    (in which case set BASE_URL=http://localhost:3001 below)
+
+cd tools/screenshots
+npm install
+npx playwright install chromium    # one-time
+npm run screenshot
+```
+
+PNGs land in `screenshots/<YYYY-MM-DD>/<route>-<desktop|mobile>.png`.
+An HTML report is written to `report/index.html` for browsing.
+
+## What gets captured
+
+One full-page screenshot per route per device profile (desktop 1440×900
+@2x, mobile = iPhone 14 Pro). Routes covered:
+
+| Route          | Notes                                              |
+| -------------- | -------------------------------------------------- |
+| `/`            | Landing / Today's Coach                            |
+| `/training`    | PMC (CTL/ATL/TSB), ACWR gauge                      |
+| `/fitness`     | VO2max, race predictions, training status          |
+| `/activities`  | Activity list + HR zones                           |
+| `/sleep`       | Sleep coach + debt                                 |
+| `/trends`      | Long-term trends                                   |
+| `/zones`       | HR zone analytics                                  |
+| `/hrv`         | HRV history                                        |
+| `/vitals`      | Resting HR, SpO2, body battery                     |
+| `/insights`    | AI insight cards                                   |
+| `/coach`       | AI chat surface                                    |
+| `/validation`  | Data quality validation page                       |
+
+Add or remove routes in `tests/dashboard.spec.ts` (the `ROUTES` array).
+
+## Configuration
+
+Copy `.env.example` to `.env`:
+
+```bash
+BASE_URL=http://localhost:3000   # where the app is served
+SCREENSHOT_DIR=screenshots       # output dir
+PULSECOACH_THEME=dark            # dark | light
+```
+
+Or pass on the command line:
+
+```bash
+BASE_URL=http://localhost:3001 PULSECOACH_THEME=light npm run screenshot
+```
+
+Single device profile:
+
+```bash
+npm run screenshot:desktop
+npm run screenshot:mobile
+```
+
+## AI review workflow
+
+1. Run `npm run screenshot` after each material UI change.
+2. Drop the day's folder into your model of choice with a prompt like:
+
+   > Review these PulseCoach dashboard screenshots for visual hierarchy,
+   > information density, chart legibility, and dark-mode contrast.
+   > Flag any cards where the value, axis, or threshold annotation is
+   > ambiguous. Suggest concrete CSS / layout changes.
+
+3. Commit the diff. Re-run. Compare with the previous day's folder.
+
+The date-stamped subdirectories make before/after diffs trivial — open
+two folders side-by-side in your file manager, or run a structural diff
+like `magick compare`.
+
+## Why not via HA ingress?
+
+HA's ingress URL embeds a **session-scoped token** that rotates per HA
+session. Long-lived access tokens authorise the WebSocket API but **not**
+ingress. Running Playwright from outside HA against ingress is not
+practical. Hitting the Next.js app directly bypasses this entirely and
+gives identical pixels (ingress only rewrites paths; it does not transform
+the rendered DOM).
+
+## Out of scope (for now)
+
+- Visual-regression assertions (pixel diff thresholds). The current setup
+  only captures — assertions would belong in the *app* repo's test suite
+  with stable seed data.
+- Authenticated screenshots. The app honors `DEV_BYPASS_AUTH=true` (the
+  standard dev setting), which is sufficient for screenshot capture.
+- Triggering screenshots from inside HA via a service call. Addon
+  isolation makes this awkward; trigger from your dev machine or a CI
+  runner instead.

--- a/tools/screenshots/package.json
+++ b/tools/screenshots/package.json
@@ -1,0 +1,18 @@
+{
+  "name": "@pulsecoach/screenshots",
+  "version": "0.1.0",
+  "private": true,
+  "description": "Playwright screenshot tooling for PulseCoach dashboard (UX iteration + AI review)",
+  "license": "Apache-2.0",
+  "type": "module",
+  "scripts": {
+    "screenshot": "playwright test",
+    "screenshot:desktop": "playwright test --project=desktop",
+    "screenshot:mobile": "playwright test --project=mobile",
+    "screenshot:dark": "PULSECOACH_THEME=dark playwright test --project=desktop",
+    "install-browsers": "playwright install chromium"
+  },
+  "devDependencies": {
+    "@playwright/test": "^1.48.0"
+  }
+}

--- a/tools/screenshots/playwright.config.ts
+++ b/tools/screenshots/playwright.config.ts
@@ -1,0 +1,54 @@
+// SPDX-FileCopyrightText: 2026 Anil Belur <askb23@gmail.com>
+// SPDX-License-Identifier: Apache-2.0
+
+import { defineConfig, devices } from "@playwright/test";
+
+/**
+ * Playwright config for PulseCoach screenshot capture.
+ *
+ * BASE_URL defaults to the dev Next.js port (`http://localhost:3000`).
+ * For a locally-running addon container, point it at the exposed port:
+ *
+ *   BASE_URL=http://localhost:3001 pnpm screenshot
+ *
+ * The runner is single-threaded so the produced PNGs land in a stable
+ * filename pattern (no shard suffixes), which is important for AI diffing
+ * and human review.
+ */
+export default defineConfig({
+  testDir: "./tests",
+  timeout: 90_000,
+  retries: 1,
+  workers: 1,
+  reporter: [["list"], ["html", { open: "never", outputFolder: "report" }]],
+
+  use: {
+    baseURL: process.env.BASE_URL ?? "http://localhost:3000",
+    trace: "retain-on-failure",
+    // We capture our own screenshots in the spec; don't let Playwright
+    // also write "test-failed-1.png" alongside them.
+    screenshot: "off",
+    video: "off",
+    colorScheme:
+      (process.env.PULSECOACH_THEME as "light" | "dark" | undefined) ?? "dark",
+  },
+
+  outputDir: "./artifacts",
+
+  projects: [
+    {
+      name: "desktop",
+      use: {
+        ...devices["Desktop Chrome"],
+        viewport: { width: 1440, height: 900 },
+        deviceScaleFactor: 2,
+      },
+    },
+    {
+      name: "mobile",
+      use: {
+        ...devices["iPhone 14 Pro"],
+      },
+    },
+  ],
+});

--- a/tools/screenshots/tests/dashboard.spec.ts
+++ b/tools/screenshots/tests/dashboard.spec.ts
@@ -1,0 +1,80 @@
+// SPDX-FileCopyrightText: 2026 Anil Belur <askb23@gmail.com>
+// SPDX-License-Identifier: Apache-2.0
+
+import path from "node:path";
+import { test } from "@playwright/test";
+
+/**
+ * Routes to capture. Add or remove freely — the spec runs once per route.
+ *
+ * `wait` lets you tune the post-load delay per route (charts on
+ * /training take longer to render than the landing page).
+ */
+const ROUTES: { name: string; path: string; wait?: number }[] = [
+  { name: "home", path: "/", wait: 4000 },
+  { name: "training", path: "/training", wait: 8000 },
+  { name: "fitness", path: "/fitness", wait: 8000 },
+  { name: "activities", path: "/activities", wait: 6000 },
+  { name: "sleep", path: "/sleep", wait: 5000 },
+  { name: "trends", path: "/trends", wait: 8000 },
+  { name: "zones", path: "/zones", wait: 6000 },
+  { name: "hrv", path: "/hrv", wait: 5000 },
+  { name: "vitals", path: "/vitals", wait: 5000 },
+  { name: "insights", path: "/insights", wait: 4000 },
+  { name: "coach", path: "/coach", wait: 4000 },
+  { name: "validation", path: "/validation", wait: 6000 },
+];
+
+const OUT_DIR = process.env.SCREENSHOT_DIR ?? "screenshots";
+
+function timestampedDir(): string {
+  return new Date().toISOString().slice(0, 10);
+}
+
+test.describe.configure({ mode: "serial" });
+
+for (const route of ROUTES) {
+  test(`screenshot ${route.name}`, async ({ page }, testInfo) => {
+    const project = testInfo.project.name; // "desktop" | "mobile"
+    const day = timestampedDir();
+    const fileName = `${route.name}-${project}.png`;
+    const outPath = path.join(OUT_DIR, day, fileName);
+
+    await page.goto(route.path, { waitUntil: "networkidle" });
+
+    // Charts (Recharts) animate in over ~300-500ms after data arrives,
+    // and several pages prefetch via tRPC then re-render. A fixed delay
+    // is the most robust signal without adding test-ids to the app.
+    await page.waitForTimeout(route.wait ?? 5000);
+
+    // Hide any noisy elements that drift run-to-run (date pickers default
+    // to "today", which makes diffs noisy). The selector list is
+    // best-effort — missing nodes don't fail the run.
+    await page
+      .addStyleTag({
+        content: `
+          [data-noisy="true"] { visibility: hidden !important; }
+          /* Kill cursor blinkers and animated spinners for crisp PNGs. */
+          *, *::before, *::after {
+            animation-duration: 0s !important;
+            animation-delay: 0s !important;
+            transition-duration: 0s !important;
+            caret-color: transparent !important;
+          }
+        `,
+      })
+      .catch(() => undefined);
+
+    await page.screenshot({
+      path: outPath,
+      fullPage: true,
+      animations: "disabled",
+    });
+
+    // Attach to the HTML report so reviewers can flip through quickly.
+    await testInfo.attach(`${route.name}-${project}`, {
+      path: outPath,
+      contentType: "image/png",
+    });
+  });
+}


### PR DESCRIPTION
## What

Adds `tools/screenshots/` — a small Playwright project that captures full-page screenshots of every major PulseCoach route (desktop + mobile) for AI-assisted UX iteration.

## How to use

```bash
# Terminal 1: serve the app
cd ../ha-garmin-fitness-coach-app && pnpm dev
# (or run the addon container with port 3001 exposed)

# Terminal 2: capture
cd tools/screenshots
npm install && npx playwright install chromium
npm run screenshot
```

PNGs land in `tools/screenshots/screenshots/<YYYY-MM-DD>/<route>-<desktop|mobile>.png`. An HTML report is written to `report/index.html`.

## Routes captured

`/`, `/training`, `/fitness`, `/activities`, `/sleep`, `/trends`, `/zones`, `/hrv`, `/vitals`, `/insights`, `/coach`, `/validation` — extend in `tests/dashboard.spec.ts` (`ROUTES` array).

## Design choices

- **No HA ingress.** Ingress URLs embed session-scoped tokens that rotate per HA session; long-lived access tokens don't authorise ingress. Hitting the underlying Next.js app directly produces identical pixels (ingress only rewrites paths) and is dramatically simpler.
- **Route-based, not selector-based.** The app has no `data-testid` attributes today, so full-page captures per route are more robust than fragile text/CSS selectors.
- **Single worker.** Stable filenames (no shard suffixes) so AI diffing is deterministic.
- **Animations disabled.** Crisp, diffable PNGs.
- **Dark mode by default.** Override with `PULSECOACH_THEME=light`.

## Deliberately out of scope

- Visual regression assertions (would need stable seed data — belongs in app repo).
- Triggering from inside HA via a service call (addon isolation makes that awkward).
- Authenticated production screenshots (relies on `DEV_BYPASS_AUTH=true`, the standard dev setting).

## REUSE

SPDX headers auto-aggregate via `REUSE.toml` — no per-file boilerplate needed for `package.json` / `.env.example`. The two `.ts` files include explicit headers anyway, matching the rest of the codebase.

## Verification

```
$ cd tools/screenshots && npm install && npx playwright install chromium
$ npm run screenshot
```

Produces 12 routes × 2 devices = 24 PNGs in ~3-4 min on a warm Next.js dev server.