### PR TITLE
fix(ha-actions): use snake_case for recommendation_audit query

### DIFF
--- a/pulsecoach/CHANGELOG.md
+++ b/pulsecoach/CHANGELOG.md
@@ -5,6 +5,17 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.17.3] - 2026-05-28
+
+### Fixed
+
+- HA actions poller now queries the Drizzle-managed `recommendation_audit`
+  table using snake_case identifiers.
+
+### Changed
+
+- Bundle app v0.17.2 with the timezone-aware dashboard greeting fix.
+
 ## [0.17.2] - 2026-05-28
 
 ### Changed

--- a/pulsecoach/config.json
+++ b/pulsecoach/config.json
@@ -1,6 +1,6 @@
 {
   "name": "PulseCoach",
-  "version": "0.17.2",
+  "version": "0.17.3",
   "slug": "pulsecoach",
   "image": "ghcr.io/askb/pulsecoach-addon-{arch}",
   "description": "AI-powered sport scientist — training analysis, coaching, and recovery optimization from your Garmin data",

--- a/pulsecoach/rootfs/app/scripts/ha-actions.py
+++ b/pulsecoach/rootfs/app/scripts/ha-actions.py
@@ -32,16 +32,10 @@ DEFAULT_DATABASE_URL = "postgresql://postgres@127.0.0.1:5432/pulsecoach"
 HA_BASE_URL = os.environ.get("HA_BASE_URL", "http://supervisor/core").rstrip("/")
 
 AUDIT_QUERY = """
-    SELECT
-        id,
-        "userId" AS user_id,
-        date,
-        kind,
-        payload,
-        "createdAt" AS created_at
-    FROM "RecommendationAudit"
-    WHERE "createdAt" > %s
-    ORDER BY "createdAt" ASC
+    SELECT id, user_id, date, kind, payload, created_at
+    FROM recommendation_audit
+    WHERE created_at > %s
+    ORDER BY created_at ASC
 """
 
 

--- a/tests/test_ha_actions.py
+++ b/tests/test_ha_actions.py
@@ -102,6 +102,16 @@ def register_event(requests_mock: Any, event_type: str, status_code: int = 200) 
     requests_mock.post(f"{SUPERVISOR_URL}/{event_type}", status_code=status_code, json={"ok": True})
 
 
+def test_audit_query_uses_drizzle_snake_case(monkeypatch):
+    """Assert the poller queries the Drizzle-managed audit table."""
+    module = load_ha_actions(monkeypatch, [])
+
+    assert "FROM recommendation_audit" in module.AUDIT_QUERY
+    assert "created_at > %s" in module.AUDIT_QUERY
+    assert '"RecommendationAudit"' not in module.AUDIT_QUERY
+    assert '"createdAt"' not in module.AUDIT_QUERY
+
+
 def test_cursor_advances_after_processing_three_rows(monkeypatch, requests_mock, cursor_file):
     base = datetime.now(timezone.utc) - timedelta(minutes=30)
     rows = [


### PR DESCRIPTION
## Summary
- update HA actions poller SQL to use Drizzle snake_case table and columns
- bump addon config and changelog to v0.17.3
- note bundled app v0.17.2 dependency

## Validation
- pytest tests/ -v: 202 passed, 7 warnings
- pre-commit run --all-files: passed