### PR TITLE
fix: bundle app v0.17.4

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -14,6 +14,14 @@ ci:
     Signed-off-by: pre-commit-ci[bot] <66853113+pre-commit-ci[bot]@users.noreply.github.com>
 
 repos:
+  - repo: local
+    hooks:
+      - id: check-app-ref
+        name: check addon app ref
+        entry: scripts/check-app-ref.sh
+        language: script
+        pass_filenames: false
+
   - repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v5.0.0
     hooks:

--- a/pulsecoach/CHANGELOG.md
+++ b/pulsecoach/CHANGELOG.md
@@ -5,6 +5,15 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.17.5] - 2026-05-28
+
+### Fixed
+
+- Bundle app v0.17.4 so HAOS containers include the timezone picker,
+  adherence activity fallback, and coach chat post-processing fixes.
+- Bump Dockerfile `APP_REF` from v0.17.1 to v0.17.4; v0.17.3 still built
+  the stale app ref despite addon release notes.
+
 ## [0.17.3] - 2026-05-28
 
 ### Fixed

--- a/pulsecoach/Dockerfile
+++ b/pulsecoach/Dockerfile
@@ -15,7 +15,7 @@ WORKDIR /build
 # Clone the app source from GitHub
 # Use build arg timestamp for cache busting instead of GitHub API (avoids 403 rate limits)
 ARG APP_REPO=askb/ha-garmin-fitness-coach-app
-ARG APP_REF=v0.17.1
+ARG APP_REF=v0.17.4
 ARG CACHEBUST=1
 RUN echo "Cache bust: ${CACHEBUST}" && \
     git clone --depth=1 --branch="${APP_REF}" \

--- a/pulsecoach/config.json
+++ b/pulsecoach/config.json
@@ -1,6 +1,6 @@
 {
   "name": "PulseCoach",
-  "version": "0.17.3",
+  "version": "0.17.5",
   "slug": "pulsecoach",
   "image": "ghcr.io/askb/pulsecoach-addon-{arch}",
   "description": "AI-powered sport scientist — training analysis, coaching, and recovery optimization from your Garmin data",

--- a/scripts/check-app-ref.sh
+++ b/scripts/check-app-ref.sh
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+# SPDX-FileCopyrightText: 2026 Anil Belur <askb23@gmail.com>
+# SPDX-License-Identifier: Apache-2.0
+##############################################################################
+# Warn if the bundled app ref is newer than the addon manifest version.
+##############################################################################
+
+set -euo pipefail
+IFS=$'\n\t'
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+dockerfile="${repo_root}/pulsecoach/Dockerfile"
+config_json="${repo_root}/pulsecoach/config.json"
+
+app_ref="$(sed -n 's/^ARG APP_REF=v//p' "${dockerfile}" | head -n1)"
+addon_version="$(python3 -c 'import json,sys; print(json.load(open(sys.argv[1]))["version"])' "${config_json}")"
+
+if [[ -z "${app_ref}" ]]; then
+    echo "WARNING: pulsecoach/Dockerfile does not define ARG APP_REF=v..." >&2
+    exit 0
+fi
+
+if [[ "$(printf '%s\n%s\n' "${app_ref}" "${addon_version}" | sort -V | head -n1)" != "${app_ref}" ]]; then
+    echo "WARNING: addon version ${addon_version} is older than APP_REF ${app_ref}" >&2
+fi


### PR DESCRIPTION
## Summary
- bump addon version to 0.17.5
- bump Dockerfile APP_REF from v0.17.1 to v0.17.4
- document the app v0.17.4 bundle and add a warn-only APP_REF guard script

## Validation
- scripts/check-app-ref.sh
- pytest tests/ -v (203 passed)
- pre-commit run --all-files