### PR TITLE
fix(readiness): preserve components when using garmin native score

### DIFF
--- a/pulsecoach/rootfs/app/scripts/metrics-compute.py
+++ b/pulsecoach/rootfs/app/scripts/metrics-compute.py
@@ -395,8 +395,8 @@ def compute_readiness_score(cur, user_id: str) -> dict:
         # below baseline = ~20pt penalty, each 1% above = ~20pt bonus.
         if spo2_val and len(spo2_history) >= 3:
             avg_spo2 = sum(spo2_history[-14:]) / len(spo2_history[-14:])
-            # Score: 100 at baseline, drops steeply below baseline
-            # Each 1% below baseline = ~20pt penalty
+            # Score: 75 at baseline (matches the block comment above);
+            # each 1% below baseline = ~20pt penalty, each 1% above = ~20pt bonus.
             deviation = spo2_val - avg_spo2
             spo2_pct = min(100, max(0, 75 + deviation * 20))
             components.append(("spo2", spo2_pct, 0.08))

--- a/pulsecoach/rootfs/app/scripts/metrics-compute.py
+++ b/pulsecoach/rootfs/app/scripts/metrics-compute.py
@@ -337,143 +337,123 @@ def compute_readiness_score(cur, user_id: str) -> dict:
     for row in rows:
         d = str(row["date"])
         garmin_readiness = row.get("garmin_training_readiness")
+        hrv_val = row.get("hrv")
+        sleep_val = row.get("sleep_score")
+        stress_val = row.get("stress_score")
+        rhr_val = row.get("resting_hr")
+        bb_val = row.get("body_battery_end")
+        spo2_val = row.get("spo2")
+        rr_val = row.get("respiration_rate")
+        skin_temp_val = row.get("skin_temp")
 
-        # If Garmin native readiness exists, use it directly
+        if hrv_val:
+            hrv_history.append(hrv_val)
+        if rhr_val:
+            rhr_history.append(rhr_val)
+        if spo2_val:
+            spo2_history.append(spo2_val)
+        if rr_val:
+            rr_history.append(rr_val)
+        if skin_temp_val:
+            skin_temp_history.append(skin_temp_val)
+
+        components = []
+        total_weight = 0
+
+        # HRV component (25%): higher is better, ratio vs 14-day avg
+        if hrv_val and len(hrv_history) >= 7:
+            avg_hrv = sum(hrv_history[-14:]) / len(hrv_history[-14:])
+            hrv_pct = min(100, max(0, (hrv_val / max(1, avg_hrv)) * 50 + 25))
+            components.append(("hrv", hrv_pct, 0.25))
+            total_weight += 0.25
+
+        # Sleep component (20%): direct score 0-100
+        if sleep_val is not None:
+            components.append(("sleep", min(100, sleep_val), 0.20))
+            total_weight += 0.20
+
+        # Training load component (15%): Body Battery as proxy
+        if bb_val is not None:
+            components.append(("load", min(100, bb_val), 0.15))
+            total_weight += 0.15
+
+        # Resting HR component (10%): lower is better vs baseline
+        if rhr_val and len(rhr_history) >= 7:
+            avg_rhr = sum(rhr_history[-14:]) / len(rhr_history[-14:])
+            rhr_pct = min(100, max(0, (2 - rhr_val / max(1, avg_rhr)) * 50 + 25))
+            components.append(("rhr", rhr_pct, 0.10))
+            total_weight += 0.10
+
+        # Stress component (8%): lower is better (invert)
+        if stress_val is not None:
+            stress_pct = max(0, 100 - stress_val)
+            components.append(("stress", stress_pct, 0.08))
+            total_weight += 0.08
+
+        # SpO2 component (8%): deviation below rolling 14-day average penalizes
+        # Normal range: 95-100%. Score starts at 75 (at baseline), each 1%
+        # below baseline = ~20pt penalty, each 1% above = ~20pt bonus.
+        if spo2_val and len(spo2_history) >= 3:
+            avg_spo2 = sum(spo2_history[-14:]) / len(spo2_history[-14:])
+            # Score: 100 at baseline, drops steeply below baseline
+            # Each 1% below baseline = ~20pt penalty
+            deviation = spo2_val - avg_spo2
+            spo2_pct = min(100, max(0, 75 + deviation * 20))
+            components.append(("spo2", spo2_pct, 0.08))
+            total_weight += 0.08
+
+        # Respiration rate component (7%): elevated RR = stress/illness
+        # Normal sleep RR: 12-20 brpm. Lower (near baseline) is better.
+        if rr_val and len(rr_history) >= 3:
+            avg_rr = sum(rr_history[-14:]) / len(rr_history[-14:])
+            # Each 1 brpm above baseline = ~15pt penalty
+            deviation = rr_val - avg_rr
+            rr_pct = min(100, max(0, 75 - deviation * 15))
+            components.append(("rr", rr_pct, 0.07))
+            total_weight += 0.07
+
+        # Skin temperature component (7%): deviation from baseline
+        # Elevated skin temp = illness/overreaching (WHOOP model)
+        if skin_temp_val and len(skin_temp_history) >= 3:
+            avg_st = sum(skin_temp_history[-14:]) / len(skin_temp_history[-14:])
+            # Each 0.5°C above baseline = ~20pt penalty
+            deviation = skin_temp_val - avg_st
+            st_pct = min(100, max(0, 75 - deviation * 40))
+            components.append(("skin_temp", st_pct, 0.07))
+            total_weight += 0.07
+
+        if total_weight == 0:
+            if garmin_readiness is None:
+                continue
+            comp_map = {}
+        else:
+            comp_map = {n: v for n, v, _ in components}
+
         if garmin_readiness is not None:
             score = int(garmin_readiness)
             zone = _readiness_zone(score)
-            results[d] = {
-                "score": score,
-                "zone": zone,
-                "explanation": f"Garmin Training Readiness: {score}/100 ({zone})",
-                "source": "garmin_native",
-                "hrv_component": None,
-                "sleep_quantity_component": None,
-                "sleep_quality_component": None,
-                "training_load_component": None,
-                "stress_component": None,
-                "resting_hr_component": None,
-            }
+            explanation = f"Garmin Training Readiness: {score}/100 ({zone})"
+            source = "garmin_native"
         else:
-            # Compute Buchheit-style composite with vitals
-            hrv_val = row.get("hrv")
-            sleep_val = row.get("sleep_score")
-            stress_val = row.get("stress_score")
-            rhr_val = row.get("resting_hr")
-            bb_val = row.get("body_battery_end")
-            spo2_val = row.get("spo2")
-            rr_val = row.get("respiration_rate")
-            skin_temp_val = row.get("skin_temp")
+            score = round(sum(v * w for _, v, w in components) / total_weight)
+            score = min(100, max(0, score))
+            zone = _readiness_zone(score)
+            parts = ", ".join(f"{n}={v:.0f}" for n, v, _ in components)
+            explanation = f"Buchheit composite: {score}/100 ({parts})"
+            source = "buchheit_composite"
 
-            if hrv_val:
-                hrv_history.append(hrv_val)
-            if rhr_val:
-                rhr_history.append(rhr_val)
-            if spo2_val:
-                spo2_history.append(spo2_val)
-            if rr_val:
-                rr_history.append(rr_val)
-            if skin_temp_val:
-                skin_temp_history.append(skin_temp_val)
-
-            components = []
-            total_weight = 0
-
-            # HRV component (25%): higher is better, ratio vs 14-day avg
-            if hrv_val and len(hrv_history) >= 7:
-                avg_hrv = sum(hrv_history[-14:]) / len(hrv_history[-14:])
-                hrv_pct = min(100, max(0, (hrv_val / max(1, avg_hrv)) * 50 + 25))
-                components.append(("hrv", hrv_pct, 0.25))
-                total_weight += 0.25
-
-            # Sleep component (20%): direct score 0-100
-            if sleep_val is not None:
-                components.append(("sleep", min(100, sleep_val), 0.20))
-                total_weight += 0.20
-
-            # Training load component (15%): Body Battery as proxy
-            if bb_val is not None:
-                components.append(("load", min(100, bb_val), 0.15))
-                total_weight += 0.15
-
-            # Resting HR component (10%): lower is better vs baseline
-            if rhr_val and len(rhr_history) >= 7:
-                avg_rhr = sum(rhr_history[-14:]) / len(rhr_history[-14:])
-                rhr_pct = min(100, max(0, (2 - rhr_val / max(1, avg_rhr)) * 50 + 25))
-                components.append(("rhr", rhr_pct, 0.10))
-                total_weight += 0.10
-
-            # Stress component (8%): lower is better (invert)
-            if stress_val is not None:
-                stress_pct = max(0, 100 - stress_val)
-                components.append(("stress", stress_pct, 0.08))
-                total_weight += 0.08
-
-            # SpO2 component (8%): deviation below rolling 14-day average penalizes
-            # Normal range: 95-100%. Score starts at 75 (at baseline), each 1%
-            # below baseline = ~20pt penalty, each 1% above = ~20pt bonus.
-            if spo2_val and len(spo2_history) >= 3:
-                avg_spo2 = sum(spo2_history[-14:]) / len(spo2_history[-14:])
-                # Score: 100 at baseline, drops steeply below baseline
-                # Each 1% below baseline = ~20pt penalty
-                deviation = spo2_val - avg_spo2
-                spo2_pct = min(100, max(0, 75 + deviation * 20))
-                components.append(("spo2", spo2_pct, 0.08))
-                total_weight += 0.08
-
-            # Respiration rate component (7%): elevated RR = stress/illness
-            # Normal sleep RR: 12-20 brpm. Lower (near baseline) is better.
-            if rr_val and len(rr_history) >= 3:
-                avg_rr = sum(rr_history[-14:]) / len(rr_history[-14:])
-                # Each 1 brpm above baseline = ~15pt penalty
-                deviation = rr_val - avg_rr
-                rr_pct = min(100, max(0, 75 - deviation * 15))
-                components.append(("rr", rr_pct, 0.07))
-                total_weight += 0.07
-
-            # Skin temperature component (7%): deviation from baseline
-            # Elevated skin temp = illness/overreaching (WHOOP model)
-            if skin_temp_val and len(skin_temp_history) >= 3:
-                avg_st = sum(skin_temp_history[-14:]) / len(skin_temp_history[-14:])
-                # Each 0.5°C above baseline = ~20pt penalty
-                deviation = skin_temp_val - avg_st
-                st_pct = min(100, max(0, 75 - deviation * 40))
-                components.append(("skin_temp", st_pct, 0.07))
-                total_weight += 0.07
-
-            if total_weight > 0:
-                score = round(sum(v * w for _, v, w in components) / total_weight)
-                score = min(100, max(0, score))
-                zone = _readiness_zone(score)
-                parts = ", ".join(f"{n}={v:.0f}" for n, v, _ in components)
-                comp_map = {n: v for n, v, _ in components}
-                results[d] = {
-                    "score": score,
-                    "zone": zone,
-                    "explanation": f"Buchheit composite: {score}/100 ({parts})",
-                    "source": "buchheit_composite",
-                    "hrv_component": comp_map.get("hrv"),
-                    "sleep_quantity_component": comp_map.get("sleep"),
-                    "sleep_quality_component": None,
-                    "training_load_component": comp_map.get("load"),
-                    "stress_component": comp_map.get("stress"),
-                    "resting_hr_component": comp_map.get("rhr"),
-                }
-            else:
-                continue
-
-        # Update history for Garmin-native rows too (for baseline computation)
-        if garmin_readiness is not None:
-            if row.get("hrv"):
-                hrv_history.append(row["hrv"])
-            if row.get("resting_hr"):
-                rhr_history.append(row["resting_hr"])
-            if row.get("spo2"):
-                spo2_history.append(row["spo2"])
-            if row.get("respiration_rate"):
-                rr_history.append(row["respiration_rate"])
-            if row.get("skin_temp"):
-                skin_temp_history.append(row["skin_temp"])
+        results[d] = {
+            "score": score,
+            "zone": zone,
+            "explanation": explanation,
+            "source": source,
+            "hrv_component": comp_map.get("hrv"),
+            "sleep_quantity_component": comp_map.get("sleep"),
+            "sleep_quality_component": None,
+            "training_load_component": comp_map.get("load"),
+            "stress_component": comp_map.get("stress"),
+            "resting_hr_component": comp_map.get("rhr"),
+        }
 
     return results
 

--- a/tests/test_metrics_compute.py
+++ b/tests/test_metrics_compute.py
@@ -271,9 +271,41 @@ class TestComputeReadinessScore:
         assert r["score"] == 85
         assert r["zone"] == "prime"
         assert r["source"] == "garmin_native"
-        # Native path leaves component columns null
-        assert r["hrv_component"] is None
-        assert r["sleep_quantity_component"] is None
+        # Native path preserves component columns computed from raw signals.
+        assert r["sleep_quantity_component"] == 80
+        assert r["training_load_component"] == 70
+        assert r["stress_component"] == 75
+
+    def test_garmin_native_preserves_components_with_history(self, metrics_compute):
+        """Native readiness keeps computed component values when raw signals exist."""
+        rows = []
+        for i in range(7):
+            rows.append({
+                "date": f"2025-01-{i + 1:02d}",
+                "hrv": 60,
+                "sleep_score": 80,
+                "stress_score": 25,
+                "resting_hr": 55,
+                "body_battery_end": 70,
+                "garmin_training_readiness": 21 if i == 6 else None,
+                "garmin_training_readiness_level": "LOW" if i == 6 else None,
+                "spo2": None,
+                "respiration_rate": None,
+                "skin_temp": None,
+            })
+
+        cur = _make_mock_cur(rows)
+        result = metrics_compute.compute_readiness_score(cur, "user-1")
+        r = result["2025-01-07"]
+
+        assert r["score"] == 21
+        assert r["zone"] == "low"
+        assert r["source"] == "garmin_native"
+        assert r["hrv_component"] is not None
+        assert r["sleep_quantity_component"] is not None
+        assert r["training_load_component"] is not None
+        assert r["stress_component"] is not None
+        assert r["resting_hr_component"] is not None
 
     def test_buchheit_composite_when_native_absent(self, metrics_compute):
         """Composite path: sleep + body battery + stress drive the score."""


### PR DESCRIPTION
Closes screenshot QA finding **P0-1** (companion to app PR askb/ha-garmin-fitness-coach-app#120).

## Root cause

`compute_readiness_score` in `metrics-compute.py` was clobbering the dedicated component columns (`hrv_component`, `sleep_quantity_component`, `training_load_component`, `stress_component`, `resting_hr_component`) with NULL whenever Garmin Connect returned a native training-readiness value. The home page metric tiles read those columns and fell back to em-dash even when raw signals were present.

Live DB query on user's HAOS confirmed today's row:
```
score=21, zone=low, source=garmin_native
hrv_component=NULL, sleep_quantity_component=NULL, ...
factors='{"hrv": 92.9, "stress": 44.8, "sleepQuantity": 15.8, ...}'
```

The `factors` JSONB had the values; the dedicated columns did not.

## Fix

Refactor so the composite-component math (HRV ratio, sleep score, body battery for load, RHR ratio, inverted stress, plus vitals SpO2 / RR / skin-temp) ALWAYS runs. Garmin's native value only overrides final `score` / `zone` / `explanation` (and sets `source = 'garmin_native'`).

## Verification

- `pytest tests/test_metrics_compute.py` — 26 passed
- New regression: `test_garmin_native_preserves_components_with_history` asserts non-None components when native readiness is used alongside raw signals.

Part of the v0.16.19 screenshot QA sweep (2026-05-16).