### PR TITLE
ci(release): grant SBOM job contents:write for release asset upload

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -110,7 +110,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: build-push
     permissions:
-      contents: read
+      contents: write
       packages: read
     timeout-minutes: 15
     steps:


### PR DESCRIPTION
## Summary

The `SBOM & Security Scan` job in `.github/workflows/release.yaml` was failing on tag pushes with:

```
Resource not accessible by integration
```

Root cause: `anchore/sbom-action@v0` auto-attaches the generated SBOM to the GitHub Release as a release asset when the workflow is triggered by a tag push. That upload requires `contents: write` on the job — but the job was scoped to `contents: read`.

## Fix

One-line permission change on the `sbom-scan` job: `contents: read` → `contents: write`. No other behaviour change; image-login + SBOM generation already worked, only the release-asset attachment was failing.

## Verification

After merge, the next release tag push (or a manual re-run of the v0.16.20 workflow) should complete the SBOM upload successfully.

Co-authored-by: Claude <claude@anthropic.com>