### PR TITLE
fix(tools/screenshots): cleaner captures (extensions off, sticky nav, coach streaming)

### DIFF
--- a/tools/screenshots/playwright.config.ts
+++ b/tools/screenshots/playwright.config.ts
@@ -36,6 +36,12 @@ export default defineConfig({
     video: "off",
     colorScheme:
       (process.env.PULSECOACH_THEME as "light" | "dark" | undefined) ?? "dark",
+    // Launch Chromium with extensions disabled so user-installed
+    // browser extensions don't bake overlay icons / toolbars into the
+    // captured PNGs (#138).
+    launchOptions: {
+      args: ["--disable-extensions", "--disable-component-extensions-with-background-pages"],
+    },
   },
 
   outputDir: "./artifacts",

--- a/tools/screenshots/tests/dashboard.spec.ts
+++ b/tools/screenshots/tests/dashboard.spec.ts
@@ -36,6 +36,7 @@ test.describe.configure({ mode: "serial" });
 for (const route of ROUTES) {
   test(`screenshot ${route.name}`, async ({ page }, testInfo) => {
     const project = testInfo.project.name; // "desktop" | "mobile"
+    const isMobile = project === "mobile";
     const day = timestampedDir();
     const fileName = `${route.name}-${project}.png`;
     const outPath = path.join(OUT_DIR, day, fileName);
@@ -47,8 +48,36 @@ for (const route of ROUTES) {
     // is the most robust signal without adding test-ids to the app.
     await page.waitForTimeout(route.wait ?? 5000);
 
+    // For the coach page, the assistant streams a response token-by-token
+    // and previous capture runs grabbed the page mid-paragraph, leaving
+    // half-formed sentences in the README. Wait for any visible streaming
+    // indicator (the cursor sentinel or a `[data-streaming]` marker) to
+    // disappear before continuing. Best-effort — never fails the run.
+    if (route.name === "coach") {
+      await page
+        .waitForFunction(
+          () =>
+            !document.querySelector("[data-streaming='true']") &&
+            !document.querySelector(".animate-pulse-cursor"),
+          undefined,
+          { timeout: 10_000 },
+        )
+        .catch(() => undefined);
+      // Extra settle so the markdown renderer commits its final layout.
+      await page.waitForTimeout(1500);
+    }
+
+    // Scroll back to the top so full-page captures begin at the page
+    // header rather than wherever the user (or `waitUntil: networkidle`)
+    // left the viewport. Important on long routes like /training and
+    // /coach (#138).
+    await page.evaluate(() => window.scrollTo(0, 0));
+    await page.waitForTimeout(200);
+
     // Hide any noisy elements that drift run-to-run (date pickers default
-    // to "today", which makes diffs noisy). The selector list is
+    // to "today", which makes diffs noisy) and — on mobile — release the
+    // fixed bottom nav so `fullPage` captures don't bake it on top of the
+    // content rows for every screen (#138). The selector list is
     // best-effort — missing nodes don't fail the run.
     await page
       .addStyleTag({
@@ -61,9 +90,27 @@ for (const route of ROUTES) {
             transition-duration: 0s !important;
             caret-color: transparent !important;
           }
+          ${
+            isMobile
+              ? `
+          /* Release the sticky bottom nav so it lands once at the end of
+             the full-page screenshot instead of being baked in over every
+             card. The fixed-position element overlaps any scrolled-past
+             content in fullPage screenshots otherwise. */
+          nav[data-bottom-nav], .bottom-nav, [class*="BottomNav"] {
+            position: relative !important;
+            bottom: auto !important;
+          }
+          `
+              : ""
+          }
         `,
       })
       .catch(() => undefined);
+
+    // Settle once more after the style injection so the layout reflows
+    // before the screenshot fires.
+    await page.waitForTimeout(200);
 
     await page.screenshot({
       path: outPath,


### PR DESCRIPTION
Closes #138.

The 2026-05-18 multi-agent UX review of the README screenshots
flagged three issues with the capture pipeline itself (not the app):

1. **Browser extensions overlaid the captures.** Chromium picked up
   user-installed extensions and baked their toolbar icons into the
   PNGs. Now launched with `--disable-extensions`.
2. **Sticky bottom nav baked over content on mobile fullPage shots.**
   The fixed-position nav covered every scrolled-past row. On mobile
   only, we now flip it to `position: relative` via injected CSS so
   it lands once at the end of the captured page.
3. **Coach page captured mid-stream.** Previous runs grabbed the page
   while the assistant was still streaming, leaving half-formed
   sentences in the README. Now waits for any
   `[data-streaming='true']` / `.animate-pulse-cursor` sentinel to
   disappear (10s timeout, best-effort) plus a 1.5s settle. Also
   scrolls to top before every screenshot so long routes begin at
   the page header rather than wherever `networkidle` left the
   viewport.

No app/runtime changes — pure tooling fix.