### PR TITLE
fix: source last sync from actual sync completion (v0.16.14)

### DIFF
--- a/pulsecoach/CHANGELOG.md
+++ b/pulsecoach/CHANGELOG.md
@@ -5,6 +5,17 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.16.14] — 2026-05-15
+
+### Fixed
+- **Settings > "Last sync" was showing the wrong timestamp** —
+  previously sourced from the Garmin token directory's mtime, which
+  only changes on (re)login and never reflects actual data sync. The
+  endpoint now reads a dedicated `.last_sync` file written by
+  `garmin-sync.py` at the end of every successful sync run; the
+  legacy mtime path is retained as a fallback for fresh installs
+  where the first sync hasn't completed yet.
+
 ## [0.16.13] — 2026-05-15
 
 ### Added

--- a/pulsecoach/config.json
+++ b/pulsecoach/config.json
@@ -1,6 +1,6 @@
 {
   "name": "PulseCoach",
-  "version": "0.16.13",
+  "version": "0.16.14",
   "slug": "pulsecoach",
   "image": "ghcr.io/askb/pulsecoach-addon-{arch}",
   "description": "AI-powered sport scientist \u2014 training analysis, coaching, and recovery optimization from your Garmin data",

--- a/pulsecoach/rootfs/app/scripts/garmin-auth-server.py
+++ b/pulsecoach/rootfs/app/scripts/garmin-auth-server.py
@@ -183,11 +183,21 @@ def status() -> Response:
 
     try:
         email = os.environ.get("GARMIN_EMAIL", "")
-        # Check for last sync time from token dir modification
-        stat = os.stat(TOKEN_DIR)
-        last_modified = datetime.fromtimestamp(
-            stat.st_mtime, tz=timezone.utc
-        ).isoformat()
+        # Prefer last successful data sync timestamp (written by garmin-sync.py)
+        # falling back to token directory mtime when that file is missing
+        # (fresh install before first sync completes).
+        last_sync_file = os.path.join(TOKEN_DIR, ".last_sync")
+        last_modified = None
+        try:
+            with open(last_sync_file, "r") as f:
+                last_modified = f.read().strip()
+        except OSError:
+            last_modified = None
+        if not last_modified:
+            stat = os.stat(TOKEN_DIR)
+            last_modified = datetime.fromtimestamp(
+                stat.st_mtime, tz=timezone.utc
+            ).isoformat()
         return jsonify(connected=True, email=email, lastSync=last_modified)
     except Exception:
         return jsonify(connected=False, email="", lastSync="")

--- a/pulsecoach/rootfs/app/scripts/garmin-sync.py
+++ b/pulsecoach/rootfs/app/scripts/garmin-sync.py
@@ -52,6 +52,17 @@ def _user_today():
     return datetime.now(USER_TZ).date()
 
 SYNC_STATUS_FILE = os.path.join(TOKEN_DIR, ".sync_status")
+LAST_SYNC_FILE = os.path.join(TOKEN_DIR, ".last_sync")
+
+
+def _write_last_sync() -> None:
+    """Record successful sync completion time for /auth/status."""
+    try:
+        os.makedirs(TOKEN_DIR, exist_ok=True)
+        with open(LAST_SYNC_FILE, "w") as f:
+            f.write(datetime.now(timezone.utc).isoformat())
+    except Exception:
+        pass
 
 
 def _write_sync_status(phase, detail="", progress=0):
@@ -1041,6 +1052,7 @@ def main():
             f.write(datetime.now(timezone.utc).isoformat())
 
     _clear_sync_status()
+    _write_last_sync()
     print("Garmin sync complete")
 
 


### PR DESCRIPTION
Source the Settings > 'Last sync' label from a dedicated `.last_sync` file written at the end of every successful `garmin-sync.py` run, instead of the Garmin token directory's mtime (which only changed on login/MFA).

Tagged as addon v0.16.14.