### PR TITLE
chore(release): v0.16.15 — pick up app v0.2.8 (analytics crash fix)

### DIFF
--- a/pulsecoach/CHANGELOG.md
+++ b/pulsecoach/CHANGELOG.md
@@ -5,6 +5,17 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.16.15] — 2026-05-15
+
+### Fixed
+- **Training & Fitness pages were returning 500s for ACWR / Training
+  Status cards** — `analytics.getTrainingLoads` and
+  `analytics.getTrainingStatus` crashed in production with
+  `RangeError: Invalid time value` from superjson's Date serializer.
+  Both endpoints now emit primitives only (ISO strings, numbers,
+  strings) and filter Activity rows with malformed `startedAt`
+  defensively at the router boundary. Picks up app `v0.2.8`.
+
 ## [0.16.14] — 2026-05-15
 
 ### Fixed

--- a/pulsecoach/config.json
+++ b/pulsecoach/config.json
@@ -1,6 +1,6 @@
 {
   "name": "PulseCoach",
-  "version": "0.16.14",
+  "version": "0.16.15",
   "slug": "pulsecoach",
   "image": "ghcr.io/askb/pulsecoach-addon-{arch}",
   "description": "AI-powered sport scientist \u2014 training analysis, coaching, and recovery optimization from your Garmin data",


### PR DESCRIPTION
Bumps to app **v0.2.8** which fixes the production
`RangeError: Invalid time value` crash in
`analytics.getTrainingLoads` and `analytics.getTrainingStatus`.
The endpoints power the ACWR card on the Training page and the
Training Status card on the Fitness page.

See app PR https://github.com/askb/ha-garmin-fitness-coach-app/pull/111.