### PR TITLE
fix(sync): handle list-wrapped garminconnect Firstbeat responses

### DIFF
--- a/pulsecoach/CHANGELOG.md
+++ b/pulsecoach/CHANGELOG.md
@@ -5,6 +5,38 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.16.18] — 2026-05-16
+
+Hot-fix for the Garmin Native (Firstbeat) card showing only em-dashes
+on every field except HRV, even though the watch had clearly synced.
+
+### Fixed
+- **Training readiness and training status no longer sync** because the
+  upstream `garminconnect` Python library changed its response shape
+  from `dict` to `list[dict]` (single-element list wrapping the same
+  payload). Our sync code called `.get("score")` directly on the
+  response and raised `AttributeError: 'list' object has no attribute
+  'get'`, which was caught by the broad `except Exception` and logged
+  as "Training readiness unavailable for &lt;date&gt;", leaving
+  `garmin_training_readiness`, `garmin_training_status`,
+  `garmin_recovery_hours`, and `garmin_training_load` columns NULL on
+  every `daily_metric` row.
+
+  Added a `_first_dict()` normaliser in `garmin-sync.py` that accepts
+  either a dict (legacy) or a non-empty `list[dict]` (current) and
+  returns the first usable dict, or `None` otherwise. Wrapped both
+  `client.get_training_readiness(...)` and
+  `client.get_training_status(...)` call sites.
+
+  After this release the Firstbeat card will populate on the next
+  scheduled sync (no manual backfill required — the orchestrator
+  re-reads the last 7 days every cycle).
+
+### Tests
+- 8 new unit tests in `tests/test_garmin_sync.py::TestFirstDict`
+  pinning the dict-passthrough / list-unwrap / empty / scalar /
+  None-fallback behaviour.
+
 ## [0.16.17] — 2026-05-16
 
 Picks up app `v0.2.10` with three correlated fixes for the next-morning

--- a/pulsecoach/config.json
+++ b/pulsecoach/config.json
@@ -1,6 +1,6 @@
 {
   "name": "PulseCoach",
-  "version": "0.16.17",
+  "version": "0.16.18",
   "slug": "pulsecoach",
   "image": "ghcr.io/askb/pulsecoach-addon-{arch}",
   "description": "AI-powered sport scientist — training analysis, coaching, and recovery optimization from your Garmin data",

--- a/pulsecoach/rootfs/app/scripts/garmin-sync.py
+++ b/pulsecoach/rootfs/app/scripts/garmin-sync.py
@@ -853,6 +853,30 @@ def sync_vo2max(client, db, days=7):
         cur.close()
 
 
+def _first_dict(data):
+    """Coerce a Garmin Connect response into a single dict or None.
+
+    Some `garminconnect` endpoints (notably `get_training_readiness` and
+    `get_training_status` since the library bumped past 0.2.x) now return
+    a `list[dict]` of one element instead of a plain `dict`. Calling
+    `.get(...)` directly on a list raises `AttributeError: 'list' object
+    has no attribute 'get'`, which the wider try/except in the sync
+    helpers swallowed silently — leaving the affected columns NULL for
+    every synced day. Normalise here so each caller can treat the result
+    as a dict (or `None` when the day genuinely has no data).
+    """
+    if data is None:
+        return None
+    if isinstance(data, dict):
+        return data
+    if isinstance(data, list):
+        for entry in data:
+            if isinstance(entry, dict) and entry:
+                return entry
+        return None
+    return None
+
+
 def sync_training_readiness(client, db, days=7):
     """Sync Garmin Training Readiness score and contributing factors."""
     cur = db.cursor()
@@ -862,7 +886,7 @@ def sync_training_readiness(client, db, days=7):
         for days_ago in range(days):
             date_str = (today - timedelta(days=days_ago)).isoformat()
             try:
-                data = client.get_training_readiness(date_str)
+                data = _first_dict(client.get_training_readiness(date_str))
                 if not data:
                     continue
 
@@ -923,7 +947,7 @@ def sync_training_status(client, db, days=7):
         for days_ago in range(days):
             date_str = (today - timedelta(days=days_ago)).isoformat()
             try:
-                data = client.get_training_status(date_str)
+                data = _first_dict(client.get_training_status(date_str))
                 if not data:
                     continue
 

--- a/tests/test_garmin_sync.py
+++ b/tests/test_garmin_sync.py
@@ -154,6 +154,50 @@ class TestSafeSleepMinutes:
 
 
 # ---------------------------------------------------------------------------
+# _first_dict — Garmin API list/dict response normaliser
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+class TestFirstDict:
+    """Regression tests for _first_dict().
+
+    Pins behaviour for the v0.16.18 fix where `garminconnect` started
+    returning `[{...}]` instead of `{...}` for training-readiness and
+    training-status endpoints, which caused all those columns to stay
+    NULL because `data.get("score")` raised AttributeError on a list.
+    """
+
+    def test_dict_passes_through(self, garmin_sync):
+        result = garmin_sync._first_dict({"score": 75})
+        assert result == {"score": 75}
+
+    def test_list_of_one_dict_unwrapped(self, garmin_sync):
+        """Latest garminconnect shape: `[{...}]`."""
+        result = garmin_sync._first_dict([{"score": 75}])
+        assert result == {"score": 75}
+
+    def test_list_with_leading_empty_dict_skipped(self, garmin_sync):
+        result = garmin_sync._first_dict([{}, {"score": 75}])
+        assert result == {"score": 75}
+
+    def test_none_returns_none(self, garmin_sync):
+        assert garmin_sync._first_dict(None) is None
+
+    def test_empty_list_returns_none(self, garmin_sync):
+        assert garmin_sync._first_dict([]) is None
+
+    def test_list_of_non_dicts_returns_none(self, garmin_sync):
+        assert garmin_sync._first_dict([1, 2, "x"]) is None
+
+    def test_scalar_returns_none(self, garmin_sync):
+        assert garmin_sync._first_dict(42) is None
+
+    def test_list_of_empty_dicts_returns_none(self, garmin_sync):
+        assert garmin_sync._first_dict([{}, {}]) is None
+
+
+# ---------------------------------------------------------------------------
 # sync_daily_stats
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## Summary

Hot-fix for the Garmin Native (Firstbeat) card showing only em-dashes on every field except HRV, confirmed live on HAOS by inspecting `daily_metric`:

```
$ sudo docker exec addon_ecfdb23d_pulsecoach \
    psql -U postgres pulsecoach -c "SELECT date, garmin_training_readiness, garmin_training_status, garmin_recovery_hours FROM daily_metric ORDER BY date DESC LIMIT 8;"
    date    | garmin_training_readiness | garmin_training_status | garmin_recovery_hours
------------+---------------------------+------------------------+-----------------------
 2026-05-16 |                           |                        |
 2026-05-15 |                           |                        |
 ... (all NULL)
```

And from the container logs:

```
Training readiness unavailable for 2026-05-16: 'list' object has no attribute 'get'
```

## Root cause

Upstream `garminconnect` Python library changed `get_training_readiness()` and `get_training_status()` from returning `dict` to `list[dict]` (single-element list wrapping the same payload). Our sync code calls `.get("score")` directly on the response → `AttributeError` → caught by broad `except Exception` → logged as "unavailable" → row never written.

## Fix

Added `_first_dict()` normaliser that accepts either a dict (legacy) or non-empty `list[dict]` (current) and returns the first usable dict, or `None`. Wrapped both broken call sites. Modelled on existing `sync_vo2max` which already handles the list shape.

## Tests

8 new cases in `tests/test_garmin_sync.py::TestFirstDict` covering dict passthrough, list unwrap, leading-empty-dict skip, empty list, scalar, None.

## Verification

After deploy, next scheduled sync will backfill 7 days. Will SSH back and confirm `daily_metric` rows populate.

Co-authored-by: Claude <claude@anthropic.com>