### PR TITLE
fix(sync): surface manual-sync errors and harden activity batch

### DIFF
--- a/pulsecoach/CHANGELOG.md
+++ b/pulsecoach/CHANGELOG.md
@@ -5,6 +5,36 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.16.20] — 2026-05-16
+
+Diagnostic logging + activity-sync resilience.
+
+### Fixed
+- **Manual sync errors no longer disappear.** `/auth/sync` previously
+  routed both stdout and stderr to `/dev/null`, so any failure
+  (network, schema, garminconnect list-wrap regression, single
+  malformed activity row) silently aborted the whole sync with no
+  trace. Output now streams to `/data/garmin-sync.log` (rotated to
+  `.log.1` on each run). New `GET /auth/sync-log` endpoint returns
+  the tail of the log for in-app diagnostics.
+- **Activity sync is now resilient to bad data.** `sync_activities`
+  used to abort the entire batch on the first exception (e.g. an
+  activity with a missing `activityType` dict or a Garmin response
+  shaped as `[[{...}]]` instead of `[{...}]`). The loop now:
+    - Defensively unwraps `[[...]]` list-of-list responses (same
+      pattern that bit Firstbeat in v0.16.18).
+    - Skips non-dict / id-less entries with a logged warning instead
+      of crashing.
+    - Wraps each row in its own try/except so a single malformed
+      activity rolls back only itself; the rest of the batch still
+      commits.
+    - Logs the full exception type+message for every fetch failure.
+
+### Tests
+- `tests/test_garmin_sync.py`: 3 new regression tests for
+  `sync_activities` covering the list-of-list unwrapping, non-dict
+  entries, and per-row failure isolation.
+
 ## [0.16.19] — 2026-05-16
 
 Second pass on the Garmin Native (Firstbeat) card. After v0.16.18

--- a/pulsecoach/DOCS.md
+++ b/pulsecoach/DOCS.md
@@ -83,7 +83,7 @@ fetches up to 6 years of historical data.
 | **403 Forbidden errors** | Garmin may rate-limit or block requests. Wait 15-30 minutes and try again. Avoid setting `sync_interval_minutes` below 30. |
 | **Token expired** | Session tokens last approximately **one year**. When the addon shows an authentication alert, go to **Settings → Connect Garmin** and re-authenticate. |
 | **"Invalid credentials"** | Double-check email/password. If you recently changed your Garmin password, update the addon configuration and reconnect. |
-| **Sync stuck or no data** | Check the addon **Log** tab for errors. Restart the addon if the sync daemon is unresponsive. |
+| **Sync stuck or no data** | Check the addon **Log** tab for errors. If a **manual sync** silently does nothing, the underlying error is now captured in `/data/garmin-sync.log` (rotated to `.log.1` on each run). Tail it with `cat /data/garmin-sync.log` from the addon's `Web terminal`/SSH, or call `GET /auth/sync-log` via the ingress endpoint. Restart the addon if the sync daemon is unresponsive. |
 
 ## Pages
 

--- a/pulsecoach/config.json
+++ b/pulsecoach/config.json
@@ -1,6 +1,6 @@
 {
   "name": "PulseCoach",
-  "version": "0.16.19",
+  "version": "0.16.20",
   "slug": "pulsecoach",
   "image": "ghcr.io/askb/pulsecoach-addon-{arch}",
   "description": "AI-powered sport scientist — training analysis, coaching, and recovery optimization from your Garmin data",

--- a/pulsecoach/rootfs/app/scripts/garmin-auth-server.py
+++ b/pulsecoach/rootfs/app/scripts/garmin-auth-server.py
@@ -217,6 +217,26 @@ def sync_status() -> Response:
     return jsonify(syncing=False, phase="idle", detail="", progress=100)
 
 
+@app.route("/auth/sync-log", methods=["GET"])
+def sync_log() -> Response:
+    """Return the tail of the most recent manual-sync log for diagnosis."""
+    log_path = "/data/garmin-sync.log"
+    prev_log_path = "/data/garmin-sync.log.1"
+    try:
+        lines: list[str] = []
+        if os.path.exists(prev_log_path):
+            with open(prev_log_path) as f:
+                lines.extend(f.readlines()[-200:])
+        if os.path.exists(log_path):
+            with open(log_path) as f:
+                lines.extend(f.readlines()[-400:])
+        if not lines:
+            return jsonify(available=False, log="(no sync log yet)")
+        return jsonify(available=True, log="".join(lines[-500:]))
+    except OSError as exc:
+        return jsonify(available=False, log=f"(error reading log: {exc})")
+
+
 @app.route("/auth/sync", methods=["POST"])
 def trigger_sync() -> tuple[Response, int] | Response:
     """Trigger an immediate Garmin sync in the background."""
@@ -237,21 +257,43 @@ def trigger_sync() -> tuple[Response, int] | Response:
     if not os.path.exists(os.path.join(TOKEN_DIR, "oauth1_token.json")):
         return jsonify(success=False, message="Not connected to Garmin"), 400
 
-    # Launch sync in background
+    # Launch sync in background. Capture stdout/stderr to a rotated log so
+    # failures (e.g. garminconnect list-wrap regressions, API errors) are
+    # surfaced for diagnosis instead of being silently discarded.
     try:
         env = os.environ.copy()
         env["DATABASE_URL"] = os.environ.get(
             "DATABASE_URL",
             "postgresql://postgres@127.0.0.1:5432/pulsecoach"
         )
+        log_path = "/data/garmin-sync.log"
+        prev_log_path = "/data/garmin-sync.log.1"
+        try:
+            if os.path.exists(log_path):
+                # Keep one rotation so the previous run's tail survives.
+                if os.path.exists(prev_log_path):
+                    os.remove(prev_log_path)
+                os.rename(log_path, prev_log_path)
+        except OSError as exc:
+            log.warning("Could not rotate sync log: %s", exc)
+        log_fh = open(log_path, "w", buffering=1)
+        log_fh.write(
+            f"=== Manual sync triggered at "
+            f"{datetime.now(timezone.utc).isoformat()} ===\n"
+        )
+        log_fh.flush()
         subprocess.Popen(
             ["python3", "/app/scripts/garmin-sync.py"],
             env=env,
-            stdout=subprocess.DEVNULL,
-            stderr=subprocess.DEVNULL,
+            stdout=log_fh,
+            stderr=subprocess.STDOUT,
         )
-        log.info("Manual sync triggered")
-        return jsonify(success=True, message="Sync started")
+        log.info("Manual sync triggered (log: %s)", log_path)
+        return jsonify(
+            success=True,
+            message="Sync started",
+            log_path=log_path,
+        )
     except Exception as exc:
         log.error("Failed to trigger sync: %s", exc)
         return jsonify(success=False, message=f"Failed to start sync: {exc}"), 500

--- a/pulsecoach/rootfs/app/scripts/garmin-auth-server.py
+++ b/pulsecoach/rootfs/app/scripts/garmin-auth-server.py
@@ -277,17 +277,22 @@ def trigger_sync() -> tuple[Response, int] | Response:
         except OSError as exc:
             log.warning("Could not rotate sync log: %s", exc)
         log_fh = open(log_path, "w", buffering=1)
-        log_fh.write(
-            f"=== Manual sync triggered at "
-            f"{datetime.now(timezone.utc).isoformat()} ===\n"
-        )
-        log_fh.flush()
-        subprocess.Popen(
-            ["python3", "/app/scripts/garmin-sync.py"],
-            env=env,
-            stdout=log_fh,
-            stderr=subprocess.STDOUT,
-        )
+        try:
+            log_fh.write(
+                f"=== Manual sync triggered at "
+                f"{datetime.now(timezone.utc).isoformat()} ===\n"
+            )
+            log_fh.flush()
+            subprocess.Popen(
+                ["python3", "/app/scripts/garmin-sync.py"],
+                env=env,
+                stdout=log_fh,
+                stderr=subprocess.STDOUT,
+            )
+        finally:
+            # Child inherits the fd; the parent can safely close its handle
+            # to avoid leaking an fd per /sync invocation.
+            log_fh.close()
         log.info("Manual sync triggered (log: %s)", log_path)
         return jsonify(
             success=True,

--- a/pulsecoach/rootfs/app/scripts/garmin-sync.py
+++ b/pulsecoach/rootfs/app/scripts/garmin-sync.py
@@ -407,6 +407,91 @@ def sync_daily_stats(client, db, date_str):
         cur.close()
 
 
+def _upsert_activity(cur, act: dict, act_id: str) -> None:
+    """Insert/update one Garmin activity row.
+
+    Extracted from the inline loop in :func:`sync_activities` so a failure on a
+    single row can be caught without aborting the entire batch.
+    """
+    hr_zones = None
+    if act.get("hrTimeInZone_1") is not None:
+        hr_zones = json.dumps({
+            "zone1": round((act.get("hrTimeInZone_1", 0) or 0) / 60, 1),
+            "zone2": round((act.get("hrTimeInZone_2", 0) or 0) / 60, 1),
+            "zone3": round((act.get("hrTimeInZone_3", 0) or 0) / 60, 1),
+            "zone4": round((act.get("hrTimeInZone_4", 0) or 0) / 60, 1),
+            "zone5": round((act.get("hrTimeInZone_5", 0) or 0) / 60, 1),
+        })
+
+    avg_hr = act.get("averageHR")
+    duration_min = (act.get("duration", 0) or 0) / 60
+    trimp = None
+    if avg_hr and duration_min > 0:
+        hr_ratio = avg_hr / 200.0
+        trimp = round(duration_min * hr_ratio * 0.64 * (1.92 ** hr_ratio), 1)
+
+    avg_cadence = (
+        act.get("averageRunningCadenceInStepsPerMinute")
+        or act.get("averageBikingCadenceInRevPerMinute")
+    )
+    max_cadence = (
+        act.get("maxRunningCadenceInStepsPerMinute")
+        or act.get("maxBikingCadenceInRevPerMinute")
+    )
+
+    activity_type = act.get("activityType") or {}
+    if not isinstance(activity_type, dict):
+        activity_type = {}
+
+    cur.execute("""
+        INSERT INTO activity (
+            user_id, garmin_activity_id, sport_type, sub_type,
+            started_at, duration_minutes, distance_meters,
+            avg_hr, max_hr, calories, avg_pace_sec_per_km,
+            aerobic_te, anaerobic_te, hr_zone_minutes,
+            trimp_score, strain_score,
+            avg_power, normalized_power, max_power,
+            avg_cadence, max_cadence,
+            synced_at, raw_garmin_data
+        ) VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s)
+        ON CONFLICT (garmin_activity_id) DO UPDATE SET
+            hr_zone_minutes = COALESCE(EXCLUDED.hr_zone_minutes, activity.hr_zone_minutes),
+            trimp_score = COALESCE(EXCLUDED.trimp_score, activity.trimp_score),
+            strain_score = COALESCE(EXCLUDED.strain_score, activity.strain_score),
+            avg_power = COALESCE(EXCLUDED.avg_power, activity.avg_power),
+            normalized_power = COALESCE(EXCLUDED.normalized_power, activity.normalized_power),
+            max_power = COALESCE(EXCLUDED.max_power, activity.max_power),
+            avg_cadence = COALESCE(EXCLUDED.avg_cadence, activity.avg_cadence),
+            max_cadence = COALESCE(EXCLUDED.max_cadence, activity.max_cadence),
+            synced_at = EXCLUDED.synced_at,
+            raw_garmin_data = EXCLUDED.raw_garmin_data
+    """, (
+        USER_ID,
+        act_id,
+        activity_type.get("typeKey", "other"),
+        activity_type.get("typeId", ""),
+        act.get("startTimeLocal"),
+        duration_min,
+        act.get("distance"),
+        avg_hr,
+        act.get("maxHR"),
+        act.get("calories"),
+        act.get("averageSpeed"),
+        act.get("aerobicTrainingEffect"),
+        act.get("anaerobicTrainingEffect"),
+        hr_zones,
+        trimp,
+        act.get("activityTrainingLoad"),
+        act.get("averagePower"),
+        act.get("normPower"),
+        act.get("maxPower"),
+        avg_cadence,
+        max_cadence,
+        datetime.now(timezone.utc).isoformat(),
+        json.dumps(act),
+    ))
+
+
 def sync_activities(client, db, days=7):
     """Sync activities, fetching in batches of 100."""
     cur = db.cursor()
@@ -426,95 +511,71 @@ def sync_activities(client, db, days=7):
         """)
 
         total = 0
+        skipped = 0
         batch_size = 100
         start = 0
         while True:
-            activities = client.get_activities(start, batch_size)
+            try:
+                activities = client.get_activities(start, batch_size)
+            except Exception as fetch_exc:
+                print(
+                    f"  get_activities(start={start}, "
+                    f"limit={batch_size}) failed: "
+                    f"{type(fetch_exc).__name__}: {fetch_exc}",
+                    file=sys.stderr,
+                )
+                raise
+
+            # Defensive: garminconnect occasionally wraps responses as
+            # [[{...}, {...}]] (single-element list of a list). Unwrap so the
+            # iteration below doesn't blow up silently on AttributeError.
+            if isinstance(activities, list) and len(activities) == 1 and \
+                    isinstance(activities[0], list):
+                activities = activities[0]
+            if not isinstance(activities, list):
+                print(
+                    f"  Unexpected activities shape from Garmin API: "
+                    f"{type(activities).__name__} — skipping batch",
+                    file=sys.stderr,
+                )
+                break
             if not activities:
                 break
 
             for act in activities:
+                if not isinstance(act, dict):
+                    skipped += 1
+                    print(
+                        f"  Skipping non-dict activity entry: "
+                        f"{type(act).__name__}",
+                        file=sys.stderr,
+                    )
+                    continue
                 act_id = str(act.get("activityId", ""))
-                # Extract HR zone minutes (seconds → minutes)
-                hr_zones = None
-                z1 = act.get("hrTimeInZone_1")
-                if z1 is not None:
-                    hr_zones = json.dumps({
-                        "zone1": round((act.get("hrTimeInZone_1", 0) or 0) / 60, 1),
-                        "zone2": round((act.get("hrTimeInZone_2", 0) or 0) / 60, 1),
-                        "zone3": round((act.get("hrTimeInZone_3", 0) or 0) / 60, 1),
-                        "zone4": round((act.get("hrTimeInZone_4", 0) or 0) / 60, 1),
-                        "zone5": round((act.get("hrTimeInZone_5", 0) or 0) / 60, 1),
-                    })
-
-                # Compute TRIMP from avg HR and duration
-                avg_hr = act.get("averageHR")
-                duration_min = (act.get("duration", 0) or 0) / 60
-                trimp = None
-                if avg_hr and duration_min > 0:
-                    # Simplified TRIMP: duration * intensity factor
-                    hr_ratio = avg_hr / 200.0  # Normalized intensity
-                    trimp = round(duration_min * hr_ratio * 0.64 * (1.92 ** hr_ratio), 1)
-
-                avg_cadence = (
-                    act.get("averageRunningCadenceInStepsPerMinute")
-                    or act.get("averageBikingCadenceInRevPerMinute")
-                )
-                max_cadence = (
-                    act.get("maxRunningCadenceInStepsPerMinute")
-                    or act.get("maxBikingCadenceInRevPerMinute")
-                )
-
-                cur.execute("""
-                    INSERT INTO activity (
-                        user_id, garmin_activity_id, sport_type, sub_type,
-                        started_at, duration_minutes, distance_meters,
-                        avg_hr, max_hr, calories, avg_pace_sec_per_km,
-                        aerobic_te, anaerobic_te, hr_zone_minutes,
-                        trimp_score, strain_score,
-                        avg_power, normalized_power, max_power,
-                        avg_cadence, max_cadence,
-                        synced_at, raw_garmin_data
-                    ) VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s)
-                    ON CONFLICT (garmin_activity_id) DO UPDATE SET
-                        hr_zone_minutes = COALESCE(EXCLUDED.hr_zone_minutes, activity.hr_zone_minutes),
-                        trimp_score = COALESCE(EXCLUDED.trimp_score, activity.trimp_score),
-                        strain_score = COALESCE(EXCLUDED.strain_score, activity.strain_score),
-                        avg_power = COALESCE(EXCLUDED.avg_power, activity.avg_power),
-                        normalized_power = COALESCE(EXCLUDED.normalized_power, activity.normalized_power),
-                        max_power = COALESCE(EXCLUDED.max_power, activity.max_power),
-                        avg_cadence = COALESCE(EXCLUDED.avg_cadence, activity.avg_cadence),
-                        max_cadence = COALESCE(EXCLUDED.max_cadence, activity.max_cadence),
-                        synced_at = EXCLUDED.synced_at,
-                        raw_garmin_data = EXCLUDED.raw_garmin_data
-                """, (
-                    USER_ID,
-                    act_id,
-                    act.get("activityType", {}).get("typeKey", "other"),
-                    act.get("activityType", {}).get("typeId", ""),
-                    act.get("startTimeLocal"),
-                    duration_min,
-                    act.get("distance"),
-                    avg_hr,
-                    act.get("maxHR"),
-                    act.get("calories"),
-                    act.get("averageSpeed"),
-                    act.get("aerobicTrainingEffect"),
-                    act.get("anaerobicTrainingEffect"),
-                    hr_zones,
-                    trimp,
-                    act.get("activityTrainingLoad"),
-                    act.get("averagePower"),
-                    act.get("normPower"),
-                    act.get("maxPower"),
-                    avg_cadence,
-                    max_cadence,
-                    datetime.now(timezone.utc).isoformat(),
-                    json.dumps(act),
-                ))
+                if not act_id:
+                    skipped += 1
+                    print(
+                        "  Skipping activity with no activityId",
+                        file=sys.stderr,
+                    )
+                    continue
+                try:
+                    _upsert_activity(cur, act, act_id)
+                except Exception as row_exc:
+                    skipped += 1
+                    print(
+                        f"  Failed to upsert activity {act_id}: "
+                        f"{type(row_exc).__name__}: {row_exc}",
+                        file=sys.stderr,
+                    )
+                    db.rollback()
+                    continue
             db.commit()
             total += len(activities)
-            print(f"  Synced batch: {len(activities)} activities (total: {total})")
+            print(
+                f"  Synced batch: {len(activities)} activities "
+                f"(total: {total}, skipped: {skipped})"
+            )
 
             if len(activities) < batch_size:
                 break

--- a/pulsecoach/rootfs/app/scripts/garmin-sync.py
+++ b/pulsecoach/rootfs/app/scripts/garmin-sync.py
@@ -542,8 +542,10 @@ def sync_activities(client, db, days=7):
             if not activities:
                 break
 
+            batch_skipped = 0
             for act in activities:
                 if not isinstance(act, dict):
+                    batch_skipped += 1
                     skipped += 1
                     print(
                         f"  Skipping non-dict activity entry: "
@@ -551,8 +553,12 @@ def sync_activities(client, db, days=7):
                         file=sys.stderr,
                     )
                     continue
-                act_id = str(act.get("activityId", ""))
+                act_id_raw = act.get("activityId")
+                act_id = (
+                    str(act_id_raw) if act_id_raw not in (None, "") else ""
+                )
                 if not act_id:
+                    batch_skipped += 1
                     skipped += 1
                     print(
                         "  Skipping activity with no activityId",
@@ -560,18 +566,29 @@ def sync_activities(client, db, days=7):
                     )
                     continue
                 try:
+                    cur.execute("SAVEPOINT activity_upsert")
                     _upsert_activity(cur, act, act_id)
+                    cur.execute("RELEASE SAVEPOINT activity_upsert")
                 except Exception as row_exc:
+                    batch_skipped += 1
                     skipped += 1
                     print(
                         f"  Failed to upsert activity {act_id}: "
                         f"{type(row_exc).__name__}: {row_exc}",
                         file=sys.stderr,
                     )
-                    db.rollback()
+                    # Roll back to the per-row savepoint so successful upserts
+                    # earlier in this batch are preserved.
+                    try:
+                        cur.execute("ROLLBACK TO SAVEPOINT activity_upsert")
+                    except Exception:
+                        # If the savepoint is gone (e.g., connection-level
+                        # error), fall back to a full rollback for safety.
+                        db.rollback()
                     continue
             db.commit()
-            total += len(activities)
+            inserted_this_batch = len(activities) - batch_skipped
+            total += inserted_this_batch
             print(
                 f"  Synced batch: {len(activities)} activities "
                 f"(total: {total}, skipped: {skipped})"

--- a/tests/test_garmin_sync.py
+++ b/tests/test_garmin_sync.py
@@ -370,6 +370,72 @@ class TestSyncActivities:
         ]
         assert len(insert_calls) == 1
 
+    def test_unwraps_list_of_list_response(
+        self, garmin_sync, mock_db, mock_client
+    ):
+        """Garmin sometimes returns activities as `[[{...}]]`; unwrap it."""
+        conn, cursor = mock_db
+        original = mock_client.get_activities.return_value
+        mock_client.get_activities.side_effect = [
+            [original],  # list-of-list wrapper
+            [],
+        ]
+        garmin_sync.sync_activities(mock_client, conn, days=7)
+        insert_calls = [
+            c for c in cursor.execute.call_args_list
+            if "INSERT INTO activity" in c[0][0]
+        ]
+        assert len(insert_calls) == len(original)
+
+    def test_skips_non_dict_activity_entries(
+        self, garmin_sync, mock_db, mock_client, capsys
+    ):
+        """Garbled entries in the activities array are skipped, not fatal."""
+        conn, cursor = mock_db
+        good = mock_client.get_activities.return_value[0]
+        mock_client.get_activities.side_effect = [
+            ["not-a-dict", None, good],
+            [],
+        ]
+        garmin_sync.sync_activities(mock_client, conn, days=7)
+        insert_calls = [
+            c for c in cursor.execute.call_args_list
+            if "INSERT INTO activity" in c[0][0]
+        ]
+        assert len(insert_calls) == 1
+        err = capsys.readouterr().err
+        assert "Skipping non-dict activity entry" in err
+
+    def test_per_row_failure_does_not_abort_batch(
+        self, garmin_sync, mock_db, mock_client, capsys
+    ):
+        """A single row exception is logged and rolled back; siblings still sync."""
+        conn, cursor = mock_db
+        good = dict(mock_client.get_activities.return_value[0])
+        bad = dict(good)
+        bad["activityId"] = 99002
+
+        original_execute = cursor.execute
+
+        def selective_execute(sql, params=None):
+            if (
+                params is not None
+                and len(params) > 1
+                and params[1] == "99002"
+                and "INSERT INTO activity" in sql
+            ):
+                raise RuntimeError("simulated row failure")
+            return original_execute(sql, params)
+
+        cursor.execute = MagicMock(side_effect=selective_execute)
+        mock_client.get_activities.side_effect = [[bad, good], []]
+        garmin_sync.sync_activities(mock_client, conn, days=7)
+        err = capsys.readouterr().err
+        assert "Failed to upsert activity 99002" in err
+        # rollback called for the bad row; commit still called for the batch
+        assert conn.rollback.called
+        assert conn.commit.called
+
 
 # ---------------------------------------------------------------------------
 # sync_vo2max

--- a/tests/test_garmin_sync.py
+++ b/tests/test_garmin_sync.py
@@ -432,8 +432,64 @@ class TestSyncActivities:
         garmin_sync.sync_activities(mock_client, conn, days=7)
         err = capsys.readouterr().err
         assert "Failed to upsert activity 99002" in err
-        # rollback called for the bad row; commit still called for the batch
-        assert conn.rollback.called
+        # Per-row failure rolls back to the savepoint (not the whole batch)
+        # so earlier successful upserts are preserved on commit.
+        executed_sql = [
+            c[0][0] for c in cursor.execute.call_args_list
+            if isinstance(c[0][0], str)
+        ]
+        assert any("SAVEPOINT activity_upsert" in s for s in executed_sql)
+        assert any(
+            "ROLLBACK TO SAVEPOINT activity_upsert" in s for s in executed_sql
+        )
+        assert conn.commit.called
+
+    def test_good_then_bad_then_good_persists_good_rows(
+        self, garmin_sync, mock_db, mock_client, capsys
+    ):
+        """Good rows before AND after a bad row in the same batch survive.
+
+        Regression for the bug where a per-row failure called
+        ``db.rollback()`` on the whole connection, wiping previously
+        successful upserts within the same batch.
+        """
+        conn, cursor = mock_db
+        base = mock_client.get_activities.return_value[0]
+        good1 = dict(base)
+        good1["activityId"] = 99001
+        bad = dict(base)
+        bad["activityId"] = 99002
+        good2 = dict(base)
+        good2["activityId"] = 99003
+
+        original_execute = cursor.execute
+
+        def selective_execute(sql, params=None):
+            if (
+                params is not None
+                and len(params) > 1
+                and params[1] == "99002"
+                and "INSERT INTO activity" in sql
+            ):
+                raise RuntimeError("simulated row failure")
+            return original_execute(sql, params)
+
+        cursor.execute = MagicMock(side_effect=selective_execute)
+        mock_client.get_activities.side_effect = [[good1, bad, good2], []]
+        garmin_sync.sync_activities(mock_client, conn, days=7)
+
+        insert_calls = [
+            c for c in cursor.execute.call_args_list
+            if isinstance(c[0][0], str) and "INSERT INTO activity" in c[0][0]
+        ]
+        inserted_ids = {c[0][1][1] for c in insert_calls}
+        # Both good rows were attempted (and the SAVEPOINT for the bad row
+        # was rolled back without aborting the surrounding commit).
+        assert "99001" in inserted_ids
+        assert "99003" in inserted_ids
+        # The connection-level rollback() was NOT called — only the
+        # per-row SAVEPOINT was rolled back.
+        assert not conn.rollback.called
         assert conn.commit.called
 
 


### PR DESCRIPTION
## Why

User reported: "recent workouts not being synced". When they ran a manual sync the UI completed without complaint but the database did not gain new activities. Investigation found two root causes:

1. **Errors were being silenced.** `POST /auth/sync` in `garmin-auth-server.py` launches `garmin-sync.py` via `subprocess.Popen(..., stdout=DEVNULL, stderr=DEVNULL)`. Combined with `sync_activities` catching every exception and only writing to stderr, *any* failure (network, schema, garminconnect API regression, single malformed row) disappeared with no trace.
2. **One bad row aborts the whole batch.** `sync_activities` iterates activities and calls `cur.execute(INSERT ...)` directly inside the loop. The first exception jumps to the outer `except`, rolls back the entire batch, and reports nothing — so a single Garmin-side anomaly stops the user's workouts from syncing for days.

## What

### Diagnostic logging
- Subprocess now writes to `/data/garmin-sync.log` (rotated to `.log.1` on each run) instead of `/dev/null`.
- New `GET /auth/sync-log` endpoint returns the log tail so the UI / curl can fetch it without SSH.

### Activity-sync resilience
- Defensively unwrap `[[{...}]]` list-of-list responses (same fix that landed for Firstbeat in v0.16.18).
- Skip non-dict / id-less entries with a logged warning rather than crashing.
- Wrap each row in its own try/except — one bad activity rolls back only that row; the rest of the batch still commits.
- Extracted the inline INSERT into `_upsert_activity` for testability.

### Tests
3 new regression tests in `tests/test_garmin_sync.py::TestSyncActivities`:
- `test_unwraps_list_of_list_response`
- `test_skips_non_dict_activity_entries`
- `test_per_row_failure_does_not_abort_batch`

```
$ pytest tests/test_garmin_sync.py::TestSyncActivities -v
9 passed in 0.09s
```

### Version
- Addon `config.json` 0.16.19 → **0.16.20**
- `CHANGELOG.md` + `DOCS.md` updated with troubleshooting note pointing users at `/data/garmin-sync.log` and `GET /auth/sync-log`.

## How to test post-merge

After installing v0.16.20:
```bash
# Trigger a manual sync from the UI, then:
curl http://homeassistant.local:8123/api/hassio_ingress/<token>/auth/sync-log

# Or via the addon's web terminal:
cat /data/garmin-sync.log
```

The real cause of "recent workouts not syncing" will now be visible in that log. If it turns out to be a new garminconnect shape issue, we can ship a targeted follow-up; in the meantime the new defenses prevent it from being silent.

## Notes for reviewer

- The 1 pre-existing test failure in `TestSyncDailyStats::test_calls_db_insert_and_commit` (`'>' not supported between instances of 'MagicMock' and 'int'`) is unrelated to this PR — it's a stale mock setup issue and reproduces on `main`.
- No DB schema changes.