### PR TITLE
chore(release): bump v0.17.0

### DIFF
--- a/pulsecoach/CHANGELOG.md
+++ b/pulsecoach/CHANGELOG.md
@@ -5,6 +5,23 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.17.0] - 2026-05-28 — AI-native coach loop
+
+### Added
+
+- HA action layer polls `RecommendationAudit` and fires Home Assistant
+  Supervisor events for recommendation decisions, low readiness,
+  completed sessions, and missed sessions (addon #166).
+- Release gate workflow verifies the app repository main branch is green
+  before addon releases proceed (addon #165).
+- Packaged app now builds from the app repo `v0.17.0` tag; see the app
+  repository changelog for the full AI-native coach loop details.
+
+### Changed
+
+- Coach loop is now rules-first; LLM only frames explanations
+  (test-enforced in the app repo).
+
 ## [0.17.0-dev.1] — 2026-05-27
 
 ### Added

--- a/pulsecoach/Dockerfile
+++ b/pulsecoach/Dockerfile
@@ -15,7 +15,7 @@ WORKDIR /build
 # Clone the app source from GitHub
 # Use build arg timestamp for cache busting instead of GitHub API (avoids 403 rate limits)
 ARG APP_REPO=askb/ha-garmin-fitness-coach-app
-ARG APP_REF=main
+ARG APP_REF=v0.17.0
 ARG CACHEBUST=1
 RUN echo "Cache bust: ${CACHEBUST}" && \
     git clone --depth=1 --branch="${APP_REF}" \
@@ -91,4 +91,4 @@ LABEL \
     io.hass.description="AI-powered sport scientist for Garmin athletes" \
     io.hass.arch="${BUILD_ARCH}" \
     io.hass.type="addon" \
-    io.hass.version="0.9.0"
+    io.hass.version="0.17.0"

--- a/pulsecoach/config.json
+++ b/pulsecoach/config.json
@@ -1,6 +1,6 @@
 {
   "name": "PulseCoach",
-  "version": "0.17.0-dev.1",
+  "version": "0.17.0",
   "slug": "pulsecoach",
   "image": "ghcr.io/askb/pulsecoach-addon-{arch}",
   "description": "AI-powered sport scientist — training analysis, coaching, and recovery optimization from your Garmin data",


### PR DESCRIPTION
## Summary
- bump addon version to 0.17.0
- add v0.17.0 addon changelog entry
- pin Docker app clone to askb/ha-garmin-fitness-coach-app@v0.17.0

## Verification
- pre-commit run --all-files
- pytest tests/ -v (196 passed)
- ./scripts/build-local.sh

Note: the agent CI check is expected to remain red and is ignored for this release.