### PR TITLE
feat: capture Garmin running dynamics in activity sync

### DIFF
--- a/pulsecoach/CHANGELOG.md
+++ b/pulsecoach/CHANGELOG.md
@@ -39,6 +39,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `DATA_QUALITY_WINDOW_DAYS`, `DATA_QUALITY_STALE_WARN_DAYS`, and
   `DATA_QUALITY_STALE_ERROR_DAYS` environment variables so they can be
   overridden in custom builds.
+- **Running-dynamics capture.** `garmin-sync.py` now populates the
+  long-existing but previously-empty activity columns
+  `avg_ground_contact_time`, `gct_balance`, `vertical_oscillation`,
+  `vertical_ratio`, `stride_length`, `avg_respiration_rate`,
+  `elevation_gain`, and `elevation_loss` from the Garmin activity summary.
+  Extraction is defensive (missing keys → `NULL`), so non-running activities
+  sync cleanly. The app already consumes these fields (activity router →
+  running-form score → activity detail page), so existing running activities
+  surface ground-contact, vertical-oscillation, stride-length and L/R
+  balance after the next sync.
 
 ### Fixed
 

--- a/pulsecoach/DOCS.md
+++ b/pulsecoach/DOCS.md
@@ -93,7 +93,7 @@ fetches up to 6 years of historical data.
 | **Today** | Daily readiness score (0-100), body battery, recent activities, quick insights |
 | **Training** | CTL / ATL / TSB fitness-fatigue chart, ACWR injury-risk gauge, load focus, recovery time |
 | **Fitness** | VO2max trends, VDOT score, race predictions (5K / 10K / half / marathon) with confidence intervals |
-| **Activities** | Activity detail — laps, efficiency factor, GAP, RPE, zone distribution |
+| **Activities** | Activity detail — laps, efficiency factor, GAP, RPE, zone distribution, running dynamics (ground-contact time/balance, vertical oscillation/ratio, stride length) |
 | **Insights** | Proactive AI insight cards — 6-rule engine (ACWR, TSB, HRV, sleep debt, ramp rate, interventions) |
 | **Journal** | Whoop-style daily check-in (body feel, inputs, cycle tracking) |
 | **Interventions** | Recovery intervention log with effectiveness ratings |

--- a/pulsecoach/rootfs/app/scripts/garmin-sync.py
+++ b/pulsecoach/rootfs/app/scripts/garmin-sync.py
@@ -629,6 +629,19 @@ def _upsert_activity(cur, act: dict, act_id: str) -> None:
     if not isinstance(activity_type, dict):
         activity_type = {}
 
+    # Running dynamics (present on running activity summaries; None otherwise).
+    # Columns already exist in the Drizzle schema but were never populated.
+    running_dynamics = (
+        act.get("avgGroundContactTime"),       # ms
+        act.get("avgGroundContactBalance"),     # % (L/R)
+        act.get("avgVerticalOscillation"),      # cm
+        act.get("avgVerticalRatio"),            # %
+        act.get("avgStrideLength"),             # cm
+        act.get("avgRespirationRate"),          # brpm
+        act.get("elevationGain"),               # m
+        act.get("elevationLoss"),               # m
+    )
+
     cur.execute("""
         INSERT INTO activity (
             user_id, garmin_activity_id, sport_type, sub_type,
@@ -638,8 +651,11 @@ def _upsert_activity(cur, act: dict, act_id: str) -> None:
             trimp_score, strain_score,
             avg_power, normalized_power, max_power,
             avg_cadence, max_cadence,
+            avg_ground_contact_time, gct_balance,
+            vertical_oscillation, vertical_ratio, stride_length,
+            avg_respiration_rate, elevation_gain, elevation_loss,
             synced_at, raw_garmin_data
-        ) VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s)
+        ) VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s)
         ON CONFLICT (garmin_activity_id) DO UPDATE SET
             hr_zone_minutes = COALESCE(EXCLUDED.hr_zone_minutes, activity.hr_zone_minutes),
             trimp_score = COALESCE(EXCLUDED.trimp_score, activity.trimp_score),
@@ -649,6 +665,14 @@ def _upsert_activity(cur, act: dict, act_id: str) -> None:
             max_power = COALESCE(EXCLUDED.max_power, activity.max_power),
             avg_cadence = COALESCE(EXCLUDED.avg_cadence, activity.avg_cadence),
             max_cadence = COALESCE(EXCLUDED.max_cadence, activity.max_cadence),
+            avg_ground_contact_time = COALESCE(EXCLUDED.avg_ground_contact_time, activity.avg_ground_contact_time),
+            gct_balance = COALESCE(EXCLUDED.gct_balance, activity.gct_balance),
+            vertical_oscillation = COALESCE(EXCLUDED.vertical_oscillation, activity.vertical_oscillation),
+            vertical_ratio = COALESCE(EXCLUDED.vertical_ratio, activity.vertical_ratio),
+            stride_length = COALESCE(EXCLUDED.stride_length, activity.stride_length),
+            avg_respiration_rate = COALESCE(EXCLUDED.avg_respiration_rate, activity.avg_respiration_rate),
+            elevation_gain = COALESCE(EXCLUDED.elevation_gain, activity.elevation_gain),
+            elevation_loss = COALESCE(EXCLUDED.elevation_loss, activity.elevation_loss),
             synced_at = EXCLUDED.synced_at,
             raw_garmin_data = EXCLUDED.raw_garmin_data
     """, (
@@ -673,6 +697,7 @@ def _upsert_activity(cur, act: dict, act_id: str) -> None:
         act.get("maxPower"),
         avg_cadence,
         max_cadence,
+        *running_dynamics,
         datetime.now(timezone.utc).isoformat(),
         json.dumps(act),
     ))

--- a/tests/test_garmin_sync.py
+++ b/tests/test_garmin_sync.py
@@ -108,6 +108,14 @@ def mock_client():
             "hrTimeInZone_3": 600,   # 10 min
             "hrTimeInZone_4": 420,   # 7 min
             "hrTimeInZone_5": 300,   # 5 min
+            "avgGroundContactTime": 240.0,        # ms
+            "avgGroundContactBalance": 49.5,      # % L/R
+            "avgVerticalOscillation": 8.2,        # cm
+            "avgVerticalRatio": 6.1,              # %
+            "avgStrideLength": 118.0,             # cm
+            "avgRespirationRate": 38.0,           # brpm
+            "elevationGain": 120.0,               # m
+            "elevationLoss": 95.0,                # m
         },
     ]
     return client
@@ -503,6 +511,44 @@ class TestSyncActivities:
         assert hr_zones["zone3"] == 10.0   # 600 s / 60
         assert hr_zones["zone4"] == 7.0    # 420 s / 60
         assert hr_zones["zone5"] == 5.0    # 300 s / 60
+
+    def test_extracts_running_dynamics(self, garmin_sync, mock_db, mock_client):
+        """Running-dynamics fields are pulled from the activity summary.
+
+        These columns already exist in the Drizzle schema and are consumed
+        by the app (activity router -> runningFormScore -> detail page) but
+        were previously never populated by the sync. The INSERT must carry
+        ground-contact time/balance, vertical oscillation/ratio, stride
+        length, respiration rate and elevation gain/loss.
+        """
+        conn, cursor = mock_db
+        garmin_sync.sync_activities(mock_client, conn, days=7)
+        insert_call = self._get_activity_insert_call(cursor)
+        assert insert_call is not None
+        values = insert_call[0][1]
+        for expected in (240.0, 49.5, 8.2, 6.1, 118.0, 38.0, 120.0, 95.0):
+            assert expected in values
+
+    def test_running_dynamics_default_to_none(
+        self, garmin_sync, mock_db, mock_client
+    ):
+        """Activities without running dynamics (e.g. cycling) store NULLs.
+
+        Field extraction is defensive: missing keys resolve to None rather
+        than raising, so non-running activities sync cleanly.
+        """
+        conn, cursor = mock_db
+        record = mock_client.get_activities.return_value[0]
+        for key in (
+            "avgGroundContactTime", "avgGroundContactBalance",
+            "avgVerticalOscillation", "avgVerticalRatio",
+            "avgStrideLength", "avgRespirationRate",
+            "elevationGain", "elevationLoss",
+        ):
+            record.pop(key, None)
+        garmin_sync.sync_activities(mock_client, conn, days=7)
+        insert_call = self._get_activity_insert_call(cursor)
+        assert insert_call is not None  # no exception, row still inserted
 
     def test_calculates_trimp_score(self, garmin_sync, mock_db, mock_client):
         """TRIMP is computed from avg HR and duration and included in the INSERT.


### PR DESCRIPTION
## Summary

Roadmap **P2.1 (metrics expansion)** — the highest-value, lowest-risk subset.

The `activity` table has long carried running-dynamics columns
(`avg_ground_contact_time`, `gct_balance`, `vertical_oscillation`,
`vertical_ratio`, `stride_length`, `avg_respiration_rate`,
`elevation_gain`, `elevation_loss`) and the **app already consumes them**
via the activity router's running-form score → activity detail page. But the
sync never populated them, so that section always rendered empty.

This wires `garmin-sync.py`'s `_upsert_activity` to extract these fields
from the Garmin activity summary.

## Why this is low-risk
- **No schema change** — columns already exist in the Drizzle schema.
- **No app change** — the consumer chain (router → `runningFormScore` →
  detail page) already exists; it was just receiving NULLs.
- **Defensive extraction** — missing keys → `None`, so cycling and other
  non-running activities sync cleanly (verified by test).
- **Non-clobbering upsert** — new columns `COALESCE` so a later detailed
  re-sync backfills without overwriting.

## Tests
- `test_extracts_running_dynamics` — all 8 fields land in the INSERT.
- `test_running_dynamics_default_to_none` — missing keys don't raise.
- Full addon suite: **232 passed**.

## Notes
Could not be validated against a live Garmin account in this environment;
field names (`avgGroundContactTime`, `avgGroundContactBalance`,
`avgVerticalOscillation`, `avgVerticalRatio`, `avgStrideLength`,
`avgRespirationRate`, `elevationGain`, `elevationLoss`) follow the
documented Garmin Connect activity-summary schema. Additive + nullable, so
worst case is columns stay NULL as before.

Independent of #181 (data-quality gap detection).