### PR TITLE
chore(release): bump addon to v0.17.2

### DIFF
--- a/pulsecoach/CHANGELOG.md
+++ b/pulsecoach/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.17.2] - 2026-05-28
+
+### Changed
+
+- Bundle app v0.17.1 with UI polish (Accept/Skip/Defer layout, adherence empty-state fallback,
+  duplicate headline removed) and LLM hardening (ordered-list renumbering, activity slug humanization).
+
 ## [0.17.1] - 2026-05-28
 
 ### Fixed

--- a/pulsecoach/Dockerfile
+++ b/pulsecoach/Dockerfile
@@ -15,7 +15,7 @@ WORKDIR /build
 # Clone the app source from GitHub
 # Use build arg timestamp for cache busting instead of GitHub API (avoids 403 rate limits)
 ARG APP_REPO=askb/ha-garmin-fitness-coach-app
-ARG APP_REF=v0.17.0
+ARG APP_REF=v0.17.1
 ARG CACHEBUST=1
 RUN echo "Cache bust: ${CACHEBUST}" && \
     git clone --depth=1 --branch="${APP_REF}" \
@@ -91,4 +91,4 @@ LABEL \
     io.hass.description="AI-powered sport scientist for Garmin athletes" \
     io.hass.arch="${BUILD_ARCH}" \
     io.hass.type="addon" \
-    io.hass.version="0.17.0"
+    io.hass.version="0.17.2"

--- a/pulsecoach/config.json
+++ b/pulsecoach/config.json
@@ -1,6 +1,6 @@
 {
   "name": "PulseCoach",
-  "version": "0.17.1",
+  "version": "0.17.2",
   "slug": "pulsecoach",
   "image": "ghcr.io/askb/pulsecoach-addon-{arch}",
   "description": "AI-powered sport scientist — training analysis, coaching, and recovery optimization from your Garmin data",


### PR DESCRIPTION
## Summary
- Bump addon manifest to v0.17.2
- Build bundled app from app tag v0.17.1
- Update addon Docker label and changelog for the polish release

## Verification
- pre-commit run --all-files
- pytest tests/ -v
- pytest pulsecoach/rootfs/app/tests/ -v
- ./scripts/build-local.sh

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>