### PR TITLE
ci(addon): v0.17.0 W4.5 release-gate workflow — block release until app main is green

### DIFF
--- a/.github/workflows/release-gate.yml
+++ b/.github/workflows/release-gate.yml
@@ -1,0 +1,113 @@
+---
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: 2025 Anil Belur <askb23@gmail.com>
+
+name: Release Gate
+
+on:
+  workflow_call:
+    inputs:
+      app_repo:
+        description: App repository to verify before releasing the addon.
+        required: false
+        type: string
+        default: askb/ha-garmin-fitness-coach-app
+      app_branch:
+        description: App branch that must be green before releasing the addon.
+        required: false
+        type: string
+        default: main
+      required_workflows:
+        description: Comma-separated check-run names that must be successful.
+        required: false
+        type: string
+        default: CI
+  workflow_dispatch:
+    inputs:
+      app_repo:
+        description: App repository to verify before releasing the addon.
+        required: false
+        type: string
+        default: askb/ha-garmin-fitness-coach-app
+      app_branch:
+        description: App branch that must be green before releasing the addon.
+        required: false
+        type: string
+        default: main
+      required_workflows:
+        description: Comma-separated check-run names that must be successful.
+        required: false
+        type: string
+        default: CI
+
+permissions:
+  contents: read
+
+jobs:
+  verify-app-main-green:
+    name: Verify app main is green
+    runs-on: ubuntu-24.04
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+
+      - name: Verify required app checks
+        env:
+          APP_REPO: ${{ inputs.app_repo }}
+          APP_BRANCH: ${{ inputs.app_branch }}
+          REQUIRED_WORKFLOWS: ${{ inputs.required_workflows }}
+          GH_TOKEN: ${{ github.token }}
+          GITHUB_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+
+          sha=$(gh api "repos/${APP_REPO}/branches/${APP_BRANCH}" --jq '.commit.sha')
+          check_runs=$(gh api \
+            "repos/${APP_REPO}/commits/${sha}/check-runs?per_page=100" \
+            --paginate \
+            --jq '.check_runs[] | select(.name != "agent") | [.name, (.conclusion // "pending")] | @tsv')
+
+          IFS=',' read -r -a required_names <<< "${REQUIRED_WORKFLOWS}"
+          failed=0
+
+          for required_name in "${required_names[@]}"; do
+            name="${required_name#"${required_name%%[![:space:]]*}"}"
+            name="${name%"${name##*[![:space:]]}"}"
+            if [[ -z "${name}" ]]; then
+              continue
+            fi
+
+            success_count=$(awk -F '\t' -v name="${name}" \
+              '$1 == name && $2 == "success" { count++ } END { print count + 0 }' \
+              <<< "${check_runs}")
+
+            if [[ "${success_count}" -eq 0 && "${name}" == "CI" ]]; then
+              ci_success_count=0
+              for ci_check in format lint typecheck test; do
+                check_success_count=$(awk -F '\t' -v name="${ci_check}" \
+                  '$1 == name && $2 == "success" { count++ } END { print count + 0 }' \
+                  <<< "${check_runs}")
+                if [[ "${check_success_count}" -gt 0 ]]; then
+                  ci_success_count=$((ci_success_count + 1))
+                fi
+              done
+              if [[ "${ci_success_count}" -eq 4 ]]; then
+                success_count=1
+              fi
+            fi
+
+            if [[ "${success_count}" -eq 0 ]]; then
+              conclusion=$(awk -F '\t' -v name="${name}" \
+                '$1 == name { print $2; found = 1; exit } END { if (!found) print "null" }' \
+                <<< "${check_runs}")
+              echo "::error::App repo ${APP_REPO}@${APP_BRANCH} (sha ${sha}) is NOT green: workflow '${name}' has conclusion='${conclusion}'. Refusing to release."
+              failed=1
+            fi
+          done
+
+          if [[ "${failed}" -ne 0 ]]; then
+            exit 1
+          fi
+
+          echo "✅ App main is green at ${sha} — addon release is allowed." \
+            >> "${GITHUB_STEP_SUMMARY}"

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -12,8 +12,15 @@ on:
 permissions: {}
 
 jobs:
+  gate:
+    name: 'Release Gate'
+    uses: ./.github/workflows/release-gate.yml
+    permissions:
+      contents: read
+
   validate:
     name: 'Validate'
+    needs: gate
     runs-on: ubuntu-latest
     permissions:
       contents: read

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -22,6 +22,7 @@ repos:
       - id: check-json
       - id: check-merge-conflict
       - id: check-yaml
+        exclude: ^pulsecoach/rootfs/app/blueprints/
       - id: end-of-file-fixer
       - id: mixed-line-ending
         args: ["--fix=lf"]

--- a/README.md
+++ b/README.md
@@ -583,6 +583,16 @@ CI checks out both repos, runs a multi-stage Docker build (Node.js builder →
 HA base image), and pushes multi-arch images (amd64 + aarch64) to GHCR.
 Tagged releases create GitHub Releases automatically.
 
+### Release gating
+
+The release workflow calls `release-gate.yml` before publishing. The gate
+checks the PulseCoach app repo's `main` branch and refuses to ship addon
+images when the app checks are not green, preventing releases that point at a
+broken app commit.
+
+Emergency override: temporarily comment out the `needs: gate` line in the
+release workflow, ship the urgent fix, then restore the gate and fix forward.
+
 ## Contributing
 
 Contributions are welcome! Please see [CONTRIBUTING.md](CONTRIBUTING.md) for


### PR DESCRIPTION
## Summary
- Add reusable `release-gate.yml` with `workflow_call` and manual `workflow_dispatch` triggers.
- Verify the PulseCoach app branch check runs with `gh api`, ignoring the known-broken `agent` check.
- Wire the existing tag release workflow through the gate before validate/build/release jobs.
- Document release gating and emergency override guidance.
- Exclude HA blueprint `!input` files from generic `check-yaml` so `pre-commit run --all-files` passes on valid Home Assistant YAML.

## Verification
- `actionlint .github/workflows/release-gate.yml`
- `yamllint .github/workflows/release-gate.yml`
- `actionlint .github/workflows/release.yaml .github/workflows/release-gate.yml`
- `yamllint .github/workflows/release.yaml .github/workflows/release-gate.yml`
- Local gate logic dry-run against `askb/ha-garmin-fitness-coach-app@main` with `required_workflows=CI`: passed at `a0ca9cc4acddb95d40f80044cbc4a1c2fa6d8b98`
- `pre-commit run --all-files`