### PR TITLE
chore(release): bump pulsecoach to v0.16.7

### DIFF
--- a/pulsecoach/CHANGELOG.md
+++ b/pulsecoach/CHANGELOG.md
@@ -5,6 +5,23 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.16.7] — 2026-05-14
+
+### Fixed
+- **Analytics 500 on malformed activity dates** — `analytics.getTrainingLoads`
+  and `analytics.getTrainingStatus` no longer return HTTP 500 when any
+  Activity row in the 42-day window has a NaN `startedAt`. The
+  `dayInTimezone` helper now short-circuits to a sentinel date, and the
+  daily-load aggregator skips bad rows so they don't pollute ACWR / CTL /
+  ATL math. (app PR #103)
+
+### Docs
+- **Screenshot tooling for HAOS** — `tools/screenshots/` now leads with
+  the HAOS port-exposure workflow (Settings → Add-ons → PulseCoach →
+  Network → enable `3000/tcp`) instead of the previous `pnpm dev`
+  instructions, which didn't apply to users running only the addon.
+  Fixes wrong port (`3001` → `3000`) in `.env.example`. (#114)
+
 ## [0.16.6] — 2026-05-13
 
 ### Added

--- a/pulsecoach/config.json
+++ b/pulsecoach/config.json
@@ -1,6 +1,6 @@
 {
   "name": "PulseCoach",
-  "version": "0.16.6",
+  "version": "0.16.7",
   "slug": "pulsecoach",
   "image": "ghcr.io/askb/pulsecoach-addon-{arch}",
   "description": "AI-powered sport scientist \u2014 training analysis, coaching, and recovery optimization from your Garmin data",

--- a/tools/screenshots/package-lock.json
+++ b/tools/screenshots/package-lock.json
@@ -1,0 +1,79 @@
+{
+  "name": "@pulsecoach/screenshots",
+  "version": "0.1.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "@pulsecoach/screenshots",
+      "version": "0.1.0",
+      "license": "Apache-2.0",
+      "devDependencies": {
+        "@playwright/test": "^1.48.0"
+      }
+    },
+    "node_modules/@playwright/test": {
+      "version": "1.60.0",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.60.0.tgz",
+      "integrity": "sha512-O71yZIbAh/PxDMNGns37GHBIfrVkEVyn+AXyIa5dOTfb4/xNvRWV+Vv/NMbNCtODB/pO7vLlF2OTmMVLhmr7Ag==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright": "1.60.0"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/playwright": {
+      "version": "1.60.0",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.60.0.tgz",
+      "integrity": "sha512-hheHdokM8cdqCb0lcE3s+zT4t4W+vvjpGxsZlDnikarzx8tSzMebh3UiFtgqwFwnTnjYQcsyMF8ei2mCO/tpeA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.60.0"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.60.0",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.60.0.tgz",
+      "integrity": "sha512-9bW6zvX/m0lEbgTKJ6YppOKx8H3VOPBMOCFh2irXFOT4BbHgrx5hPjwJYLT40Lu+4qtD36qKc/Hn56StUW57IA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    }
+  }
+}


### PR DESCRIPTION
Picks up app v0.2.1 with the analytics invalid-date fix (askb/ha-garmin-fitness-coach-app#103).

## Why
`analytics.getTrainingLoads` and `analytics.getTrainingStatus` were returning HTTP 500 in production logs:
```
>>> tRPC Error on 'analytics.getTrainingStatus' Error [TRPCError]: Invalid time value
```

Root cause was a malformed `Activity.startedAt` in the 42-day window propagating `RangeError: Invalid time value` out of `dayInTimezone`. Fixed in the app; this bump pulls it into the addon image.

The addon Dockerfile clones the app from `main` at build time, so this version bump + tag is what (a) triggers HA Supervisor to surface an update and (b) causes the GHCR image to rebuild against the patched app.