### PR TITLE
feat: data-quality gap detection + HA sensor (P1.4)

### DIFF
--- a/README.md
+++ b/README.md
@@ -163,7 +163,7 @@ graph TD
     PG --> Metrics
     Metrics --> PG
     PG --> Notify
-    Notify -->|7 sensors| HA
+    Notify -->|8 sensors| HA
     PG --> NextJS
     NextJS -.-> Ollama
     NextJS -.-> HA
@@ -315,14 +315,14 @@ PulseCoach authenticates with Garmin Connect using a **web-based auth flow**:
 - **Readiness card upgrade** — confidence %, data quality dots, action text
 - **8 new database tables** — session_report, intervention, advanced_metric, athlete_baseline, data_quality_log, audit_log, reference_measurement, ai_insight
 - **metrics-compute.py** — EWMA CTL/ATL/TSB/ACWR/CP computation service
-- **ha-notify.py** — pushes 7 sensors to HA + fires injury-risk alerts
+- **ha-notify.py** — pushes 8 sensors to HA + fires injury-risk alerts
 - **AI context pipeline** — 10 structured sections in every coaching prompt
 - **239 app tests** (Jest + Playwright) and **19 addon tests** (pytest)
 - **CI workflows** — typecheck + test + Docker build on every PR
 
 ## HA Sensors
 
-`ha-notify.py` pushes 7 sensors to Home Assistant via the Supervisor API:
+`ha-notify.py` pushes 8 sensors to Home Assistant via the Supervisor API:
 
 | Entity ID | Description |
 |-----------|-------------|

--- a/README.md
+++ b/README.md
@@ -333,6 +333,7 @@ PulseCoach authenticates with Garmin Connect using a **web-based auth flow**:
 | `sensor.pulsecoach_injury_risk` | Risk level: Low / Moderate / High / Very High |
 | `sensor.pulsecoach_body_battery` | Current Garmin Body Battery value |
 | `sensor.pulsecoach_sleep_debt` | Accumulated sleep debt (hours) |
+| `sensor.pulsecoach_data_quality` | Unresolved sync-gap count, with `missing_days_14d` / `stale_days` / `field_gaps` / `status` attributes |
 
 ## Automation Blueprints & Templates
 

--- a/README.md
+++ b/README.md
@@ -163,7 +163,7 @@ graph TD
     PG --> Metrics
     Metrics --> PG
     PG --> Notify
-    Notify -->|8 sensors| HA
+    Notify -->|sensors| HA
     PG --> NextJS
     NextJS -.-> Ollama
     NextJS -.-> HA
@@ -315,14 +315,14 @@ PulseCoach authenticates with Garmin Connect using a **web-based auth flow**:
 - **Readiness card upgrade** — confidence %, data quality dots, action text
 - **8 new database tables** — session_report, intervention, advanced_metric, athlete_baseline, data_quality_log, audit_log, reference_measurement, ai_insight
 - **metrics-compute.py** — EWMA CTL/ATL/TSB/ACWR/CP computation service
-- **ha-notify.py** — pushes 8 sensors to HA + fires injury-risk alerts
+- **ha-notify.py** — pushes Home Assistant sensors + fires injury-risk alerts
 - **AI context pipeline** — 10 structured sections in every coaching prompt
 - **239 app tests** (Jest + Playwright) and **19 addon tests** (pytest)
 - **CI workflows** — typecheck + test + Docker build on every PR
 
 ## HA Sensors
 
-`ha-notify.py` pushes 8 sensors to Home Assistant via the Supervisor API:
+`ha-notify.py` pushes a set of Home Assistant sensors via the Supervisor API, including:
 
 | Entity ID | Description |
 |-----------|-------------|

--- a/pulsecoach/CHANGELOG.md
+++ b/pulsecoach/CHANGELOG.md
@@ -27,6 +27,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   loopback memory-rebuild POSTs. The app's internal endpoint is fail-closed
   (rejects unauthenticated requests), so this keeps the nightly rebuild
   working without exposing an unauthenticated endpoint.
+- **Data-quality gap detection.** `metrics-compute.py` now detects missing
+  calendar days, stale sync, and missing per-day fields (HRV, resting HR,
+  sleep score) within a recent window and records them to the
+  `data_quality_log` table with provenance (no fabricated metric rows). A new
+  `sensor.pulsecoach_data_quality` surfaces the unresolved issue count plus
+  `missing_days_14d`, `stale_days`, `field_gaps`, and an `ok`/`warn`/`error`
+  status, and a persistent notification fires when sync is ≥3 days stale.
+  Window/threshold tunable via `DATA_QUALITY_WINDOW_DAYS`,
+  `DATA_QUALITY_STALE_WARN_DAYS`, `DATA_QUALITY_STALE_ERROR_DAYS`.
 
 ### Fixed
 

--- a/pulsecoach/CHANGELOG.md
+++ b/pulsecoach/CHANGELOG.md
@@ -34,8 +34,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `sensor.pulsecoach_data_quality` surfaces the unresolved issue count plus
   `missing_days_14d`, `stale_days`, `field_gaps`, and an `ok`/`warn`/`error`
   status, and a persistent notification fires when sync is ≥3 days stale.
-  Window/threshold tunable via `DATA_QUALITY_WINDOW_DAYS`,
-  `DATA_QUALITY_STALE_WARN_DAYS`, `DATA_QUALITY_STALE_ERROR_DAYS`.
+  The detection window and stale-day thresholds use sensible internal
+  defaults (30-day window; warn at 2 days, error at 7 days), read from the
+  `DATA_QUALITY_WINDOW_DAYS`, `DATA_QUALITY_STALE_WARN_DAYS`, and
+  `DATA_QUALITY_STALE_ERROR_DAYS` environment variables so they can be
+  overridden in custom builds.
 
 ### Fixed
 

--- a/pulsecoach/DOCS.md
+++ b/pulsecoach/DOCS.md
@@ -21,7 +21,7 @@ Home Assistant OS
 │   ├── pulsecoach orchestrator
 │   │   ├── garmin-sync.py      (Garmin Connect → PostgreSQL, every N min)
 │   │   ├── metrics-compute.py  (CTL/ATL/TSB/ACWR/CP → PostgreSQL, every 60 min)
-│   │   ├── ha-notify.py        (PostgreSQL → 7 HA sensors, every 30 min)
+│   │   ├── ha-notify.py        (PostgreSQL → 8 HA sensors, every 30 min)
 │   │   ├── Next.js standalone  (:3001, tRPC + Drizzle ORM)
 │   │   ├── ingress-proxy       (:3000 → :3001, HA path rewriting)
 │   │   └── process monitor     (restarts dead services every 60s)
@@ -110,7 +110,7 @@ Zones, Trends, and the AI Coach — is in the
 
 ## HA Sensors
 
-The addon pushes 7 sensors to Home Assistant via the Supervisor API:
+The addon pushes 8 sensors to Home Assistant via the Supervisor API:
 
 | Entity ID | Description |
 |-----------|-------------|

--- a/pulsecoach/DOCS.md
+++ b/pulsecoach/DOCS.md
@@ -121,6 +121,7 @@ The addon pushes 7 sensors to Home Assistant via the Supervisor API:
 | `sensor.pulsecoach_injury_risk` | Risk level: Low / Moderate / High / Very High |
 | `sensor.pulsecoach_body_battery` | Current Garmin Body Battery |
 | `sensor.pulsecoach_sleep_debt` | Accumulated sleep debt (hours) |
+| `sensor.pulsecoach_data_quality` | Unresolved sync-gap count (state) with `missing_days_14d`, `stale_days`, `field_gaps`, `status` (`ok`/`warn`/`error`) attributes |
 
 ## Resource Usage
 

--- a/pulsecoach/DOCS.md
+++ b/pulsecoach/DOCS.md
@@ -21,7 +21,7 @@ Home Assistant OS
 │   ├── pulsecoach orchestrator
 │   │   ├── garmin-sync.py      (Garmin Connect → PostgreSQL, every N min)
 │   │   ├── metrics-compute.py  (CTL/ATL/TSB/ACWR/CP → PostgreSQL, every 60 min)
-│   │   ├── ha-notify.py        (PostgreSQL → 8 HA sensors, every 30 min)
+│   │   ├── ha-notify.py        (PostgreSQL → HA sensors, every 30 min)
 │   │   ├── Next.js standalone  (:3001, tRPC + Drizzle ORM)
 │   │   ├── ingress-proxy       (:3000 → :3001, HA path rewriting)
 │   │   └── process monitor     (restarts dead services every 60s)
@@ -110,7 +110,7 @@ Zones, Trends, and the AI Coach — is in the
 
 ## HA Sensors
 
-The addon pushes 8 sensors to Home Assistant via the Supervisor API:
+The addon pushes a set of Home Assistant sensors via the Supervisor API, including:
 
 | Entity ID | Description |
 |-----------|-------------|

--- a/pulsecoach/rootfs/app/scripts/ha-notify.py
+++ b/pulsecoach/rootfs/app/scripts/ha-notify.py
@@ -491,6 +491,7 @@ def fetch_data_quality(cur, user_id: str) -> dict:
             WHERE user_id = %s
               AND resolved_at IS NULL
               AND date >= (CURRENT_DATE - INTERVAL '14 days')
+              AND date < CURRENT_DATE
             ORDER BY created_at DESC
             """,
             (user_id,),

--- a/pulsecoach/rootfs/app/scripts/ha-notify.py
+++ b/pulsecoach/rootfs/app/scripts/ha-notify.py
@@ -490,8 +490,7 @@ def fetch_data_quality(cur, user_id: str) -> dict:
             FROM data_quality_log
             WHERE user_id = %s
               AND resolved_at IS NULL
-              AND date >= (CURRENT_DATE - INTERVAL '14 days')
-              AND date < CURRENT_DATE
+              AND date >= (CURRENT_DATE - INTERVAL '13 days')
             ORDER BY created_at DESC
             """,
             (user_id,),

--- a/pulsecoach/rootfs/app/scripts/ha-notify.py
+++ b/pulsecoach/rootfs/app/scripts/ha-notify.py
@@ -469,6 +469,64 @@ def compute_injury_risk(acwr: float | None, tsb: float | None, ramp_rate: float 
     return (level, risk_score)
 
 
+def fetch_data_quality(cur, user_id: str) -> dict:
+    """Summarise unresolved data_quality_log entries for the HA sensor.
+
+    Returns a dict with counts + the most relevant stale-sync message. Safe
+    if the table doesn't exist yet (returns an empty/ok summary).
+    """
+    summary = {
+        "missing_days": 0,
+        "stale_days": 0,
+        "issues": 0,
+        "status": "ok",
+        "message": "All recent data present",
+        "field_gaps": [],
+    }
+    try:
+        cur.execute(
+            """
+            SELECT check_name, severity, message, raw_value, date::text AS d
+            FROM data_quality_log
+            WHERE user_id = %s
+              AND resolved_at IS NULL
+              AND date >= (CURRENT_DATE - INTERVAL '14 days')
+            ORDER BY created_at DESC
+            """,
+            (user_id,),
+        )
+        rows = cur.fetchall()
+    except Exception as exc:  # table missing / transient
+        print(f"[ha-notify] data_quality unavailable: {exc}", file=sys.stderr)
+        return summary
+
+    if not rows:
+        return summary
+
+    severities = {"info": 0, "warn": 1, "error": 2}
+    worst = 0
+    for r in rows:
+        cn = r["check_name"]
+        worst = max(worst, severities.get(r["severity"], 0))
+        if cn == "missing_day":
+            summary["missing_days"] += 1
+        elif cn == "stale_data":
+            summary["stale_days"] = int(r["raw_value"] or 0)
+            summary["message"] = r["message"]
+        elif cn == "missing_field":
+            summary["field_gaps"].append(r["message"])
+
+    summary["issues"] = sum(
+        1 for r in rows if r["severity"] in ("warn", "error")
+    )
+    summary["status"] = {0: "ok", 1: "warn", 2: "error"}[worst]
+    if summary["missing_days"] and summary["message"] == "All recent data present":
+        summary["message"] = (
+            f"{summary['missing_days']} day(s) missing in the last 14 days"
+        )
+    return summary
+
+
 def run_notifications(user_id: str):
     """Push all sensor states and check for alerts."""
     print(f"[ha-notify] Running notification pass for user {user_id}...")
@@ -709,8 +767,30 @@ def run_notifications(user_id: str):
             f"Risk: {risk_level}, Workout: {workout['workout_type']}"
         )
 
+        # sensor.pulsecoach_data_quality — transparency on sync gaps
+        dq = fetch_data_quality(cur, user_id)
+        push_sensor("sensor.pulsecoach_data_quality",
+                    dq["issues"],
+                    {
+                        "friendly_name": "PulseCoach Data Quality",
+                        "unit_of_measurement": "issues",
+                        "icon": "mdi:database-check" if dq["status"] == "ok"
+                                else "mdi:database-alert",
+                        "status": dq["status"],
+                        "missing_days_14d": dq["missing_days"],
+                        "stale_days": dq["stale_days"],
+                        "field_gaps": dq["field_gaps"],
+                        "message": dq["message"],
+                    })
+
         # --- Alert notifications ---
         alerts = []
+
+        if dq["stale_days"] >= 3:
+            alerts.append(("📡 PulseCoach Data Sync Stale",
+                          f"{dq['message']}. Check the Garmin sync — readiness and "
+                          f"load metrics may be out of date.",
+                          "gc_data_stale"))
 
         if acwr and acwr > 1.5:
             alerts.append(("🔴 High Injury Risk — ACWR",

--- a/pulsecoach/rootfs/app/scripts/metrics-compute.py
+++ b/pulsecoach/rootfs/app/scripts/metrics-compute.py
@@ -57,6 +57,13 @@ ACWR_ACUTE_DAYS = 7       # acute rolling-mean window (Hulin et al. 2016)
 ACWR_CHRONIC_DAYS = 28    # chronic rolling-mean window (Hulin et al. 2016)
 RAMP_LOOKBACK_DAYS = 7    # ramp rate = CTL change over the trailing week
 
+# Data-quality gap detection
+GAP_WINDOW_DAYS = int(os.environ.get("DATA_QUALITY_WINDOW_DAYS", "30"))
+STALE_WARN_DAYS = int(os.environ.get("DATA_QUALITY_STALE_WARN_DAYS", "2"))
+STALE_ERROR_DAYS = int(os.environ.get("DATA_QUALITY_STALE_ERROR_DAYS", "7"))
+# Per-row fields whose absence in recent days is worth flagging.
+GAP_FIELDS = ("hrv", "resting_hr", "sleep_score")
+
 
 def get_db():
     return psycopg2.connect(DATABASE_URL)
@@ -162,6 +169,152 @@ def ensure_advanced_metric_table(cur):
             WHEN unique_violation THEN NULL;
         END $$;
     """)
+
+
+def ensure_data_quality_log_table(cur):
+    """Create the data_quality_log table if Drizzle hasn't yet.
+
+    Mirrors packages/db/src/schema.ts `DataQualityLog`. The addon may run a
+    fresh Postgres before the app's migrations apply, so guard with
+    CREATE TABLE IF NOT EXISTS (same rationale as ensure_advanced_metric_table).
+    """
+    cur.execute("""
+        CREATE TABLE IF NOT EXISTS data_quality_log (
+            id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+            user_id TEXT NOT NULL,
+            date DATE NOT NULL,
+            check_name VARCHAR(50) NOT NULL,
+            severity VARCHAR(10) NOT NULL,
+            message TEXT NOT NULL,
+            raw_value DOUBLE PRECISION,
+            expected_range JSONB,
+            resolved_at TIMESTAMP,
+            created_at TIMESTAMP DEFAULT NOW() NOT NULL
+        );
+    """)
+
+
+def datetime_now_user_tz_date() -> date:
+    """Return today's date in the user's configured timezone."""
+    from datetime import datetime as _dt
+    return _dt.now(USER_TZ).date()
+
+
+def detect_and_log_gaps(cur, user_id: str, today=None) -> dict:
+    """Detect data gaps and write provenance rows to data_quality_log.
+
+    Honest-by-design: we never fabricate metric rows. Instead we *detect*
+    missing calendar days, stale sync, and missing per-day fields within a
+    recent window, and record them so the UI and an HA sensor can surface
+    "N days missing" transparently.
+
+    Idempotent: clears this user's previously auto-generated unresolved gap
+    rows for the window before re-inserting the current snapshot.
+
+    Returns a summary dict consumed by the run log (and, indirectly via the
+    table, by ha-notify's data-quality sensor).
+    """
+    if today is None:
+        today = datetime_now_user_tz_date()
+
+    cur.execute(
+        """
+        SELECT date::text AS d, hrv, resting_hr, sleep_score
+        FROM daily_metric
+        WHERE user_id = %s AND date IS NOT NULL
+        ORDER BY date ASC
+        """,
+        (user_id,),
+    )
+    rows = cur.fetchall()
+    summary = {
+        "latest_date": None,
+        "stale_days": 0,
+        "missing_days_window": 0,
+        "missing_dates": [],
+        "field_gaps": dict.fromkeys(GAP_FIELDS, 0),
+    }
+    if not rows:
+        return summary
+
+    present = {r["d"]: r for r in rows}
+    latest = date.fromisoformat(rows[-1]["d"])
+    summary["latest_date"] = latest.isoformat()
+    summary["stale_days"] = max(0, (today - latest).days)
+
+    # Window: the trailing GAP_WINDOW_DAYS up to the latest synced day,
+    # never starting before the first ever record.
+    earliest = date.fromisoformat(rows[0]["d"])
+    window_start = max(earliest, latest - timedelta(days=GAP_WINDOW_DAYS - 1))
+
+    missing_dates = []
+    cur_day = window_start
+    while cur_day <= latest:
+        if cur_day.isoformat() not in present:
+            missing_dates.append(cur_day.isoformat())
+        cur_day += timedelta(days=1)
+    summary["missing_dates"] = missing_dates
+    summary["missing_days_window"] = len(missing_dates)
+
+    # Per-field gaps within the last 14 days of present rows.
+    recent_cutoff = latest - timedelta(days=13)
+    for d_str, r in present.items():
+        if date.fromisoformat(d_str) < recent_cutoff:
+            continue
+        for f in GAP_FIELDS:
+            if r.get(f) is None:
+                summary["field_gaps"][f] += 1
+
+    # --- Persist: clear prior auto rows for this window, then insert. ---
+    auto_checks = ("missing_day", "stale_data", "missing_field")
+    cur.execute(
+        """
+        DELETE FROM data_quality_log
+        WHERE user_id = %s
+          AND check_name = ANY(%s)
+          AND resolved_at IS NULL
+          AND date >= %s
+        """,
+        (user_id, list(auto_checks), window_start.isoformat()),
+    )
+
+    inserts = []
+    today_iso = today.isoformat()
+    for md in missing_dates:
+        recent = date.fromisoformat(md) >= (latest - timedelta(days=6))
+        inserts.append((
+            user_id, md, "missing_day", "warn" if recent else "info",
+            f"No synced data for {md}", None, None,
+        ))
+    if summary["stale_days"] >= STALE_WARN_DAYS:
+        sev = "error" if summary["stale_days"] >= STALE_ERROR_DAYS else "warn"
+        inserts.append((
+            user_id, today_iso, "stale_data", sev,
+            f"Latest synced data is {summary['stale_days']} day(s) old "
+            f"(last: {latest.isoformat()})",
+            float(summary["stale_days"]), None,
+        ))
+    for f, count in summary["field_gaps"].items():
+        if count > 0:
+            inserts.append((
+                user_id, latest.isoformat(), "missing_field", "info",
+                f"{f} missing on {count} of the last 14 day(s)",
+                float(count), None,
+            ))
+
+    if inserts:
+        psycopg2.extras.execute_values(
+            cur,
+            """
+            INSERT INTO data_quality_log
+                (user_id, date, check_name, severity, message,
+                 raw_value, expected_range)
+            VALUES %s
+            """,
+            inserts,
+        )
+
+    return summary
 
 
 def fetch_daily_loads(cur, user_id):
@@ -623,6 +776,7 @@ def run_compute(user_id: str):
     cur = db.cursor(cursor_factory=psycopg2.extras.RealDictCursor)
     try:
         ensure_advanced_metric_table(cur)
+        ensure_data_quality_log_table(cur)
         daily_loads = fetch_daily_loads(cur, user_id)
         if not daily_loads:
             print("[metrics-compute] No daily load data found — skipping")
@@ -639,6 +793,13 @@ def run_compute(user_id: str):
         readiness_data = compute_readiness_score(cur, user_id)
         if readiness_data:
             upsert_readiness_scores(cur, user_id, readiness_data)
+
+        # Detect data gaps + stale sync, log to data_quality_log (provenance).
+        gap_summary = {}
+        try:
+            gap_summary = detect_and_log_gaps(cur, user_id)
+        except Exception as gap_err:
+            print(f"[metrics-compute] Gap detection skipped: {gap_err}", file=sys.stderr)
 
         db.commit()
 
@@ -676,6 +837,14 @@ def run_compute(user_id: str):
             f"{len(readiness_data)} readiness scores, "
             f"{'CP computed' if cp_data else 'no CP data'}"
         )
+        if gap_summary:
+            print(
+                f"[metrics-compute] Data quality — "
+                f"{gap_summary.get('missing_days_window', 0)} missing day(s) "
+                f"in last {GAP_WINDOW_DAYS}d, "
+                f"latest sync {gap_summary.get('latest_date')}, "
+                f"{gap_summary.get('stale_days', 0)}d stale"
+            )
 
         # Refresh materialized view for consistent downstream queries
         try:

--- a/pulsecoach/rootfs/app/scripts/metrics-compute.py
+++ b/pulsecoach/rootfs/app/scripts/metrics-compute.py
@@ -795,10 +795,15 @@ def run_compute(user_id: str):
             upsert_readiness_scores(cur, user_id, readiness_data)
 
         # Detect data gaps + stale sync, log to data_quality_log (provenance).
+        # Isolated in a SAVEPOINT so a gap-detection failure cannot abort the
+        # surrounding transaction and roll back the readiness/advanced metrics.
         gap_summary = {}
+        cur.execute("SAVEPOINT gap_detect")
         try:
             gap_summary = detect_and_log_gaps(cur, user_id)
+            cur.execute("RELEASE SAVEPOINT gap_detect")
         except Exception as gap_err:
+            cur.execute("ROLLBACK TO SAVEPOINT gap_detect")
             print(f"[metrics-compute] Gap detection skipped: {gap_err}", file=sys.stderr)
 
         db.commit()

--- a/tests/test_ha_notify_data_quality.py
+++ b/tests/test_ha_notify_data_quality.py
@@ -1,0 +1,110 @@
+# SPDX-FileCopyrightText: 2026 Anil Belur <askb23@gmail.com>
+# SPDX-License-Identifier: Apache-2.0
+"""Tests for ha-notify.py fetch_data_quality summary."""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+import types
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+SCRIPTS_DIR = (
+    Path(__file__).resolve().parents[1]
+    / "pulsecoach" / "rootfs" / "app" / "scripts"
+)
+
+
+class FakeCursor:
+    """Minimal cursor returning a fixed data_quality_log result set."""
+
+    def __init__(self, rows: list[dict[str, Any]] | Exception) -> None:
+        self._rows = rows
+
+    def execute(self, _query: str, _params: tuple[Any, ...]) -> None:
+        if isinstance(self._rows, Exception):
+            raise self._rows
+
+    def fetchall(self) -> list[dict[str, Any]]:
+        assert not isinstance(self._rows, Exception)
+        return self._rows
+
+
+def load_ha_notify(monkeypatch: pytest.MonkeyPatch) -> types.ModuleType:
+    monkeypatch.setenv("DATABASE_URL", "postgresql://test:test@127.0.0.1:5432/test")
+    monkeypatch.setenv("USER_TIMEZONE", "UTC")
+    spec = importlib.util.spec_from_file_location(
+        "ha_notify", SCRIPTS_DIR / "ha-notify.py"
+    )
+    assert spec and spec.loader
+    module = importlib.util.module_from_spec(spec)
+    sys.modules["ha_notify"] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+def _dq_row(check_name: str, severity: str, message: str,
+            raw_value: float | None = None, d: str = "2025-01-04") -> dict:
+    return {
+        "check_name": check_name,
+        "severity": severity,
+        "message": message,
+        "raw_value": raw_value,
+        "d": d,
+    }
+
+
+def test_no_rows_is_ok(monkeypatch: pytest.MonkeyPatch) -> None:
+    mod = load_ha_notify(monkeypatch)
+    dq = mod.fetch_data_quality(FakeCursor([]), "user-1")
+    assert dq["status"] == "ok"
+    assert dq["issues"] == 0
+    assert dq["missing_days"] == 0
+
+
+def test_missing_table_returns_safe_default(monkeypatch: pytest.MonkeyPatch) -> None:
+    mod = load_ha_notify(monkeypatch)
+    dq = mod.fetch_data_quality(FakeCursor(RuntimeError("no such table")), "user-1")
+    assert dq["status"] == "ok"
+    assert dq["issues"] == 0
+
+
+def test_counts_missing_days_and_status(monkeypatch: pytest.MonkeyPatch) -> None:
+    mod = load_ha_notify(monkeypatch)
+    rows = [
+        _dq_row("missing_day", "warn", "No synced data for 2025-01-03"),
+        _dq_row("missing_day", "warn", "No synced data for 2025-01-02"),
+    ]
+    dq = mod.fetch_data_quality(FakeCursor(rows), "user-1")
+    assert dq["missing_days"] == 2
+    assert dq["issues"] == 2
+    assert dq["status"] == "warn"
+    assert "2 day(s) missing" in dq["message"]
+
+
+def test_stale_data_error_severity(monkeypatch: pytest.MonkeyPatch) -> None:
+    mod = load_ha_notify(monkeypatch)
+    rows = [
+        _dq_row("stale_data", "error",
+                "Latest synced data is 10 day(s) old (last: 2025-01-01)",
+                raw_value=10.0),
+    ]
+    dq = mod.fetch_data_quality(FakeCursor(rows), "user-1")
+    assert dq["status"] == "error"
+    assert dq["stale_days"] == 10
+    assert "10 day(s) old" in dq["message"]
+
+
+def test_field_gaps_collected(monkeypatch: pytest.MonkeyPatch) -> None:
+    mod = load_ha_notify(monkeypatch)
+    rows = [
+        _dq_row("missing_field", "info",
+                "hrv missing on 3 of the last 14 day(s)", raw_value=3.0),
+    ]
+    dq = mod.fetch_data_quality(FakeCursor(rows), "user-1")
+    assert dq["field_gaps"] == ["hrv missing on 3 of the last 14 day(s)"]
+    # info-only -> status stays ok
+    assert dq["status"] == "ok"

--- a/tests/test_metrics_compute.py
+++ b/tests/test_metrics_compute.py
@@ -516,3 +516,91 @@ class TestFetchDailyLoads:
         cur = MagicMock()
         cur.fetchall.side_effect = [[], []]
         assert metrics_compute.fetch_daily_loads(cur, "user-1") == {}
+
+
+class TestDetectAndLogGaps:
+    """detect_and_log_gaps must find missing days, stale sync and field gaps."""
+
+    @staticmethod
+    def _row(d, hrv=50.0, resting_hr=48.0, sleep_score=80.0):
+        return {"d": d, "hrv": hrv, "resting_hr": resting_hr,
+                "sleep_score": sleep_score}
+
+    def _run(self, metrics_compute, rows, today, capture):
+        cur = MagicMock()
+        cur.fetchall.return_value = rows
+
+        def _capture_values(_cur, _sql, argslist):
+            capture.extend(argslist)
+
+        with patch.object(
+            metrics_compute.psycopg2.extras, "execute_values", _capture_values
+        ):
+            return metrics_compute.detect_and_log_gaps(cur, "user-1", today=today)
+
+    def test_no_rows_returns_zeroed_summary(self, metrics_compute):
+        cur = MagicMock()
+        cur.fetchall.return_value = []
+        summary = metrics_compute.detect_and_log_gaps(
+            cur, "user-1", today=date(2025, 2, 1)
+        )
+        assert summary["missing_days_window"] == 0
+        assert summary["latest_date"] is None
+
+    def test_detects_interior_missing_day(self, metrics_compute):
+        rows = [
+            self._row("2025-01-01"),
+            self._row("2025-01-02"),
+            # 2025-01-03 missing
+            self._row("2025-01-04"),
+        ]
+        inserts = []
+        summary = self._run(
+            metrics_compute, rows, date(2025, 1, 4), inserts
+        )
+        assert summary["missing_days_window"] == 1
+        assert "2025-01-03" in summary["missing_dates"]
+        # A missing_day row must be queued for insert.
+        assert any(r[2] == "missing_day" and r[1] == "2025-01-03"
+                   for r in inserts)
+
+    def test_recent_missing_day_is_warn(self, metrics_compute):
+        rows = [self._row("2025-01-01"), self._row("2025-01-04")]
+        inserts = []
+        self._run(metrics_compute, rows, date(2025, 1, 4), inserts)
+        # 2025-01-02 / -03 are within 6 days of latest -> warn severity.
+        missing = [r for r in inserts if r[2] == "missing_day"]
+        assert missing and all(r[3] == "warn" for r in missing)
+
+    def test_stale_sync_flagged_with_escalating_severity(self, metrics_compute):
+        rows = [self._row("2025-01-01")]
+        # 3 days stale -> warn
+        inserts = []
+        summary = self._run(metrics_compute, rows, date(2025, 1, 4), inserts)
+        assert summary["stale_days"] == 3
+        stale = [r for r in inserts if r[2] == "stale_data"]
+        assert stale and stale[0][3] == "warn"
+
+        # 10 days stale -> error
+        inserts2 = []
+        summary2 = self._run(metrics_compute, rows, date(2025, 1, 11), inserts2)
+        assert summary2["stale_days"] == 10
+        stale2 = [r for r in inserts2 if r[2] == "stale_data"]
+        assert stale2 and stale2[0][3] == "error"
+
+    def test_fresh_sync_not_flagged_stale(self, metrics_compute):
+        rows = [self._row("2025-01-03"), self._row("2025-01-04")]
+        inserts = []
+        summary = self._run(metrics_compute, rows, date(2025, 1, 4), inserts)
+        assert summary["stale_days"] == 0
+        assert not [r for r in inserts if r[2] == "stale_data"]
+
+    def test_missing_field_counted_and_logged(self, metrics_compute):
+        rows = [
+            self._row("2025-01-03", hrv=None),
+            self._row("2025-01-04", hrv=None),
+        ]
+        inserts = []
+        summary = self._run(metrics_compute, rows, date(2025, 1, 4), inserts)
+        assert summary["field_gaps"]["hrv"] == 2
+        assert any(r[2] == "missing_field" for r in inserts)


### PR DESCRIPTION
## P1.4 — Gap imputation + alerts (AI-native closed loop)

Surfaces sync gaps **transparently** instead of silently fabricating data — extends the quality-gate philosophy to the data layer.

### What
- **`metrics-compute.py`** — new `detect_and_log_gaps()` runs each compute pass:
  - missing calendar days within a trailing window
  - stale sync (latest synced day vs today, escalating warn→error)
  - missing per-day fields (HRV, resting HR, sleep score) over the last 14 days
  - writes provenance rows to `data_quality_log` (idempotent per-window snapshot); **never fabricates metric rows**.
  - tunable: `DATA_QUALITY_WINDOW_DAYS`, `DATA_QUALITY_STALE_WARN_DAYS`, `DATA_QUALITY_STALE_ERROR_DAYS`.
- **`ha-notify.py`** — new `sensor.pulsecoach_data_quality` (issue count + `missing_days_14d` / `stale_days` / `field_gaps` / `status` attrs) and a persistent notification when sync is ≥3 days stale.

### Why
Readiness/load baselines silently degrade when days are missing. Now the user (and HA automations) can see *"N days missing"* / *"sync N days stale"* and act.

### Tests
11 new pytest cases (6 gap-detection, 5 sensor summary). Full suite **230 pass**. ruff-clean on new code. DOCS/README sensor tables + CHANGELOG Unreleased updated.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>