### PR TITLE
fix(metrics-compute): make ensure_*_table idempotent under race

### DIFF
--- a/pulsecoach/rootfs/app/scripts/metrics-compute.py
+++ b/pulsecoach/rootfs/app/scripts/metrics-compute.py
@@ -69,6 +69,15 @@ def ensure_advanced_metric_table(cur):
     """)
     # If the table was created by Drizzle push (without the constraint),
     # CREATE TABLE IF NOT EXISTS won't add it. Ensure it exists separately.
+    # The DO block guards against the constraint existing, but two
+    # concurrent metrics-compute runs (manual + chained-after-sync, or
+    # racing s6 periodic) can both pass the guard before either
+    # executes ALTER TABLE — at which point the second ADD CONSTRAINT
+    # fails with DuplicateTable. The .recompute_status lock added in
+    # v0.16.29 prevents the most common cause but a TOCTOU race is
+    # still possible (manual /auth/recompute vs periodic loop, or
+    # corrupted lock file). Make the SQL itself idempotent by
+    # swallowing duplicate_table / duplicate_object inside the DO.
     cur.execute("""
         DO $$
         BEGIN
@@ -85,6 +94,10 @@ def ensure_advanced_metric_table(cur):
                     ADD CONSTRAINT advanced_metric_user_date_unique
                     UNIQUE (user_id, date);
             END IF;
+        EXCEPTION
+            WHEN duplicate_table THEN NULL;
+            WHEN duplicate_object THEN NULL;
+            WHEN unique_violation THEN NULL;
         END $$;
     """)
 
@@ -104,6 +117,8 @@ def ensure_advanced_metric_table(cur):
     """)
     # If the table was created by Drizzle push (without the constraint),
     # CREATE TABLE IF NOT EXISTS won't add it. Ensure it exists separately.
+    # See the advanced_metric block above for the rationale on the
+    # EXCEPTION arms — same race window applies here.
     cur.execute("""
         DO $$
         BEGIN
@@ -124,6 +139,10 @@ def ensure_advanced_metric_table(cur):
                     ADD CONSTRAINT readiness_score_user_date_unique
                     UNIQUE (user_id, date);
             END IF;
+        EXCEPTION
+            WHEN duplicate_table THEN NULL;
+            WHEN duplicate_object THEN NULL;
+            WHEN unique_violation THEN NULL;
         END $$;
     """)
 


### PR DESCRIPTION
**Reported error from v0.16.28 install:**

```
[metrics-compute] ERROR: relation "advanced_metric_user_date_unique" already exists
CONTEXT: SQL statement "ALTER TABLE advanced_metric ADD CONSTRAINT
        advanced_metric_user_date_unique UNIQUE (user_id, date)"
PL/pgSQL function inline_code_block line 12 at SQL statement
```

**Root cause:** `ensure_advanced_metric_table` and `ensure_readiness_score_table` both guard `ALTER TABLE ... ADD CONSTRAINT` with an `IF NOT EXISTS` check inside a `DO` block. Two concurrent `metrics-compute.py` runs can both pass the guard before either executes the ALTER — second `ADD CONSTRAINT` then fails with `DuplicateTable`.

v0.16.29's `.recompute_status` file lock prevents the most common trigger (chained-after-sync overlapping with s6 periodic), but a TOCTOU race window still exists.

**Fix:** Add `EXCEPTION WHEN duplicate_table / duplicate_object / unique_violation THEN NULL` arms to both DO blocks so the SQL is genuinely idempotent. End state is unchanged (constraint exists, upserts work).

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>