### PR TITLE
docs: document HA Supervisor store reload for new versions

### DIFF
--- a/README.md
+++ b/README.md
@@ -242,13 +242,18 @@ shipped here but the **Update** button has not yet appeared in the UI:
    `version:` field within a few seconds.
 2. Open **PulseCoach** in the store — if a newer version exists, an
    **Update** button replaces **Open**.
-3. Click **Update** and wait for the rebuild (~5 min amd64, ~10–15 min
-   aarch64). The addon restarts automatically when it finishes.
+3. Click **Update**. The addon ships as a prebuilt multi-arch image on
+   GHCR (`ghcr.io/askb/pulsecoach-addon-{arch}`), so Supervisor pulls the
+   image rather than rebuilding from source — usually under a minute on
+   a decent connection. The addon restarts automatically when the pull
+   completes.
 
 Power-user alternatives:
 
 - **CLI** (HAOS / Supervised): `ha store reload` then `ha addons update <slug>`.
-- **REST API**: `POST /supervisor/reload` against the Supervisor.
+- **REST API**: `POST /store/reload` against the Supervisor to refresh
+  add-on store metadata (this is the endpoint backing `ha store reload`;
+  `POST /supervisor/reload` only reloads the Supervisor process config).
 - **HACS users**: HACS pulls release tags via the GitHub API and usually
   picks up new releases within ~30 minutes. To force it, open HACS → ⋮ →
   **Reload data**.

--- a/README.md
+++ b/README.md
@@ -231,6 +231,34 @@ Then install **PulseCoach** from the add-on store and start it.
 > **💡 Tip:** You can trigger a manual sync at any time from
 > **Settings → 🔄 Sync Now** without waiting for the next scheduled interval.
 
+### Updating to a new version
+
+Home Assistant Supervisor caches the addon store on disk and only re-reads
+release metadata every few hours. If a new version (e.g. `v0.17.10`) has
+shipped here but the **Update** button has not yet appeared in the UI:
+
+1. **Settings → Add-ons → Add-on Store → ⋮ (top-right) → Reload**.
+   This re-fetches `config.json` from this repository and shows the latest
+   `version:` field within a few seconds.
+2. Open **PulseCoach** in the store — if a newer version exists, an
+   **Update** button replaces **Open**.
+3. Click **Update** and wait for the rebuild (~5 min amd64, ~10–15 min
+   aarch64). The addon restarts automatically when it finishes.
+
+Power-user alternatives:
+
+- **CLI** (HAOS / Supervised): `ha store reload` then `ha addons update <slug>`.
+- **REST API**: `POST /supervisor/reload` against the Supervisor.
+- **HACS users**: HACS pulls release tags via the GitHub API and usually
+  picks up new releases within ~30 minutes. To force it, open HACS → ⋮ →
+  **Reload data**.
+
+If the version still does not appear after a reload, confirm the release
+is published (not draft) at
+[the releases page](https://github.com/askb/ha-garmin-fitness-coach-addon/releases)
+and that `pulsecoach/config.json` on `main` has the matching `version:` —
+HA Supervisor reads the config file, not the git tag.
+
 ## Configuration
 
 | Option | Type | Default | Required | Description |

--- a/pulsecoach/CHANGELOG.md
+++ b/pulsecoach/CHANGELOG.md
@@ -5,6 +5,28 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.17.10] - 2026-05-29
+
+### Fixed
+
+- **Coach context — answers aggregate questions properly.** Previously the LLM
+  context was capped at 14 days / 10 activities, so questions like "analyse all
+  my runs done this year" returned "I only have one run in the last 14 days".
+  The coach now detects aggregate intent ("this year", "YTD", "annual",
+  "last 6 months", etc.) and widens to 365 days / up to 500 sessions, and
+  always emits a Year-to-Date activity summary grouped by sport so the model
+  can answer aggregate questions even when keyword detection misses.
+- **HA Assist intent matcher no longer hijacks the coach.** The persona swap
+  ("As a voice assistant, I can help you with controlling your smart home
+  devices…") was caused by the HA Conversation API's intent matcher running
+  before the LLM agent. The coach now detects the fallback string, refreshes
+  the cached agent id every 5 minutes, and routes through Ollama when an HA
+  Assist fallback is detected.
+
+### Changed
+
+- Bundle app v0.17.9.
+
 ## [0.17.9] - 2026-05-29
 
 ### Fixed

--- a/pulsecoach/Dockerfile
+++ b/pulsecoach/Dockerfile
@@ -15,7 +15,7 @@ WORKDIR /build
 # Clone the app source from GitHub
 # Use build arg timestamp for cache busting instead of GitHub API (avoids 403 rate limits)
 ARG APP_REPO=askb/ha-garmin-fitness-coach-app
-ARG APP_REF=v0.17.8
+ARG APP_REF=v0.17.9
 ARG CACHEBUST=1
 RUN echo "Cache bust: ${CACHEBUST}" && \
     git clone --depth=1 --branch="${APP_REF}" \

--- a/pulsecoach/config.json
+++ b/pulsecoach/config.json
@@ -1,6 +1,6 @@
 {
   "name": "PulseCoach",
-  "version": "0.17.9",
+  "version": "0.17.10",
   "slug": "pulsecoach",
   "image": "ghcr.io/askb/pulsecoach-addon-{arch}",
   "description": "AI-powered sport scientist — training analysis, coaching, and recovery optimization from your Garmin data",


### PR DESCRIPTION
Adds an 'Updating to a new version' subsection under Installation, covering:

- HA UI flow (Settings → Add-ons → Add-on Store → ⋮ → Reload)
- `ha store reload` / `ha addons update` CLI
- `POST /supervisor/reload` REST API
- HACS reload-data workaround
- Sanity-check pointer to the [releases page](https://github.com/askb/ha-garmin-fitness-coach-addon/releases) + `pulsecoach/config.json` on `main`

Motivation: users have asked how to force the addon store to surface a freshly-shipped version (e.g. `v0.17.10`) when the **Update** button doesn't appear right away. Supervisor caches addon metadata for several hours; a manual reload triggers an immediate refresh.

Docs-only change. README only.