### PR TITLE
fix(sync): populate recovery hours from readiness; parse status DTOs

### DIFF
--- a/pulsecoach/CHANGELOG.md
+++ b/pulsecoach/CHANGELOG.md
@@ -5,6 +5,38 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.16.19] — 2026-05-16
+
+Second pass on the Garmin Native (Firstbeat) card. After v0.16.18
+restored the `training_readiness` sync, live inspection on HAOS
+revealed two remaining issues:
+
+1. Recovery time (hours) was still NULL because `get_training_status`
+   returns `mostRecentTrainingStatus: null` for users whose watch
+   hasn't yet computed Firstbeat status (typically requires ~7 days
+   of structured activity). However the value we actually want for
+   the card — `recoveryTime` in minutes — is already inside the
+   `get_training_readiness` payload.
+2. When `get_training_status` does populate, the meaningful fields
+   live under `mostRecentTrainingStatus.latestTrainingStatusData.
+   <deviceId>.{trainingStatus, recoveryTime, ...}` — a nested DTO
+   shape the previous code never inspected. So even users with a
+   computed status would have seen empty columns.
+
+### Fixed
+- **`sync_training_readiness` now also writes `garmin_recovery_hours`**
+  by converting `recoveryTime` (minutes) from the readiness payload.
+  Uses `COALESCE` so it never clobbers a value that `sync_training_status`
+  may have written later in the same run.
+- **`sync_training_status` parses the nested DTO shape**
+  (`mostRecentTrainingStatus.latestTrainingStatusData.<deviceId>`)
+  for status / load focus / recovery time, with fallbacks to the
+  flat shapes used by older library versions. Updates use `COALESCE`
+  so partial responses don't blank out previously-populated columns.
+
+After this release, the Firstbeat card should show Recovery hours
+even for users without computed Firstbeat training status.
+
 ## [0.16.18] — 2026-05-16
 
 Hot-fix for the Garmin Native (Firstbeat) card showing only em-dashes

--- a/pulsecoach/CHANGELOG.md
+++ b/pulsecoach/CHANGELOG.md
@@ -26,13 +26,16 @@ revealed two remaining issues:
 ### Fixed
 - **`sync_training_readiness` now also writes `garmin_recovery_hours`**
   by converting `recoveryTime` (minutes) from the readiness payload.
-  Uses `COALESCE` so it never clobbers a value that `sync_training_status`
-  may have written later in the same run.
+  Uses `COALESCE` so a later run that hits an emptier payload can't
+  blank out a recovery value previously stored for the same day.
 - **`sync_training_status` parses the nested DTO shape**
   (`mostRecentTrainingStatus.latestTrainingStatusData.<deviceId>`)
   for status / load focus / recovery time, with fallbacks to the
-  flat shapes used by older library versions. Updates use `COALESCE`
-  so partial responses don't blank out previously-populated columns.
+  flat shapes used by older library versions. Recovery time lookup
+  now uses an explicit `is not None` check so a fully-recovered
+  `recoveryTime == 0` isn't discarded as "missing". Updates use
+  `COALESCE` so a partial response can't blank out columns the
+  readiness sync populated earlier in the run.
 
 After this release, the Firstbeat card should show Recovery hours
 even for users without computed Firstbeat training status.

--- a/pulsecoach/config.json
+++ b/pulsecoach/config.json
@@ -1,6 +1,6 @@
 {
   "name": "PulseCoach",
-  "version": "0.16.18",
+  "version": "0.16.19",
   "slug": "pulsecoach",
   "image": "ghcr.io/askb/pulsecoach-addon-{arch}",
   "description": "AI-powered sport scientist — training analysis, coaching, and recovery optimization from your Garmin data",

--- a/pulsecoach/rootfs/app/scripts/garmin-sync.py
+++ b/pulsecoach/rootfs/app/scripts/garmin-sync.py
@@ -905,6 +905,20 @@ def sync_training_readiness(client, db, days=7):
                     if val is not None:
                         factors[key] = val
 
+                # Recovery time is reported in minutes inside the readiness
+                # payload itself. Convert to hours so the Garmin Native
+                # (Firstbeat) card and downstream consumers can render it
+                # even when get_training_status() comes back empty (which is
+                # the common case until Garmin has computed Firstbeat status
+                # from enough recent activity).
+                recovery_minutes = data.get("recoveryTime")
+                recovery_hours = (
+                    round(recovery_minutes / 60.0, 1)
+                    if isinstance(recovery_minutes, (int, float))
+                    and recovery_minutes >= 0
+                    else None
+                )
+
                 cur.execute("""
                     INSERT INTO daily_metric (user_id, date)
                     VALUES (%s, %s)
@@ -915,12 +929,14 @@ def sync_training_readiness(client, db, days=7):
                     UPDATE daily_metric SET
                         garmin_training_readiness = %s,
                         garmin_training_readiness_level = %s,
-                        garmin_readiness_factors = %s
+                        garmin_readiness_factors = %s,
+                        garmin_recovery_hours = COALESCE(%s, garmin_recovery_hours)
                     WHERE user_id = %s AND date = %s
                 """, (
                     round(score),
                     level.lower() if isinstance(level, str) else str(level),
                     json.dumps(factors) if factors else None,
+                    recovery_hours,
                     USER_ID, date_str,
                 ))
                 synced += 1
@@ -951,26 +967,76 @@ def sync_training_status(client, db, days=7):
                 if not data:
                     continue
 
-                # Training status fields
-                status = data.get("trainingStatus") or data.get("status", "")
-                load_focus = data.get("trainingLoadFocus") or data.get("loadFocus")
+                # The endpoint returns a flat top-level dict whose meaningful
+                # payload lives in nested DTOs:
+                #   {
+                #     "userId": ...,
+                #     "mostRecentTrainingStatus": {...} | null,
+                #     "mostRecentTrainingLoadBalance": {...} | null,
+                #     "mostRecentVO2Max": {...} | null,
+                #     "heatAltitudeAcclimationDTO": {...} | null,
+                #   }
+                # Garmin only populates these once the watch has computed
+                # Firstbeat status (typically needs ~7 days of structured
+                # activity). When they're null we just leave the columns
+                # alone — `garmin_recovery_hours` is filled from the
+                # readiness payload instead (see sync_training_readiness).
+                status_dto = data.get("mostRecentTrainingStatus") or {}
+                load_dto = data.get("mostRecentTrainingLoadBalance") or {}
 
-                # Extract load distribution (low/high aerobic + anaerobic)
+                # mostRecentTrainingStatus is itself wrapped — the actual
+                # per-device payload sits under
+                # latestTrainingStatusData.<deviceId>.
+                inner_status = {}
+                if isinstance(status_dto, dict):
+                    latest = status_dto.get("latestTrainingStatusData") or {}
+                    if isinstance(latest, dict) and latest:
+                        # Pick the first (and usually only) device entry.
+                        for v in latest.values():
+                            if isinstance(v, dict):
+                                inner_status = v
+                                break
+
+                status = (
+                    inner_status.get("trainingStatus")
+                    or inner_status.get("trainingStatusFeedbackPhrase")
+                    # Legacy/flat shapes seen on older library versions.
+                    or data.get("trainingStatus")
+                    or data.get("status")
+                    or ""
+                )
+                load_focus = (
+                    inner_status.get("trainingLoadFocus")
+                    or (load_dto.get("trainingLoadFocus")
+                        if isinstance(load_dto, dict) else None)
+                    or data.get("trainingLoadFocus")
+                    or data.get("loadFocus")
+                )
+
+                # Load distribution lives on the load-balance DTO when present.
                 load_dist = {}
+                load_source = load_dto if isinstance(load_dto, dict) and load_dto else data
                 for key in [
                     "lowAerobicTrainingLoad", "highAerobicTrainingLoad",
                     "anaerobicTrainingLoad", "lowAerobicTrainingLoadPercentage",
                     "highAerobicTrainingLoadPercentage", "anaerobicTrainingLoadPercentage",
                 ]:
-                    val = data.get(key)
+                    val = load_source.get(key)
                     if val is not None:
                         load_dist[key] = val
 
-                recovery_hrs = data.get("recoveryTimeInMinutes")
-                if recovery_hrs is not None:
-                    recovery_hrs = round(recovery_hrs / 60, 1)
+                recovery_min = (
+                    inner_status.get("recoveryTime")
+                    or data.get("recoveryTimeInMinutes")
+                )
+                recovery_hrs = (
+                    round(recovery_min / 60.0, 1)
+                    if isinstance(recovery_min, (int, float))
+                    and recovery_min >= 0
+                    else None
+                )
 
-                if not status and not load_focus and not recovery_hrs:
+                if not status and not load_focus and not recovery_hrs and not load_dist:
                     continue
 
                 cur.execute("""
@@ -981,9 +1047,9 @@ def sync_training_status(client, db, days=7):
 
                 cur.execute("""
                     UPDATE daily_metric SET
-                        garmin_training_status = %s,
-                        garmin_load_focus = %s,
-                        garmin_recovery_hours = %s
+                        garmin_training_status = COALESCE(%s, garmin_training_status),
+                        garmin_load_focus = COALESCE(%s, garmin_load_focus),
+                        garmin_recovery_hours = COALESCE(%s, garmin_recovery_hours)
                     WHERE user_id = %s AND date = %s
                 """, (
                     str(status).upper() if status else None,

--- a/pulsecoach/rootfs/app/scripts/garmin-sync.py
+++ b/pulsecoach/rootfs/app/scripts/garmin-sync.py
@@ -1025,10 +1025,11 @@ def sync_training_status(client, db, days=7):
                     if val is not None:
                         load_dist[key] = val
 
-                recovery_min = (
-                    inner_status.get("recoveryTime")
-                    or data.get("recoveryTimeInMinutes")
-                )
+                # Use explicit None-check (not `or`) so a fully-recovered
+                # user's `recoveryTime == 0` isn't discarded as "missing".
+                recovery_min = inner_status.get("recoveryTime")
+                if recovery_min is None:
+                    recovery_min = data.get("recoveryTimeInMinutes")
                 recovery_hrs = (
                     round(recovery_min / 60.0, 1)
                     if isinstance(recovery_min, (int, float))
@@ -1036,7 +1037,12 @@ def sync_training_status(client, db, days=7):
                     else None
                 )
 
-                if not status and not load_focus and not recovery_hrs and not load_dist:
+                if (
+                    not status
+                    and not load_focus
+                    and recovery_hrs is None
+                    and not load_dist
+                ):
                     continue
 
                 cur.execute("""

--- a/tests/unit/test_garmin_sync.py
+++ b/tests/unit/test_garmin_sync.py
@@ -451,6 +451,61 @@ class TestSyncTrainingReadiness:
         ]
         assert len(update_calls) == 1
 
+    # --- v0.16.19 regressions ----------------------------------------------
+
+    def test_writes_recovery_hours_from_readiness_payload(self, garmin_sync, mock_pg_db):
+        """recoveryTime (min) inside the readiness payload should land in
+        garmin_recovery_hours, since get_training_status() is empty for
+        many users until Garmin computes Firstbeat status."""
+        conn, cursor = mock_pg_db
+        client = self._make_client({
+            "score": 29, "level": "LOW",
+            "recoveryTime": 240,  # 4 hours
+        })
+        garmin_sync.sync_training_readiness(client, conn, days=1)
+
+        update_calls = [
+            c for c in cursor.execute.call_args_list
+            if "UPDATE daily_metric" in c.args[0]
+            and "garmin_training_readiness" in c.args[0]
+        ]
+        assert update_calls
+        params = update_calls[0].args[1]
+        # New parameter order: score, level, factors, recovery_hours
+        assert params[3] == 4.0
+        # The UPDATE must use COALESCE so a later partial run can't blank
+        # a value populated by sync_training_status earlier.
+        assert "COALESCE" in update_calls[0].args[0]
+
+    def test_recovery_hours_zero_preserved(self, garmin_sync, mock_pg_db):
+        """recoveryTime == 0 (fully recovered) converts to 0.0 hours, not None."""
+        conn, cursor = mock_pg_db
+        client = self._make_client({"score": 90, "level": "PRIME", "recoveryTime": 0})
+        garmin_sync.sync_training_readiness(client, conn, days=1)
+
+        update_calls = [
+            c for c in cursor.execute.call_args_list
+            if "UPDATE daily_metric" in c.args[0]
+            and "garmin_training_readiness" in c.args[0]
+        ]
+        assert update_calls
+        assert update_calls[0].args[1][3] == 0.0
+
+    def test_recovery_hours_missing_passes_none(self, garmin_sync, mock_pg_db):
+        """Without recoveryTime, parameter is None and COALESCE preserves
+        any existing column value."""
+        conn, cursor = mock_pg_db
+        client = self._make_client({"score": 60, "level": "GOOD"})  # no recoveryTime
+        garmin_sync.sync_training_readiness(client, conn, days=1)
+
+        update_calls = [
+            c for c in cursor.execute.call_args_list
+            if "UPDATE daily_metric" in c.args[0]
+            and "garmin_training_readiness" in c.args[0]
+        ]
+        assert update_calls
+        assert update_calls[0].args[1][3] is None
+
 
 # ── Training status sync ─────────────────────────────────────────────────────
 
@@ -555,3 +610,75 @@ class TestSyncTrainingStatus:
             and "garmin_training_status" in c.args[0]
         ]
         assert len(update_calls) == 1
+
+    # --- v0.16.19 regressions ----------------------------------------------
+
+    def test_parses_nested_mostRecentTrainingStatus_dto(self, garmin_sync, mock_pg_db):
+        """Current Garmin shape: status under mostRecentTrainingStatus.
+        latestTrainingStatusData.<deviceId>.{trainingStatus,recoveryTime}."""
+        conn, cursor = mock_pg_db
+        client = self._make_client({
+            "userId": 72997753,
+            "mostRecentVO2Max": None,
+            "mostRecentTrainingLoadBalance": None,
+            "mostRecentTrainingStatus": {
+                "latestTrainingStatusData": {
+                    "3610171495": {
+                        "trainingStatus": "productive",
+                        "trainingLoadFocus": "high_aerobic",
+                        "recoveryTime": 240,  # 4 hours
+                    }
+                }
+            },
+            "heatAltitudeAcclimationDTO": None,
+        })
+        garmin_sync.sync_training_status(client, conn, days=1)
+
+        update_calls = [
+            c for c in cursor.execute.call_args_list
+            if "UPDATE daily_metric" in c.args[0]
+            and "garmin_training_status" in c.args[0]
+        ]
+        assert update_calls, "expected nested DTO to drive an UPDATE"
+        params = update_calls[0].args[1]
+        assert params[0] == "PRODUCTIVE"
+        assert params[2] == 4.0  # 240 min → 4.0 h
+
+    def test_recovery_time_zero_is_preserved(self, garmin_sync, mock_pg_db):
+        """recoveryTime == 0 (fully recovered) must NOT be discarded as missing."""
+        conn, cursor = mock_pg_db
+        client = self._make_client({
+            "mostRecentTrainingStatus": {
+                "latestTrainingStatusData": {
+                    "dev": {"trainingStatus": "productive", "recoveryTime": 0}
+                }
+            }
+        })
+        garmin_sync.sync_training_status(client, conn, days=1)
+
+        update_calls = [
+            c for c in cursor.execute.call_args_list
+            if "UPDATE daily_metric" in c.args[0]
+            and "garmin_training_status" in c.args[0]
+        ]
+        assert update_calls
+        assert update_calls[0].args[1][2] == 0.0  # 0 min → 0.0 h, NOT None
+
+    def test_null_dtos_skip_silently(self, garmin_sync, mock_pg_db):
+        """The common empty-payload shape (all nested DTOs null) is skipped."""
+        conn, cursor = mock_pg_db
+        client = self._make_client({
+            "userId": 72997753,
+            "mostRecentVO2Max": None,
+            "mostRecentTrainingLoadBalance": None,
+            "mostRecentTrainingStatus": None,
+            "heatAltitudeAcclimationDTO": None,
+        })
+        garmin_sync.sync_training_status(client, conn, days=1)
+
+        update_calls = [
+            c for c in cursor.execute.call_args_list
+            if "UPDATE daily_metric" in c.args[0]
+            and "garmin_training_status" in c.args[0]
+        ]
+        assert not update_calls


### PR DESCRIPTION
## Summary

Follow-up to #127 / v0.16.18. After that release restored the training-readiness sync, live SSH on HAOS confirmed the readiness column populates (score=29 across 7 days) but `garmin_recovery_hours` and `garmin_training_status` were still NULL.

## Root causes

**Issue 1 — `get_training_status()` returns null payload for many users:**
```python
>>> client.get_training_status('2026-05-16')
{'userId': 72997753, 'mostRecentVO2Max': None, 'mostRecentTrainingLoadBalance': None, 'mostRecentTrainingStatus': None, 'heatAltitudeAcclimationDTO': None}
```
Garmin only computes Firstbeat training status once it has ~7 days of structured activity, so for many users the endpoint is intentionally empty. But the value we want most for the card — recovery time — is already in the readiness payload:
```python
>>> client.get_training_readiness('2026-05-16')[0]
{... 'score': 29, 'recoveryTime': 232, ...}
```

**Issue 2 — nested DTO shape was never parsed:**
When training_status DOES populate, fields live under `mostRecentTrainingStatus.latestTrainingStatusData.<deviceId>.{trainingStatus,recoveryTime,...}`. Previous code looked for `data.get("trainingStatus")` at the top level → would always be empty.

## Fix

1. `sync_training_readiness` extracts `recoveryTime` (min) → writes `garmin_recovery_hours` via `COALESCE`.
2. `sync_training_status` parses the nested DTO with fallbacks to the legacy flat shape.
3. Both use `COALESCE(%s, column)` so partial responses can't clobber columns populated by the other helper.

## Verification

After deploy, SSH back and confirm `garmin_recovery_hours` is populated for the last 7 days even though `garmin_training_status` may remain NULL for users without computed Firstbeat status.

Co-authored-by: Claude <claude@anthropic.com>