### PR TITLE
chore: release 0.18.0

### DIFF
--- a/pulsecoach/CHANGELOG.md
+++ b/pulsecoach/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.18.0] - 2026-05-31
+
 ### Added
 
 - **Secondary Ollama probe under HA Conversation.** When `ai_backend` is

--- a/pulsecoach/Dockerfile
+++ b/pulsecoach/Dockerfile
@@ -15,7 +15,7 @@ WORKDIR /build
 # Clone the app source from GitHub
 # Use build arg timestamp for cache busting instead of GitHub API (avoids 403 rate limits)
 ARG APP_REPO=askb/ha-garmin-fitness-coach-app
-ARG APP_REF=v0.17.10
+ARG APP_REF=v0.18.0
 ARG CACHEBUST=1
 RUN echo "Cache bust: ${CACHEBUST}" && \
     git clone --depth=1 --branch="${APP_REF}" \
@@ -91,4 +91,4 @@ LABEL \
     io.hass.description="AI-powered sport scientist for Garmin athletes" \
     io.hass.arch="${BUILD_ARCH}" \
     io.hass.type="addon" \
-    io.hass.version="0.17.11"
+    io.hass.version="0.18.0"

--- a/pulsecoach/config.json
+++ b/pulsecoach/config.json
@@ -1,6 +1,6 @@
 {
   "name": "PulseCoach",
-  "version": "0.17.11",
+  "version": "0.18.0",
   "slug": "pulsecoach",
   "image": "ghcr.io/askb/pulsecoach-addon-{arch}",
   "description": "AI-powered sport scientist — training analysis, coaching, and recovery optimization from your Garmin data",


### PR DESCRIPTION
## Release 0.18.0 (minor)

Prepares the addon **0.18.0** release, keeping it on the unified version
line shared with the app (`v0.18.0` tagged on `ha-garmin-fitness-coach-app`).

### Version bumps
- `pulsecoach/config.json` version: 0.17.11 → **0.18.0**
- `pulsecoach/Dockerfile` `APP_REF`: `v0.17.10` → **`v0.18.0`** (bundles the matching app release)
- `pulsecoach/Dockerfile` `io.hass.version`: 0.17.11 → **0.18.0**

### Changelog (promoted from Unreleased → [0.18.0])
- Secondary Ollama probe under HA Conversation (#195)
- Nightly coach memory / RAG rebuild + `ollama_embed_model` option (#179)
- Internal task authentication for the loopback rebuild
- Data-quality gap detection + `sensor.pulsecoach_data_quality` (#181)
- Running-dynamics capture in `garmin-sync.py` (#182)
- Training-load engine parity — single source of truth with the app engine (#183)

### Release mechanics
Merging this does **not** publish. The release is cut by pushing the
`v0.18.0` tag (triggers `release.yaml`: release-gate verifies app `main`
is green → multi-arch GHCR build/push bundling app `v0.18.0` → GitHub Release).

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>