### PR TITLE
chore: release v0.17.10 (app v0.17.9 — coach context fix)

### DIFF
--- a/pulsecoach/CHANGELOG.md
+++ b/pulsecoach/CHANGELOG.md
@@ -5,6 +5,28 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.17.10] - 2026-05-29
+
+### Fixed
+
+- **Coach context — answers aggregate questions properly.** Previously the LLM
+  context was capped at 14 days / 10 activities, so questions like "analyse all
+  my runs done this year" returned "I only have one run in the last 14 days".
+  The coach now detects aggregate intent ("this year", "YTD", "annual",
+  "last 6 months", etc.) and widens to 365 days / up to 500 sessions, and
+  always emits a Year-to-Date activity summary grouped by sport so the model
+  can answer aggregate questions even when keyword detection misses.
+- **HA Assist intent matcher no longer hijacks the coach.** The persona swap
+  ("As a voice assistant, I can help you with controlling your smart home
+  devices…") was caused by the HA Conversation API's intent matcher running
+  before the LLM agent. The coach now detects the fallback string, refreshes
+  the cached agent id every 5 minutes, and routes through Ollama when an HA
+  Assist fallback is detected.
+
+### Changed
+
+- Bundle app v0.17.9.
+
 ## [0.17.9] - 2026-05-29
 
 ### Fixed

--- a/pulsecoach/Dockerfile
+++ b/pulsecoach/Dockerfile
@@ -15,7 +15,7 @@ WORKDIR /build
 # Clone the app source from GitHub
 # Use build arg timestamp for cache busting instead of GitHub API (avoids 403 rate limits)
 ARG APP_REPO=askb/ha-garmin-fitness-coach-app
-ARG APP_REF=v0.17.8
+ARG APP_REF=v0.17.9
 ARG CACHEBUST=1
 RUN echo "Cache bust: ${CACHEBUST}" && \
     git clone --depth=1 --branch="${APP_REF}" \

--- a/pulsecoach/config.json
+++ b/pulsecoach/config.json
@@ -1,6 +1,6 @@
 {
   "name": "PulseCoach",
-  "version": "0.17.9",
+  "version": "0.17.10",
   "slug": "pulsecoach",
   "image": "ghcr.io/askb/pulsecoach-addon-{arch}",
   "description": "AI-powered sport scientist — training analysis, coaching, and recovery optimization from your Garmin data",


### PR DESCRIPTION
Bumps addon to v0.17.10, pinned to app **v0.17.9** which carries the coach context fix users have been asking for live in chat.

## What changes for end users

- The coach can now answer aggregate questions like "analyse all my runs done this year" / "give me a 6-month report" instead of replying "I only have one run in the last 14 days".
- The persona swap ("As a voice assistant, I can help you with controlling your smart home devices…") is detected and worked around — coach now stays on-topic.

## Wiring

- `pulsecoach/config.json`: version 0.17.9 → 0.17.10
- `pulsecoach/Dockerfile`: ARG APP_REF v0.17.8 → v0.17.9
- `pulsecoach/CHANGELOG.md`: 0.17.10 section added

Companion app release: askb/ha-garmin-fitness-coach-app#224 (merged) → tagged v0.17.9.