### PR TITLE
ci: raise multi-arch build timeout to 60min

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -28,7 +28,7 @@ jobs:
     permissions:
       contents: read
       packages: write
-    timeout-minutes: 30
+    timeout-minutes: 60
     strategy:
       matrix:
         arch: [amd64, aarch64]


### PR DESCRIPTION
The aarch64 QEMU build timed out on v0.16.22 (rerun succeeded with warm cache). Raise the ceiling so cold builds aren't on a knife's edge.