### PR TITLE
fix(screenshots): hide bottom nav via DOM walk + isolated profile (#141, #142)

### DIFF
--- a/tools/screenshots/.env.example
+++ b/tools/screenshots/.env.example
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: 2026 Anil Belur <askb23@gmail.com>
+# SPDX-License-Identifier: Apache-2.0
+#
 # Copy to .env and adjust as needed. Playwright doesn't auto-load .env —
 # prefix commands with `npx dotenv-cli --` or set these in your shell rc.
 
@@ -13,4 +16,3 @@ SCREENSHOT_DIR=screenshots
 
 # "dark" or "light"
 PULSECOACH_THEME=dark
-

--- a/tools/screenshots/playwright.config.ts
+++ b/tools/screenshots/playwright.config.ts
@@ -1,7 +1,20 @@
 // SPDX-FileCopyrightText: 2026 Anil Belur <askb23@gmail.com>
 // SPDX-License-Identifier: Apache-2.0
 
+import { mkdtempSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+
 import { defineConfig, devices } from "@playwright/test";
+
+// Use a freshly-created throwaway user-data-dir for every run so the
+// browser profile cannot carry over any user-installed extension UI
+// from a developer's everyday Chromium profile (#142). The directory
+// is left behind in the OS tmp tree; the host's tmpfile reaper handles
+// cleanup.
+const ISOLATED_PROFILE = mkdtempSync(
+  path.join(tmpdir(), "pulsecoach-screenshot-profile-"),
+);
 
 /**
  * Playwright config for PulseCoach screenshot capture.
@@ -36,11 +49,17 @@ export default defineConfig({
     video: "off",
     colorScheme:
       (process.env.PULSECOACH_THEME as "light" | "dark" | undefined) ?? "dark",
-    // Launch Chromium with extensions disabled so user-installed
-    // browser extensions don't bake overlay icons / toolbars into the
-    // captured PNGs (#138).
+    // Launch Chromium with extensions disabled and an isolated, empty
+    // user-data-dir so user-installed browser extensions don't bake
+    // overlay icons / toolbars into the captured PNGs (#138, #142).
     launchOptions: {
-      args: ["--disable-extensions", "--disable-component-extensions-with-background-pages"],
+      args: [
+        "--disable-extensions",
+        "--disable-component-extensions-with-background-pages",
+        `--user-data-dir=${ISOLATED_PROFILE}`,
+        "--no-first-run",
+        "--no-default-browser-check",
+      ],
     },
   },
 

--- a/tools/screenshots/tests/dashboard.spec.ts
+++ b/tools/screenshots/tests/dashboard.spec.ts
@@ -75,10 +75,9 @@ for (const route of ROUTES) {
     await page.waitForTimeout(200);
 
     // Hide any noisy elements that drift run-to-run (date pickers default
-    // to "today", which makes diffs noisy) and — on mobile — release the
-    // fixed bottom nav so `fullPage` captures don't bake it on top of the
-    // content rows for every screen (#138). The selector list is
-    // best-effort — missing nodes don't fail the run.
+    // to "today", which makes diffs noisy) and strip any third-party
+    // accessibility / chat / analytics widgets that may have injected
+    // themselves into the host page (#142).
     await page
       .addStyleTag({
         content: `
@@ -90,23 +89,60 @@ for (const route of ROUTES) {
             transition-duration: 0s !important;
             caret-color: transparent !important;
           }
-          ${
-            isMobile
-              ? `
-          /* Release the sticky bottom nav so it lands once at the end of
-             the full-page screenshot instead of being baked in over every
-             card. The fixed-position element overlaps any scrolled-past
-             content in fullPage screenshots otherwise. */
-          nav[data-bottom-nav], .bottom-nav, [class*="BottomNav"] {
-            position: relative !important;
-            bottom: auto !important;
-          }
-          `
-              : ""
+          /* Strip common host-injected overlay widgets (a11y bars, chat
+             bubbles, feedback launchers) that aren't part of the app
+             but slip past --disable-extensions because they're shipped
+             as npm packages on the page itself (#142). */
+          [id*="accessibility" i][id*="widget" i],
+          [class*="accessibility" i][class*="widget" i],
+          [id*="ally-toolbar" i],
+          [class*="ally-toolbar" i],
+          [id*="userway" i],
+          [class*="userway" i],
+          [id*="acsb" i],
+          [class*="acsb" i],
+          [aria-label*="accessibility menu" i],
+          [aria-label*="open accessibility" i],
+          iframe[title*="accessibility" i],
+          iframe[src*="accessibility" i] {
+            display: none !important;
+            visibility: hidden !important;
           }
         `,
       })
       .catch(() => undefined);
+
+    // Mobile-only: locate any element whose computed position is fixed
+    // or sticky AND whose bottom edge is anchored to the viewport, then
+    // hide it before fullPage capture. This is far more robust than a
+    // hand-maintained selector list — the previous CSS-based fix (#140)
+    // missed the actual nav DOM and left the bar baked over every row
+    // of every mobile screenshot (#141).
+    if (isMobile) {
+      await page
+        .evaluate(() => {
+          const viewportH = window.innerHeight;
+          document.querySelectorAll<HTMLElement>("body *").forEach((el) => {
+            const cs = window.getComputedStyle(el);
+            if (cs.position !== "fixed" && cs.position !== "sticky") return;
+            const rect = el.getBoundingClientRect();
+            // Element is anchored to (or sits within 8px of) the bottom
+            // of the viewport — almost certainly a bottom nav / toast /
+            // floating action bar.
+            const anchoredBottom =
+              rect.bottom >= viewportH - 8 && rect.bottom <= viewportH + 8;
+            const looksLikeNav =
+              el.tagName === "NAV" ||
+              /\b(nav|bottom|tabbar|tab-bar)\b/i.test(el.className) ||
+              el.getAttribute("role") === "navigation" ||
+              el.hasAttribute("data-bottom-nav");
+            if (anchoredBottom || looksLikeNav) {
+              el.style.setProperty("display", "none", "important");
+            }
+          });
+        })
+        .catch(() => undefined);
+    }
 
     // Settle once more after the style injection so the layout reflows
     // before the screenshot fires.


### PR DESCRIPTION
## Why

The 2026-05-19 capture batch (post-PR #140) regressed: all 12 mobile fullPage screenshots still bake the bottom navigation bar mid-page. Two-agent UX review confirmed it across every mobile route. Plus `home-desktop.png` had an accessibility-extension overlay despite `--disable-extensions`.

## What changed

### `tests/dashboard.spec.ts`
Replaced the brittle CSS selector list:
```ts
```

Also added CSS to strip common host-injected accessibility widgets (UserWay, ally-toolbar, accessibility iframes, ARIA-labeled menu triggers) — these slipped past `--disable-extensions` because they ship as npm packages on the host page, not as browser extensions.

### `playwright.config.ts`
Launch Chromium with a freshly-created `--user-data-dir` per run so any state from a developer's everyday browser profile cannot leak into captures (#142). Added `--no-first-run --no-default-browser-check` to keep the isolated profile silent.

### `.env.example`
Drive-by: add the missing SPDX headers so `pre-commit run --all-files` is clean.

## Validation plan

After merge:
1. Run `cd tools/screenshots && BASE_URL=http://homeassistant.local:3000 npm run screenshot:mobile`
2. Verify all 12 mobile PNGs have content flowing continuously with no nav baked mid-page
3. Verify `home-desktop.png` has no purple accessibility button
4. If clean, re-launch the UX-review agents and update the README with the mobile gallery

Closes #141
Closes #142
Refs #138

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>