### PR TITLE
feat(sync): chain metrics-compute after every garmin-sync run

### DIFF
--- a/pulsecoach/rootfs/app/scripts/garmin-sync.py
+++ b/pulsecoach/rootfs/app/scripts/garmin-sync.py
@@ -1342,6 +1342,91 @@ def main():
     _write_last_sync()
     print("Garmin sync complete")
 
+    # Chain metrics recompute so derived rows (readiness_score,
+    # advanced_metric, daily_athlete_summary) pick up the freshly synced
+    # daily_metric + activity rows without the user having to click
+    # "Recompute metrics".
+    #
+    # Guards:
+    #   1. Skip if .recompute_status already shows running:true — both
+    #      the s6 periodic compute loop and the manual /auth/recompute
+    #      endpoint set this; we don't want overlapping passes.
+    #   2. Write running:true BEFORE spawning so the app's polling on
+    #      /auth/recompute-status sees a true→false falling edge when
+    #      metrics-compute.py finishes (it calls _clear_recompute_status
+    #      which only updates the file if it already exists).
+    #   3. Log to /data/metrics-compute.log so chained-run failures are
+    #      diagnosable instead of silently swallowed.
+    try:
+        import subprocess
+        import time
+
+        status_file = os.path.join(TOKEN_DIR, ".recompute_status")
+        try:
+            if os.path.exists(status_file):
+                with open(status_file) as f:
+                    sf = json.load(f)
+                if sf.get("running"):
+                    print(
+                        "metrics-compute already running "
+                        "(s6 loop or manual recompute) — "
+                        "skipping post-sync chain"
+                    )
+                    raise StopIteration
+        except StopIteration:
+            raise
+        except Exception:
+            # Corrupt / unreadable status file — treat as not-running.
+            pass
+
+        try:
+            os.makedirs(TOKEN_DIR, exist_ok=True)
+            with open(status_file, "w") as f:
+                json.dump(
+                    {
+                        "running": True,
+                        "started": time.time(),
+                        "source": "post-sync",
+                    },
+                    f,
+                )
+        except OSError as exc:
+            print(f"Warning: could not mark recompute running: {exc}")
+
+        # Inherit the parent environment so DATABASE_URL stays in sync
+        # with whatever the sync run used (no duplicated default).
+        log_path = "/data/metrics-compute.log"
+        try:
+            log_fh = open(log_path, "a", buffering=1)
+            log_fh.write(
+                f"=== chained from garmin-sync at "
+                f"{datetime.now(timezone.utc).isoformat()} ===\n"
+            )
+            log_fh.flush()
+            print("Chaining metrics-compute after sync...")
+            subprocess.Popen(
+                ["python3", "/app/scripts/metrics-compute.py", "--once"],
+                stdout=log_fh,
+                stderr=subprocess.STDOUT,
+            )
+            log_fh.close()
+            print(f"metrics-compute started in background (log: {log_path})")
+        except OSError as exc:
+            # Spawn or log-open failed — clear the running marker so the
+            # status file doesn't deadlock subsequent runs.
+            try:
+                with open(status_file, "w") as f:
+                    json.dump(
+                        {"running": False, "error": str(exc)}, f
+                    )
+            except OSError:
+                pass
+            print(f"Warning: failed to chain metrics-compute: {exc}")
+    except StopIteration:
+        pass
+    except Exception as exc:
+        print(f"Warning: chained metrics-compute setup failed: {exc}")
+
 
 if __name__ == "__main__":
     main()

--- a/pulsecoach/rootfs/etc/s6-overlay/s6-rc.d/pulsecoach/run
+++ b/pulsecoach/rootfs/etc/s6-overlay/s6-rc.d/pulsecoach/run
@@ -344,8 +344,24 @@ export COMPUTE_INTERVAL_MINUTES="${SYNC_INTERVAL}"
     # Wait for initial sync to complete before first compute (120s grace period)
     sleep 120
     while true; do
-        bashio::log.info "Computing advanced metrics..."
-        python3 /app/scripts/metrics-compute.py --once 2>&1 || bashio::log.warning "Metrics compute failed"
+        # Cooperate with chained-from-sync runs and manual /auth/recompute
+        # so we don't double-run metrics-compute. _clear_recompute_status
+        # only updates the marker if it exists, so we always write
+        # running:true here too.
+        status_file="/data/garmin-tokens/.recompute_status"
+        skip=0
+        if [ -f "$status_file" ]; then
+            if grep -q '"running":[[:space:]]*true' "$status_file" 2>/dev/null; then
+                bashio::log.info "metrics-compute already running — skipping periodic pass"
+                skip=1
+            fi
+        fi
+        if [ "$skip" -eq 0 ]; then
+            mkdir -p /data/garmin-tokens
+            printf '{"running":true,"started":%s,"source":"s6-periodic"}' "$(date +%s)" > "$status_file"
+            bashio::log.info "Computing advanced metrics..."
+            python3 /app/scripts/metrics-compute.py --once 2>&1 || bashio::log.warning "Metrics compute failed"
+        fi
         sleep "$((COMPUTE_INTERVAL_MINUTES * 60))"
     done
 ) &
@@ -449,8 +465,20 @@ while true; do
         bashio::log.warning "Metrics compute died, restarting..."
         (
             while true; do
-                bashio::log.info "Computing advanced metrics..."
-                python3 /app/scripts/metrics-compute.py --once 2>&1 || bashio::log.warning "Metrics compute failed"
+                status_file="/data/garmin-tokens/.recompute_status"
+                skip=0
+                if [ -f "$status_file" ]; then
+                    if grep -q '"running":[[:space:]]*true' "$status_file" 2>/dev/null; then
+                        bashio::log.info "metrics-compute already running — skipping periodic pass"
+                        skip=1
+                    fi
+                fi
+                if [ "$skip" -eq 0 ]; then
+                    mkdir -p /data/garmin-tokens
+                    printf '{"running":true,"started":%s,"source":"s6-periodic"}' "$(date +%s)" > "$status_file"
+                    bashio::log.info "Computing advanced metrics..."
+                    python3 /app/scripts/metrics-compute.py --once 2>&1 || bashio::log.warning "Metrics compute failed"
+                fi
                 sleep "$((COMPUTE_INTERVAL_MINUTES * 60))"
             done
         ) &


### PR DESCRIPTION
**Problem:** Sync writes `daily_metric` + `activity` rows but does NOT touch the derived tables (`readiness_score`, `advanced_metric`, `daily_athlete_summary`). The user has to manually click `Recompute metrics` in Settings for their Home readiness/stress to reflect a new activity. Very easy to miss — especially on the scheduled sync path where there's no UI prompt at all.

**Fix:** At the end of `garmin-sync.py main()` (after `_clear_sync_status()`) spawn `metrics-compute.py --once` as a background subprocess. Best-effort — if the spawn fails the sync itself is still marked successful and the user can retry manually.

**Pairs with:** app `fix/settings-invalidate-on-data-refresh` which polls `/auth/recompute-status` and invalidates every React Query cache on the falling edge, so the dashboards refresh without a manual reload.

**End-to-end UX after both ship:**
1. User taps `Sync now` (or scheduled sync fires)
2. Sync writes `daily_metric` + `activity` rows
3. `metrics-compute` auto-runs in the background
4. App polls recompute status; when it flips idle, every query in the tree refetches
5. Home readiness/stress and all derived charts update automatically

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>