### PR TITLE
feat: probe secondary ollama backend under ha_conversation

### DIFF
--- a/pulsecoach/CHANGELOG.md
+++ b/pulsecoach/CHANGELOG.md
@@ -9,6 +9,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **Secondary Ollama probe under HA Conversation.** When `ai_backend` is
+  `ha_conversation` and an `ollama_url` is configured, startup now probes the
+  Ollama host and logs `Secondary backend: Ollama at <url> (embeddings +
+  fallback)` (or a warning when unreachable). Previously the Ollama URL was
+  only probed when `ai_backend=ollama`, so users running HA Conversation with
+  Ollama wired for embeddings/fallback had no confirmation it was reachable.
 - **Coach memory / RAG (nightly).** A background worker now rebuilds
   multi-year history embeddings by calling the app's
   `/api/internal/rebuild-memory` endpoint (default every 1440 minutes / 24h,

--- a/pulsecoach/rootfs/etc/s6-overlay/s6-rc.d/pulsecoach/run
+++ b/pulsecoach/rootfs/etc/s6-overlay/s6-rc.d/pulsecoach/run
@@ -423,6 +423,13 @@ case "${AI_BACKEND}" in
             bashio::log.info "AI backend: HA Conversation API"
             bashio::log.info "  Requires a conversation agent configured in HA (Settings → Voice Assistants)"
             bashio::log.info "  Using Supervisor token for HA API access"
+            if [ -n "${OLLAMA_URL}" ]; then
+                if curl -s -o /dev/null -w "%{http_code}" "${OLLAMA_URL}/api/tags" | grep -q "200"; then
+                    bashio::log.info "  Secondary backend: Ollama at ${OLLAMA_URL} (embeddings + fallback)"
+                else
+                    bashio::log.warning "  Secondary backend Ollama not reachable at ${OLLAMA_URL} — embeddings/fallback unavailable"
+                fi
+            fi
         else
             bashio::log.warning "AI backend set to ha_conversation but no Supervisor token — falling back to rules-based"
             export AI_BACKEND="none"


### PR DESCRIPTION
## Summary
When `ai_backend=ha_conversation` and `ollama_url` is configured, the startup script now probes the Ollama host and logs whether the secondary backend (embeddings + rules fallback) is reachable.

Previously `OLLAMA_URL` was only health-checked in the `ai_backend=ollama` branch, so users running HA Conversation **with** Ollama wired for embeddings/RAG had no confirmation at boot that the backup was reachable.

## Change
- `pulsecoach/rootfs/etc/s6-overlay/s6-rc.d/pulsecoach/run`: in the `ha_conversation` case, if `OLLAMA_URL` is set, `curl` the `/api/tags` endpoint and log:
  - info: `Secondary backend: Ollama at <url> (embeddings + fallback)` when reachable
  - warning: `Secondary backend Ollama not reachable...` otherwise
- Reuses the exact probe pattern already used in the `ollama` case (consistent, non-fatal).
- CHANGELOG entry under Unreleased.

## Testing
- `bash -n` syntax OK; `shellcheck -x` adds no new warnings (only pre-existing ones).
- pre-commit (reuse, eof, whitespace, addon-app-ref) green.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>