### PR TITLE
chore(release): v0.16.29

### DIFF
--- a/pulsecoach/CHANGELOG.md
+++ b/pulsecoach/CHANGELOG.md
@@ -5,6 +5,35 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.16.29] — 2026-05-21
+
+Refresh-pipeline overhaul: dashboards now light up automatically
+after sync without a page reload.
+
+### Auto-recompute after sync
+
+- **garmin-sync.py** chains `metrics-compute.py --once` at the end
+  of every sync run (manual or scheduled), so derived rows
+  (`readiness_score`, `advanced_metric`, `daily_athlete_summary`)
+  always reflect the freshly synced `daily_metric` + `activity`
+  rows. No more clicking "Recompute metrics" to see Home update.
+- A `.recompute_status` file lock prevents the post-sync chain
+  from overlapping with the s6 periodic compute loop or a manual
+  `/auth/recompute` invocation. The s6 loop now writes the same
+  marker so all three paths cooperate.
+- Chained recompute logs to `/data/metrics-compute.log` (rotated
+  on each chain) instead of `/dev/null`, so failures are
+  diagnosable.
+
+### Picked up from app
+
+- **Settings invalidates React Query caches** when sync OR
+  recompute transitions running → idle. Polls `/auth/sync` and
+  `/auth/recompute-status` every 3 s while a job is in flight,
+  30 s otherwise. End-to-end UX: tap **Sync now** → sync writes
+  rows → recompute auto-runs → caches invalidate → every
+  dashboard refetches and renders the new values (app#203).
+
 ## [0.16.28] — 2026-05-21
 
 Closes the 2026-05-21 screenshot review loop. Four app polish fixes

--- a/pulsecoach/config.json
+++ b/pulsecoach/config.json
@@ -1,6 +1,6 @@
 {
   "name": "PulseCoach",
-  "version": "0.16.28",
+  "version": "0.16.29",
   "slug": "pulsecoach",
   "image": "ghcr.io/askb/pulsecoach-addon-{arch}",
   "description": "AI-powered sport scientist — training analysis, coaching, and recovery optimization from your Garmin data",


### PR DESCRIPTION
**Refresh-pipeline overhaul.** Dashboards now light up automatically after sync without a page reload.

### Picked up

| PR | What |
|---|---|
| addon#156 | `garmin-sync.py` chains `metrics-compute.py --once` at the end of every run with a `.recompute_status` lock so it doesn't collide with the s6 periodic loop or a manual `/auth/recompute`; logs to `/data/metrics-compute.log`. |
| app#203 | Settings polls `/auth/sync` and `/auth/recompute-status`; on the running → idle falling edge it calls `queryClient.invalidateQueries()` so every dashboard refetches. |

### End-to-end UX

1. User taps `Sync now` (or scheduled sync fires)
2. Sync writes `daily_metric` + `activity` rows
3. `metrics-compute` auto-runs in the background
4. App polls recompute status; when it flips idle, every query in the tree refetches
5. Home readiness/stress and all derived charts update automatically

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>