### PR TITLE
chore: release v0.17.11 (app v0.17.10 — upstream provider fallthrough)

### DIFF
--- a/pulsecoach/CHANGELOG.md
+++ b/pulsecoach/CHANGELOG.md
@@ -5,6 +5,24 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.17.11] - 2026-05-29
+
+### Fixed
+
+- **Coach upstream provider fallthrough.** When the HA Conversation agent's
+  upstream LLM provider (Google AI / OpenAI / Anthropic) hits a quota or
+  overload error, HA wrapped the error in a successful Conversation response
+  and the user saw "This model is currently experiencing high demand…" verbatim instead of
+  a coaching answer. Aggregate-intent questions ("analyse my runs this year")
+  tripped this more often because their bigger context payload is more
+  likely to exceed Gemini Pro's load guardrail. New `isProviderError()`
+  detector now throws on these wrappers so the existing fallback chain
+  routes through Ollama instead. Bundles app **v0.17.10** which carries
+  the fix plus 6 new vitest cases.
+- **Manifest hygiene.** `io.hass.version` Dockerfile label now tracks the
+  add-on version (`0.17.11`) so the OCI image label and the manifest no
+  longer drift apart across releases.
+
 ## [0.17.10] - 2026-05-29
 
 ### Fixed

--- a/pulsecoach/Dockerfile
+++ b/pulsecoach/Dockerfile
@@ -15,7 +15,7 @@ WORKDIR /build
 # Clone the app source from GitHub
 # Use build arg timestamp for cache busting instead of GitHub API (avoids 403 rate limits)
 ARG APP_REPO=askb/ha-garmin-fitness-coach-app
-ARG APP_REF=v0.17.9
+ARG APP_REF=v0.17.10
 ARG CACHEBUST=1
 RUN echo "Cache bust: ${CACHEBUST}" && \
     git clone --depth=1 --branch="${APP_REF}" \
@@ -91,4 +91,4 @@ LABEL \
     io.hass.description="AI-powered sport scientist for Garmin athletes" \
     io.hass.arch="${BUILD_ARCH}" \
     io.hass.type="addon" \
-    io.hass.version="0.17.2"
+    io.hass.version="0.17.11"

--- a/pulsecoach/config.json
+++ b/pulsecoach/config.json
@@ -1,6 +1,6 @@
 {
   "name": "PulseCoach",
-  "version": "0.17.10",
+  "version": "0.17.11",
   "slug": "pulsecoach",
   "image": "ghcr.io/askb/pulsecoach-addon-{arch}",
   "description": "AI-powered sport scientist — training analysis, coaching, and recovery optimization from your Garmin data",


### PR DESCRIPTION
Bumps `APP_REF` v0.17.9 → **v0.17.10** which carries the upstream-provider fallthrough fix.

## What v0.17.10 fixes

When the HA Conversation agent's upstream LLM (Google AI / OpenAI / Anthropic) hits a quota or overload error, HA wraps the error in a *successful* Conversation response and the user sees:

> Sorry, I had a problem getting a response from Google Generative AI.: This model is currently experiencing high demand. Spikes in demand are usually temporary. Please try again later.

…instead of a coaching answer. Aggregate-intent questions (`'analyse my runs this year'`) tripped this more often because their bigger context payload is more likely to exceed Gemini Pro's load guardrail.

New `isProviderError()` detector now throws on those wrappers so the chat router's existing fallback chain routes through Ollama instead. See app PR [#225](https://github.com/askb/ha-garmin-fitness-coach-app/pull/225).

## Also in this release

Fixes Dockerfile metadata drift flagged in PR #177 review — `io.hass.version` now tracks the addon version (`0.17.11`) instead of being pinned at `0.17.2`.