### PR TITLE
ci: add e2e screenshot workflow for addon PRs

### DIFF
--- a/.github/workflows/e2e-screenshots.yml
+++ b/.github/workflows/e2e-screenshots.yml
@@ -51,7 +51,7 @@ jobs:
         # athlete profile harmlessly.
         persona: [athlete, recreational, beginner, detrained]
     steps:
-      - uses: step-security/harden-runner@f4a75cfd619ee5ce8d5b864b0d183aff3c69b55a  # v2.13.1
+      - uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411  # v2.19.4
         with:
           egress-policy: audit
 
@@ -59,7 +59,7 @@ jobs:
         with:
           persist-credentials: false
 
-      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020  # v4.4.0
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e  # v6.4.0
         with:
           node-version: "22"
 
@@ -157,7 +157,7 @@ jobs:
 
       - name: Upload screenshots
         if: always()
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02  # v4.6.2
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1
         with:
           name: screenshots-${{ matrix.persona }}
           path: |

--- a/.github/workflows/e2e-screenshots.yml
+++ b/.github/workflows/e2e-screenshots.yml
@@ -124,7 +124,7 @@ jobs:
             -e PERSONA="${PERSONA}" \
             pulsecoach sh -c '
               cd /app/packages/db &&
-              npm install --no-save tsx >/dev/null 2>&1 &&
+              npm install --no-save tsx >/dev/null &&
               echo "Seeding 90-day ${PERSONA} history…" &&
               npx tsx src/seed.ts &&
               echo "Seeding coach-loop e2e data…" &&

--- a/.github/workflows/e2e-screenshots.yml
+++ b/.github/workflows/e2e-screenshots.yml
@@ -1,0 +1,165 @@
+# SPDX-FileCopyrightText: 2026 Anil Belur <askb23@gmail.com>
+# SPDX-License-Identifier: Apache-2.0
+#
+# Runs the PulseCoach addon image standalone on a hosted runner (no HAOS,
+# no KVM), seeds athlete demo data, captures the dashboard screenshots via
+# Playwright, and structurally validates the result. This is the fast,
+# hermetic per-PR / per-release UI gate.
+#
+# The addon image is self-contained: it bundles its own PostgreSQL, pushes
+# the Drizzle schema at boot, runs Next.js on :3000, and honours
+# DEV_BYPASS_AUTH=true (session user "seed-user-001", matching the seed
+# scripts). See docs-mvp/pulsecoach E2E research for the design rationale.
+---
+name: E2E Screenshots
+
+"on":
+  workflow_dispatch:
+    inputs:
+      app_ref:
+        description: "App repo git ref to build into the addon image"
+        required: false
+        default: "main"
+  pull_request:
+    branches: [main]
+    paths:
+      - "pulsecoach/**"
+      - "tools/screenshots/**"
+      - ".github/workflows/e2e-screenshots.yml"
+
+permissions: {}
+
+concurrency:
+  group: "${{ github.workflow }}-${{ github.ref }}"
+  cancel-in-progress: true
+
+jobs:
+  screenshots:
+    name: Capture & validate (${{ matrix.persona }})
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    timeout-minutes: 45
+    strategy:
+      fail-fast: false
+      matrix:
+        # Single athlete persona today (seed.ts + seed-e2e.ts). Add
+        # recreational / beginner / detrained once seed.ts is parameterised
+        # by PERSONA (see docs-mvp pulsecoach E2E research, work item 1).
+        persona: [athlete]
+    steps:
+      - uses: step-security/harden-runner@f4a75cfd619ee5ce8d5b864b0d183aff3c69b55a  # v2.13.1
+        with:
+          egress-policy: audit
+
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020  # v4.4.0
+        with:
+          node-version: "22"
+
+      - name: Resolve build config
+        id: config
+        run: |
+          BUILD_FROM=$(jq -r '.build_from.amd64' pulsecoach/build.json)
+          VERSION=$(jq -r '.version' pulsecoach/config.json)
+          APP_REF="${{ github.event.inputs.app_ref || 'main' }}"
+          {
+            echo "build_from=${BUILD_FROM}"
+            echo "version=${VERSION}"
+            echo "app_ref=${APP_REF}"
+          } >> "$GITHUB_OUTPUT"
+          echo "Building addon v${VERSION} with app ref ${APP_REF}"
+
+      - name: Build addon image
+        run: |
+          docker build \
+            --build-arg BUILD_FROM="${{ steps.config.outputs.build_from }}" \
+            --build-arg BUILD_ARCH=amd64 \
+            --build-arg APP_REF="${{ steps.config.outputs.app_ref }}" \
+            --build-arg CACHEBUST="${{ github.sha }}" \
+            -t pulsecoach-e2e \
+            pulsecoach/
+
+      - name: Start addon container
+        run: |
+          docker run -d --name pulsecoach \
+            -e DEV_BYPASS_AUTH=true \
+            -e AI_BACKEND=none \
+            -p 3000:3000 \
+            pulsecoach-e2e
+          echo "Started container $(docker ps -q -f name=pulsecoach)"
+
+      - name: Wait for Next.js (:3000)
+        run: |
+          for i in $(seq 1 60); do
+            if curl -sf -o /dev/null http://localhost:3000/; then
+              echo "Next.js is up after ${i} attempts."
+              exit 0
+            fi
+            sleep 5
+          done
+          echo "::error::Next.js did not become ready in time"
+          docker logs pulsecoach || true
+          exit 1
+
+      - name: Seed ${{ matrix.persona }} data
+        env:
+          POSTGRES_URL: "postgresql://postgres@127.0.0.1:5432/pulsecoach"
+        run: |
+          # The seed scripts are TypeScript bundled at /app/packages/db/src
+          # and self-contained (drizzle-orm + pg, relative ./schema import).
+          # Run them inside the container with tsx.
+          docker exec \
+            -e POSTGRES_URL="${POSTGRES_URL}" \
+            pulsecoach sh -c '
+              cd /app/packages/db &&
+              npm install --no-save tsx >/dev/null 2>&1 &&
+              echo "Seeding 90-day athlete history…" &&
+              npx tsx src/seed.ts &&
+              echo "Seeding coach-loop e2e data…" &&
+              npx tsx src/seed-e2e.ts
+            '
+
+      - name: Refresh computed metrics
+        run: |
+          # Populate advanced metrics + the daily_athlete_summary matview so
+          # charts/readiness render. Best-effort — never fail the run on this.
+          docker exec pulsecoach \
+            python3 /app/scripts/metrics-compute.py --once || true
+
+      - name: Install Playwright (chromium)
+        working-directory: tools/screenshots
+        run: |
+          npm ci
+          npx playwright install --with-deps chromium
+
+      - name: Capture screenshots
+        working-directory: tools/screenshots
+        env:
+          BASE_URL: "http://localhost:3000"
+          SCREENSHOT_DIR: "screenshots/${{ matrix.persona }}"
+        run: npm run screenshot
+
+      - name: Validate screens
+        working-directory: tools/screenshots
+        run: node scripts/validate-screens.mjs "screenshots/${{ matrix.persona }}"
+
+      - name: Upload screenshots
+        if: always()
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02  # v4.6.2
+        with:
+          name: screenshots-${{ matrix.persona }}
+          path: |
+            tools/screenshots/screenshots/${{ matrix.persona }}
+            tools/screenshots/report
+          if-no-files-found: warn
+          retention-days: 14
+
+      - name: Container logs
+        if: always()
+        run: docker logs pulsecoach || true
+
+      - name: Tear down
+        if: always()
+        run: docker rm -f pulsecoach || true

--- a/.github/workflows/e2e-screenshots.yml
+++ b/.github/workflows/e2e-screenshots.yml
@@ -43,16 +43,21 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        # Single athlete persona today (seed.ts + seed-e2e.ts). Add
-        # recreational / beginner / detrained once seed.ts is parameterised
-        # by PERSONA (see docs-mvp pulsecoach E2E research, work item 1).
-        persona: [athlete]
+        # seed.ts is parameterised by PERSONA (app PR #227). Each persona
+        # seeds a distinct training archetype so a release captures
+        # representative screens across fitness levels. Personas other than
+        # "athlete" require an app build that includes #227 (APP_REF=main
+        # once merged); against older app refs the seed falls back to the
+        # athlete profile harmlessly.
+        persona: [athlete, recreational, beginner, detrained]
     steps:
       - uses: step-security/harden-runner@f4a75cfd619ee5ce8d5b864b0d183aff3c69b55a  # v2.13.1
         with:
           egress-policy: audit
 
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+        with:
+          persist-credentials: false
 
       - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020  # v4.4.0
         with:
@@ -60,10 +65,12 @@ jobs:
 
       - name: Resolve build config
         id: config
+        env:
+          APP_REF_INPUT: "${{ github.event.inputs.app_ref || 'main' }}"
         run: |
           BUILD_FROM=$(jq -r '.build_from.amd64' pulsecoach/build.json)
           VERSION=$(jq -r '.version' pulsecoach/config.json)
-          APP_REF="${{ github.event.inputs.app_ref || 'main' }}"
+          APP_REF="${APP_REF_INPUT}"
           {
             echo "build_from=${BUILD_FROM}"
             echo "version=${VERSION}"
@@ -106,16 +113,19 @@ jobs:
       - name: Seed ${{ matrix.persona }} data
         env:
           POSTGRES_URL: "postgresql://postgres@127.0.0.1:5432/pulsecoach"
+          PERSONA: "${{ matrix.persona }}"
         run: |
           # The seed scripts are TypeScript bundled at /app/packages/db/src
           # and self-contained (drizzle-orm + pg, relative ./schema import).
-          # Run them inside the container with tsx.
+          # Run them inside the container with tsx. PERSONA selects the
+          # training archetype (app PR #227).
           docker exec \
             -e POSTGRES_URL="${POSTGRES_URL}" \
+            -e PERSONA="${PERSONA}" \
             pulsecoach sh -c '
               cd /app/packages/db &&
               npm install --no-save tsx >/dev/null 2>&1 &&
-              echo "Seeding 90-day athlete history…" &&
+              echo "Seeding 90-day ${PERSONA} history…" &&
               npx tsx src/seed.ts &&
               echo "Seeding coach-loop e2e data…" &&
               npx tsx src/seed-e2e.ts

--- a/tools/screenshots/routes.mjs
+++ b/tools/screenshots/routes.mjs
@@ -1,0 +1,32 @@
+// SPDX-FileCopyrightText: 2026 Anil Belur <askb23@gmail.com>
+// SPDX-License-Identifier: Apache-2.0
+//
+// Single source of truth for the screenshot route manifest, consumed by
+// both the Playwright capture spec (tests/dashboard.spec.ts) and the
+// structural validator (scripts/validate-screens.mjs) so the two cannot
+// silently drift when a route is added or removed.
+//
+// `wait` tunes the post-load delay per route (charts render slower than
+// the landing page). `timeframes`, when set, captures one PNG per
+// DateRangeSelector tab label (e.g. fitness-7d-desktop.png) instead of a
+// single default-state capture.
+
+export const ROUTES = [
+  { name: "home", path: "/", wait: 4000 },
+  { name: "training", path: "/training", wait: 8000 },
+  {
+    name: "fitness",
+    path: "/fitness",
+    wait: 8000,
+    timeframes: ["7d", "14d", "28d", "90d", "180d", "1y"],
+  },
+  { name: "activities", path: "/activities", wait: 6000 },
+  { name: "sleep", path: "/sleep", wait: 5000 },
+  { name: "trends", path: "/trends", wait: 8000 },
+  { name: "zones", path: "/zones", wait: 6000 },
+  { name: "hrv", path: "/hrv", wait: 5000 },
+  { name: "vitals", path: "/vitals", wait: 5000 },
+  { name: "insights", path: "/insights", wait: 4000 },
+  { name: "coach", path: "/coach", wait: 4000 },
+  { name: "validation", path: "/validation", wait: 6000 },
+];

--- a/tools/screenshots/scripts/validate-screens.mjs
+++ b/tools/screenshots/scripts/validate-screens.mjs
@@ -1,0 +1,117 @@
+// SPDX-FileCopyrightText: 2026 Anil Belur <askb23@gmail.com>
+// SPDX-License-Identifier: Apache-2.0
+//
+// Structural validator for the screenshot suite. Confirms that every
+// expected route was captured for every project (desktop + mobile) and
+// that each PNG is non-trivial in size — a cheap, low-flake gate that
+// catches blank pages, error boundaries, and missing routes without
+// pixel-diff baselines.
+//
+// Usage:
+//   node scripts/validate-screens.mjs <screenshots-base-dir>
+//
+// Env:
+//   MIN_BYTES   minimum acceptable PNG size (default 5000)
+//   PROJECTS    comma-separated projects to require (default "desktop,mobile")
+
+import { readdirSync, statSync } from "node:fs";
+import { join } from "node:path";
+
+const baseDir = process.argv[2] ?? "screenshots";
+const minBytes = Number(process.env.MIN_BYTES ?? "5000");
+const projects = (process.env.PROJECTS ?? "desktop,mobile")
+  .split(",")
+  .map((p) => p.trim())
+  .filter(Boolean);
+
+// Routes the dashboard spec captures. Keep in sync with
+// tests/dashboard.spec.ts ROUTES.
+const ROUTES = [
+  "home",
+  "training",
+  "fitness",
+  "activities",
+  "sleep",
+  "trends",
+  "zones",
+  "hrv",
+  "vitals",
+  "insights",
+  "coach",
+  "validation",
+];
+
+function fail(msg) {
+  console.error(`❌ ${msg}`);
+  process.exitCode = 1;
+}
+
+// The spec writes to <baseDir>/<YYYY-MM-DD>/<route>-<project>.png. Pick the
+// most recent dated subdirectory.
+let datedDir;
+try {
+  const dirs = readdirSync(baseDir, { withFileTypes: true })
+    .filter((d) => d.isDirectory() && /^\d{4}-\d{2}-\d{2}$/.test(d.name))
+    .map((d) => d.name)
+    .sort();
+  datedDir = dirs.at(-1);
+} catch (err) {
+  fail(`Cannot read screenshots dir "${baseDir}": ${err.message}`);
+  process.exit(1);
+}
+
+if (!datedDir) {
+  fail(`No dated capture directory found under "${baseDir}".`);
+  process.exit(1);
+}
+
+const captureDir = join(baseDir, datedDir);
+console.log(`🔎 Validating screenshots in ${captureDir}`);
+
+let checked = 0;
+let ok = 0;
+for (const route of ROUTES) {
+  for (const project of projects) {
+    // fitness emits per-timeframe files (fitness-7d-desktop.png …) instead
+    // of a bare fitness-desktop.png, so match by prefix for that route.
+    const isWindowed = route === "fitness";
+    let matches = [];
+    try {
+      const files = readdirSync(captureDir);
+      matches = files.filter((f) =>
+        isWindowed
+          ? f.startsWith(`${route}-`) && f.endsWith(`-${project}.png`)
+          : f === `${route}-${project}.png`,
+      );
+    } catch {
+      matches = [];
+    }
+
+    checked++;
+    if (matches.length === 0) {
+      fail(`Missing capture: ${route}-${project}.png`);
+      continue;
+    }
+
+    let allBigEnough = true;
+    for (const m of matches) {
+      const size = statSync(join(captureDir, m)).size;
+      if (size < minBytes) {
+        fail(`${m} is only ${size} bytes (< ${minBytes}) — likely blank/error`);
+        allBigEnough = false;
+      }
+    }
+    if (allBigEnough) ok++;
+  }
+}
+
+console.log(
+  `\n📊 ${ok}/${checked} route×project captures valid ` +
+    `(min ${minBytes} bytes, projects: ${projects.join(", ")}).`,
+);
+
+if (process.exitCode === 1) {
+  console.error("\n❌ Screenshot validation failed.");
+} else {
+  console.log("\n✅ Screenshot validation passed.");
+}

--- a/tools/screenshots/scripts/validate-screens.mjs
+++ b/tools/screenshots/scripts/validate-screens.mjs
@@ -16,6 +16,7 @@
 
 import { readdirSync, statSync } from "node:fs";
 import { join } from "node:path";
+import { ROUTES as ROUTES_MANIFEST } from "../routes.mjs";
 
 const baseDir = process.argv[2] ?? "screenshots";
 const minBytes = Number(process.env.MIN_BYTES ?? "5000");
@@ -24,22 +25,15 @@ const projects = (process.env.PROJECTS ?? "desktop,mobile")
   .map((p) => p.trim())
   .filter(Boolean);
 
-// Routes the dashboard spec captures. Keep in sync with
-// tests/dashboard.spec.ts ROUTES.
-const ROUTES = [
-  "home",
-  "training",
-  "fitness",
-  "activities",
-  "sleep",
-  "trends",
-  "zones",
-  "hrv",
-  "vitals",
-  "insights",
-  "coach",
-  "validation",
-];
+// Routes the dashboard spec captures, from the shared manifest that the
+// spec (tests/dashboard.spec.ts) also imports — single source of truth, so
+// the validator and the capture spec cannot silently drift.
+const ROUTES = ROUTES_MANIFEST.map((r) => r.name);
+const WINDOWED = new Set(
+  ROUTES_MANIFEST.filter(
+    (r) => Array.isArray(r.timeframes) && r.timeframes.length > 0,
+  ).map((r) => r.name),
+);
 
 function fail(msg) {
   console.error(`❌ ${msg}`);
@@ -68,24 +62,24 @@ if (!datedDir) {
 const captureDir = join(baseDir, datedDir);
 console.log(`🔎 Validating screenshots in ${captureDir}`);
 
+// Enumerate the capture directory once and reuse it for every route×project
+// lookup. Let any unexpected filesystem error propagate so the failure mode
+// is clear rather than masquerading as a "Missing capture" message.
+const captureFiles = readdirSync(captureDir);
+
 let checked = 0;
 let ok = 0;
 for (const route of ROUTES) {
   for (const project of projects) {
-    // fitness emits per-timeframe files (fitness-7d-desktop.png …) instead
-    // of a bare fitness-desktop.png, so match by prefix for that route.
-    const isWindowed = route === "fitness";
-    let matches = [];
-    try {
-      const files = readdirSync(captureDir);
-      matches = files.filter((f) =>
-        isWindowed
-          ? f.startsWith(`${route}-`) && f.endsWith(`-${project}.png`)
-          : f === `${route}-${project}.png`,
-      );
-    } catch {
-      matches = [];
-    }
+    // Windowed routes (e.g. fitness) emit per-timeframe files
+    // (fitness-7d-desktop.png …) instead of a bare fitness-desktop.png, so
+    // match by prefix for those.
+    const isWindowed = WINDOWED.has(route);
+    const matches = captureFiles.filter((f) =>
+      isWindowed
+        ? f.startsWith(`${route}-`) && f.endsWith(`-${project}.png`)
+        : f === `${route}-${project}.png`,
+    );
 
     checked++;
     if (matches.length === 0) {

--- a/tools/screenshots/tests/dashboard.spec.ts
+++ b/tools/screenshots/tests/dashboard.spec.ts
@@ -3,12 +3,15 @@
 
 import path from "node:path";
 import { test } from "@playwright/test";
+import { ROUTES as ROUTES_MANIFEST } from "../routes.mjs";
 
 /**
- * Routes to capture. Add or remove freely — the spec runs once per route.
+ * Routes to capture come from the shared manifest in `../routes.mjs`, the
+ * single source of truth also consumed by scripts/validate-screens.mjs so
+ * the two cannot drift. Add or remove routes there.
  *
- * `wait` lets you tune the post-load delay per route (charts on
- * /training take longer to render than the landing page).
+ * `wait` tunes the post-load delay per route (charts on /training take
+ * longer to render than the landing page).
  *
  * `timeframes` is an optional list of DateRangeSelector tab labels
  * ("7d", "14d", "28d", "90d", "180d", "1y") to click and capture
@@ -17,25 +20,8 @@ import { test } from "@playwright/test";
  * This catches windowed-data regressions like sparse VO2max readings
  * that only render correctly on the longer windows (#163 follow-up).
  */
-const ROUTES: { name: string; path: string; wait?: number; timeframes?: string[] }[] = [
-  { name: "home", path: "/", wait: 4000 },
-  { name: "training", path: "/training", wait: 8000 },
-  {
-    name: "fitness",
-    path: "/fitness",
-    wait: 8000,
-    timeframes: ["7d", "14d", "28d", "90d", "180d", "1y"],
-  },
-  { name: "activities", path: "/activities", wait: 6000 },
-  { name: "sleep", path: "/sleep", wait: 5000 },
-  { name: "trends", path: "/trends", wait: 8000 },
-  { name: "zones", path: "/zones", wait: 6000 },
-  { name: "hrv", path: "/hrv", wait: 5000 },
-  { name: "vitals", path: "/vitals", wait: 5000 },
-  { name: "insights", path: "/insights", wait: 4000 },
-  { name: "coach", path: "/coach", wait: 4000 },
-  { name: "validation", path: "/validation", wait: 6000 },
-];
+const ROUTES: { name: string; path: string; wait?: number; timeframes?: string[] }[] =
+  ROUTES_MANIFEST;
 
 const OUT_DIR = process.env.SCREENSHOT_DIR ?? "screenshots";
 


### PR DESCRIPTION
## What

Adds `.github/workflows/e2e-screenshots.yml` + `tools/screenshots/scripts/validate-screens.mjs` — a hermetic, per-PR UI gate.

## How it works

1. **Build** the addon image, cloning the app at build time via the `APP_REF` build-arg (default `main`; overridable via `workflow_dispatch` `app_ref` to test unmerged **app** PRs end-to-end).
2. **Run** the container standalone: it bundles PostgreSQL, pushes the Drizzle schema at boot, serves Next.js on `:3000`, and runs with `DEV_BYPASS_AUTH=true` (session user `seed-user-001`) + `AI_BACKEND=none`.
3. **Seed** athlete demo data inside the container (`seed.ts` + `seed-e2e.ts` via `tsx`).
4. **Capture** all 12 dashboard routes × {desktop, mobile} with Playwright.
5. **Validate** structurally with `validate-screens.mjs` (every route present, every PNG over min byte size — catches blank/error pages without pixel baselines).
6. **Upload** screenshots as artifacts; always dump container logs + tear down.

No HAOS/KVM needed — runs on plain `ubuntu-latest`.

## Triggers

- `pull_request` → `main` on `pulsecoach/**`, `tools/screenshots/**`, or the workflow file
- `workflow_dispatch` with optional `app_ref` input

## Notes

- Actions are SHA-pinned; `harden-runner` in audit mode; `permissions: {}` at top with least-privilege `contents: read` on the job.
- Single **athlete** persona for now; recreational/beginner/detrained land once `seed.ts` is parameterised by persona.
- `actionlint` + `yamllint` clean; validator smoke-tested (24/24) against existing captures.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>