### PR TITLE
ci: bump remaining workflow actions to node 24 + pin harden-runner

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -33,7 +33,7 @@ jobs:
       matrix:
         arch: [amd64, aarch64]
     steps:
-      - uses: step-security/harden-runner@v2
+      - uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411  # v2.19.4
         with:
           egress-policy: audit
 

--- a/.github/workflows/review.yml
+++ b/.github/workflows/review.yml
@@ -55,7 +55,7 @@ jobs:
       pull-requests: read
     steps:
       - name: 'Checkout PR head'
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
         with:
           ref: ${{ github.event.pull_request.head.sha }}
           fetch-depth: 0

--- a/.github/workflows/scan.yml
+++ b/.github/workflows/scan.yml
@@ -25,10 +25,10 @@ jobs:
       issues: write
     steps:
       - name: 'Checkout'
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
 
       - name: 'Setup Python'
-        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065  # v5.6.0
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405  # v6.2.0
         with:
           python-version: '3.12'
 
@@ -81,7 +81,7 @@ jobs:
 
       - name: 'Upload failures artifact'
         if: steps.collect.outputs.count != '0'
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02  # v4.6.2
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1
         with:
           name: failures
           path: failures.json


### PR DESCRIPTION
## What
Full-repo sweep of hand-authored workflows for Node.js 20 actions (runner deprecation **2026-06-16**), plus pins the floating `harden-runner@v2`.

| File | Action | Before | After |
|------|--------|--------|-------|
| build.yml | harden-runner | `@v2` (floating) | **v2.19.4** (SHA) |
| scan.yml | checkout | v4.2.2 | **v6.0.2** |
| scan.yml | setup-python | v5.6.0 | **v6.2.0** |
| scan.yml | upload-artifact | v4.6.2 | **v7.0.1** |
| review.yml | checkout | v4.2.2 | **v6.0.2** |

All targets verified `using: node24`. `ci.yml`, `release-gate.yml`, `copilot-setup-steps.yml` were already on Node 24 (checkout v6 / setup-python v6).

Complements #180 (which fixed the e2e workflow's setup-node/upload-artifact/harden-runner).

## Out of scope
`build.yml`'s docker/* actions still use floating major tags — a separate SHA-pinning task (they're not Node 20 deprecation blockers).

## Validation
pre-commit (yamllint, REUSE, actionlint) ✅