### PR TITLE
fix(sync): stamp activity.started_at as UTC from startTimeGMT

### DIFF
--- a/pulsecoach/rootfs/app/scripts/garmin-sync.py
+++ b/pulsecoach/rootfs/app/scripts/garmin-sync.py
@@ -13,6 +13,7 @@ Supports two auth modes:
 import json
 import math
 import os
+import re
 import sys
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
@@ -435,9 +436,16 @@ def _normalize_started_at(act: dict) -> str | None:
     """
     gmt = act.get("startTimeGMT")
     if isinstance(gmt, str) and gmt.strip():
-        # Garmin returns "YYYY-MM-DD HH:MM:SS" with no offset.
-        # Avoid double-stamping if a future Garmin build ever includes one.
-        return gmt if ("+" in gmt or gmt.endswith("Z")) else f"{gmt}+00:00"
+        # Garmin currently returns "YYYY-MM-DD HH:MM:SS" with no offset.
+        # Defensively detect a trailing offset / 'Z' so we never
+        # double-stamp if a future Garmin build adds one. Match both
+        # positive and negative offsets in the trailing tz-suffix
+        # position (can't just look for '-' because the date contains
+        # '-' separators).
+        s = gmt.rstrip()
+        if s.endswith("Z") or re.search(r"[+-]\d{2}:?\d{2}$", s):
+            return s
+        return f"{s}+00:00"
     local = act.get("startTimeLocal")
     return local if isinstance(local, str) else None
 

--- a/pulsecoach/rootfs/app/scripts/garmin-sync.py
+++ b/pulsecoach/rootfs/app/scripts/garmin-sync.py
@@ -407,6 +407,41 @@ def sync_daily_stats(client, db, date_str):
         cur.close()
 
 
+def _normalize_started_at(act: dict) -> str | None:
+    """Resolve an Activity's start time as an unambiguous UTC instant.
+
+    Garmin's activity payload contains two start-time fields:
+
+    * ``startTimeGMT`` — the real UTC instant of the activity, formatted
+      as a TZ-naive string (e.g. ``"2026-05-17 09:00:00"``).
+    * ``startTimeLocal`` — the same moment expressed in the watch's local
+      time, also TZ-naive.
+
+    Previously we stored ``startTimeLocal`` directly into a ``timestamptz``
+    column. Postgres applies the session's ``TimeZone`` setting to a
+    TZ-naive literal, so on a UTC-default Postgres the local string was
+    *re-interpreted* as UTC. For any user east of UTC this shifted
+    morning activities into the future and they were then filtered out
+    by ``lte(Activity.startedAt, new Date())`` in the app layer — the
+    "missing recent workouts" bug. See
+    https://github.com/askb/ha-garmin-fitness-coach-addon/issues
+    for context.
+
+    Stamp ``startTimeGMT`` with an explicit ``+00:00`` so Postgres always
+    treats it as UTC regardless of session TZ. Fall back to
+    ``startTimeLocal`` only if ``startTimeGMT`` is missing (older Garmin
+    activities occasionally lack it); the legacy behaviour is preserved
+    as a last resort.
+    """
+    gmt = act.get("startTimeGMT")
+    if isinstance(gmt, str) and gmt.strip():
+        # Garmin returns "YYYY-MM-DD HH:MM:SS" with no offset.
+        # Avoid double-stamping if a future Garmin build ever includes one.
+        return gmt if ("+" in gmt or gmt.endswith("Z")) else f"{gmt}+00:00"
+    local = act.get("startTimeLocal")
+    return local if isinstance(local, str) else None
+
+
 def _upsert_activity(cur, act: dict, act_id: str) -> None:
     """Insert/update one Garmin activity row.
 
@@ -470,7 +505,7 @@ def _upsert_activity(cur, act: dict, act_id: str) -> None:
         act_id,
         activity_type.get("typeKey", "other"),
         activity_type.get("typeId", ""),
-        act.get("startTimeLocal"),
+        _normalize_started_at(act),
         duration_min,
         act.get("distance"),
         avg_hr,
@@ -606,6 +641,69 @@ def sync_activities(client, db, days=7):
     except Exception as e:
         db.rollback()
         print(f"  Failed to sync activities: {e}", file=sys.stderr)
+    finally:
+        cur.close()
+
+
+def backfill_activity_started_at_utc(db):
+    """One-time migration: re-stamp Activity.started_at using startTimeGMT.
+
+    Earlier sync code stored ``startTimeLocal`` (TZ-naive) into a
+    ``timestamptz`` column. Postgres interpreted the literal in the
+    session's TimeZone (UTC by default for the HA Postgres base
+    image), so morning activities for users east of UTC ended up
+    timestamped in the *future* and were filtered out of the home
+    page by ``lte(Activity.startedAt, new Date())``.
+
+    Re-derive every row's start instant from ``raw_garmin_data->>
+    'startTimeGMT'`` (always the true UTC moment) and stamp it
+    explicitly with ``+00:00``. Idempotent: rows that already match
+    the GMT field are left untouched.
+
+    Guarded by a marker file in ``TOKEN_DIR`` so the migration only
+    runs once per install. Set ``PULSECOACH_REBACKFILL_STARTED_AT=1``
+    to force a re-run (useful for support / testing).
+    """
+    marker = os.path.join(TOKEN_DIR, ".activity_started_at_utc_backfill_done")
+    if os.path.exists(marker) and not os.environ.get(
+            "PULSECOACH_REBACKFILL_STARTED_AT"):
+        return
+
+    cur = db.cursor()
+    try:
+        cur.execute(
+            """
+            UPDATE activity SET
+                started_at = ((raw_garmin_data->>'startTimeGMT') || '+00:00')::timestamptz
+            WHERE user_id = %s
+              AND raw_garmin_data IS NOT NULL
+              AND raw_garmin_data ? 'startTimeGMT'
+              AND (raw_garmin_data->>'startTimeGMT') ~ '^[0-9]{4}-[0-9]{2}-[0-9]{2} [0-9]{2}:[0-9]{2}:[0-9]{2}$'
+              AND started_at <> ((raw_garmin_data->>'startTimeGMT') || '+00:00')::timestamptz
+            """,
+            (USER_ID,),
+        )
+        updated = cur.rowcount
+        db.commit()
+        if updated:
+            print(
+                f"  Re-stamped {updated} activities to UTC from "
+                f"raw_garmin_data.startTimeGMT (TZ-correctness backfill)"
+            )
+        try:
+            with open(marker, "w") as f:
+                f.write(datetime.now(timezone.utc).isoformat())
+        except OSError as e:
+            print(
+                f"  Warning: could not write backfill marker {marker}: {e}",
+                file=sys.stderr,
+            )
+    except Exception as e:
+        db.rollback()
+        print(
+            f"  Activity started_at UTC backfill failed: {e}",
+            file=sys.stderr,
+        )
     finally:
         cur.close()
 
@@ -1202,6 +1300,13 @@ def main():
     # Backfill computed fields from raw Garmin JSON
     _write_sync_status("backfill", "Computing zones & strain...", 80)
     backfill_from_raw_json(db)
+
+    # One-time: re-stamp activity.started_at from startTimeGMT so rows
+    # synced by older versions (which used startTimeLocal as a TZ-naive
+    # literal) get their true UTC instant. Guarded by a marker file so
+    # subsequent syncs are no-ops.
+    _write_sync_status("backfill_started_at", "Fixing activity timestamps...", 82)
+    backfill_activity_started_at_utc(db)
 
     _write_sync_status("backfill_stress", "Backfilling stress & sleep timing...", 85)
     backfill_stress_and_sleep(client, db)

--- a/tests/test_garmin_sync.py
+++ b/tests/test_garmin_sync.py
@@ -317,6 +317,23 @@ class TestNormalizeStartedAt:
         act = {"startTimeGMT": "2026-05-17T09:00:00Z"}
         assert garmin_sync._normalize_started_at(act) == "2026-05-17T09:00:00Z"
 
+    def test_does_not_double_stamp_when_negative_offset_present(self, garmin_sync):
+        # Defensive: a future Garmin build may emit a non-UTC offset.
+        # The trailing-offset detector must not be fooled by the '-'
+        # characters inside the date portion.
+        act = {"startTimeGMT": "2026-05-17 04:00:00-05:00"}
+        assert (
+            garmin_sync._normalize_started_at(act)
+            == "2026-05-17 04:00:00-05:00"
+        )
+
+    def test_does_not_double_stamp_when_compact_offset_present(self, garmin_sync):
+        act = {"startTimeGMT": "2026-05-17 04:00:00-0500"}
+        assert (
+            garmin_sync._normalize_started_at(act)
+            == "2026-05-17 04:00:00-0500"
+        )
+
     def test_blank_gmt_falls_back_to_local(self, garmin_sync):
         act = {
             "startTimeGMT": "   ",

--- a/tests/test_garmin_sync.py
+++ b/tests/test_garmin_sync.py
@@ -87,6 +87,7 @@ def mock_client():
             "activityId": 99001,
             "activityType": {"typeKey": "running", "typeId": "1"},
             "startTimeLocal": "2025-01-15 07:30:00",
+            "startTimeGMT": "2025-01-14 21:30:00",
             "duration": 1800.0,   # 30 min
             "distance": 5000.0,
             "averageHR": 150,
@@ -274,6 +275,57 @@ class TestSyncDailyStats:
 
 
 @pytest.mark.unit
+class TestNormalizeStartedAt:
+    """Tests for _normalize_started_at() — UTC-correctness regression.
+
+    Earlier sync code passed Garmin's ``startTimeLocal`` (a TZ-naive
+    string in the watch's local time) straight into a ``timestamptz``
+    column. Postgres re-interpreted the literal in the session's
+    TimeZone (UTC by default), so morning activities for users east
+    of UTC were timestamped in the future and were filtered out of
+    the home page by ``lte(Activity.startedAt, new Date())``. The
+    normalize helper must:
+
+    1. Prefer ``startTimeGMT``.
+    2. Stamp it with an explicit ``+00:00`` offset.
+    3. Fall back to ``startTimeLocal`` only when ``startTimeGMT`` is
+       absent.
+    """
+
+    def test_prefers_gmt_and_appends_utc_offset(self, garmin_sync):
+        act = {
+            "startTimeGMT": "2026-05-17 09:00:00",
+            "startTimeLocal": "2026-05-17 19:00:00",  # AEST same instant
+        }
+        assert garmin_sync._normalize_started_at(act) == "2026-05-17 09:00:00+00:00"
+
+    def test_falls_back_to_local_when_gmt_missing(self, garmin_sync):
+        act = {"startTimeLocal": "2026-05-17 19:00:00"}
+        # Legacy behaviour preserved when GMT is unavailable; we'd
+        # rather store *something* than NULL on these rare rows.
+        assert garmin_sync._normalize_started_at(act) == "2026-05-17 19:00:00"
+
+    def test_returns_none_when_both_missing(self, garmin_sync):
+        assert garmin_sync._normalize_started_at({}) is None
+
+    def test_does_not_double_stamp_when_offset_already_present(self, garmin_sync):
+        # Defensive: future Garmin client versions may include an offset.
+        act = {"startTimeGMT": "2026-05-17 09:00:00+00:00"}
+        assert garmin_sync._normalize_started_at(act) == "2026-05-17 09:00:00+00:00"
+
+    def test_does_not_double_stamp_when_z_suffix_present(self, garmin_sync):
+        act = {"startTimeGMT": "2026-05-17T09:00:00Z"}
+        assert garmin_sync._normalize_started_at(act) == "2026-05-17T09:00:00Z"
+
+    def test_blank_gmt_falls_back_to_local(self, garmin_sync):
+        act = {
+            "startTimeGMT": "   ",
+            "startTimeLocal": "2026-05-17 19:00:00",
+        }
+        assert garmin_sync._normalize_started_at(act) == "2026-05-17 19:00:00"
+
+
+@pytest.mark.unit
 class TestSyncActivities:
     """Tests for sync_activities() — activity parsing, HR zones, TRIMP."""
 
@@ -296,6 +348,28 @@ class TestSyncActivities:
             if "INSERT INTO activity" in c[0][0]
         ]
         assert len(insert_calls) == 1
+
+    def test_started_at_uses_gmt_with_utc_offset(
+        self, garmin_sync, mock_db, mock_client
+    ):
+        """started_at hits the DB as the UTC instant, never the local string.
+
+        Regression for the "missing recent workouts" bug where AEST
+        morning activities were timestamped in the future and filtered
+        out by the app router. The INSERT must carry the GMT field
+        with an explicit ``+00:00`` so Postgres always parses it as
+        UTC regardless of the database session's TimeZone.
+        """
+        conn, cursor = mock_db
+        garmin_sync.sync_activities(mock_client, conn, days=7)
+        insert_call = self._get_activity_insert_call(cursor)
+        assert insert_call is not None
+        values = insert_call[0][1]
+        # started_at is the 5th positional in the INSERT (after
+        # user_id, garmin_activity_id, sport_type, sub_type).
+        assert "2025-01-14 21:30:00+00:00" in values
+        # And the local-time string must NOT have leaked through.
+        assert "2025-01-15 07:30:00" not in values
 
     def test_stores_raw_garmin_json(self, garmin_sync, mock_db, mock_client):
         """The raw Garmin activity dict is serialised to JSON in the INSERT values."""


### PR DESCRIPTION
## Summary

Recent workouts (especially morning ones in AEST / UTC+10) were disappearing from the home page because their `started_at` was being stored ~10h in the future.

**Reproduction**: 09:00 AEST morning hike → Garmin returns `startTimeLocal="2026-05-17 09:00:00"` (TZ-naive) → addon sync passed it straight to a `timestamptz` column → Postgres re-parses in the session's TimeZone (UTC by default in the HA postgres image) → row stored as `2026-05-17 09:00 UTC` ≡ `2026-05-17 19:00 AEST` (10h in the future at 09:00 local) → app router's `lte(startedAt, new Date())` future-row filter hides it.

This explains why missing workouts "silently appear later" — the wall clock eventually catches up to the wrong timestamp.

## Fix

- `_normalize_started_at()` prefers `startTimeGMT` (the real UTC instant Garmin already provides) and stamps it with an explicit `+00:00`, so Postgres always parses it as UTC. Falls back to `startTimeLocal` only when GMT is missing.
- `backfill_activity_started_at_utc()` — one-time idempotent backfill that re-stamps existing rows from `raw_garmin_data->>'startTimeGMT'`. Gated by a marker file in `TOKEN_DIR`; force-replay with `PULSECOACH_REBACKFILL_STARTED_AT=1`.
- Wired into `main()` right after `backfill_from_raw_json`.

## Tests

- 6 new unit tests for `_normalize_started_at` (GMT preferred, local fallback, missing both, pre-offset, Z suffix, blank GMT)
- Regression test `test_started_at_uses_gmt_with_utc_offset` asserts the INSERT carries the GMT-derived UTC string and that the local-time string is not present in the values tuple.

## Companion PR

App-side defense — relax the future-row filter from `new Date()` to `addHours(new Date(), 24)` so this class of bug fails loudly instead of silently hiding data. Filed separately on the app repo.

## Affected users

Anyone east of UTC who synced activities with v0.16.20 or earlier. Once merged + released, first sync after upgrade will re-stamp all affected rows.

Co-authored-by: Claude <claude@anthropic.com>