### PR TITLE
fix(sync): guard Garmin training readiness to the 0-100 range

### DIFF
--- a/pulsecoach/CHANGELOG.md
+++ b/pulsecoach/CHANGELOG.md
@@ -7,6 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **Reject out-of-range Garmin Training Readiness at sync.** Garmin
+  occasionally returns malformed readiness payloads (e.g. `130`, `530`)
+  outside the defined 0–100 scale. `sync_training_readiness` now validates
+  the score and skips physiologically-impossible values instead of storing
+  them, mirroring the existing VO2max 10–90 guard. Also fixed a latent bug
+  where a legitimate readiness of `0` was discarded as falsy. Prevents the
+  app's Engine-vs-Garmin validation table from reporting bad data as
+  agreement (companion to app #258).
+
 ## [0.18.0] - 2026-05-31
 
 ### Added

--- a/pulsecoach/rootfs/app/scripts/garmin-sync.py
+++ b/pulsecoach/rootfs/app/scripts/garmin-sync.py
@@ -1283,9 +1283,28 @@ def sync_training_readiness(client, db, days=7):
                 if not data:
                     continue
 
-                score = data.get("score") or data.get("readinessScore")
+                score = data.get("score")
+                if score is None:
+                    score = data.get("readinessScore")
                 level = data.get("level") or data.get("readinessLevel", "")
                 if score is None:
+                    continue
+
+                # Training Readiness is defined on a 0-100 scale. Garmin
+                # occasionally returns malformed payloads (e.g. 130, 530)
+                # that would otherwise corrupt the validation/agreement
+                # metrics downstream. Reject physiologically-impossible
+                # values rather than storing them (mirrors the vo2max guard).
+                try:
+                    score = float(score)
+                except (TypeError, ValueError):
+                    continue
+                if score < 0 or score > 100:
+                    print(
+                        f"  Skipping out-of-range readiness {score} "
+                        f"for {date_str} (expected 0-100)",
+                        file=sys.stderr,
+                    )
                     continue
 
                 # Extract contributing factors (Garmin's 6-factor breakdown)

--- a/pulsecoach/rootfs/app/scripts/garmin-sync.py
+++ b/pulsecoach/rootfs/app/scripts/garmin-sync.py
@@ -1299,7 +1299,7 @@ def sync_training_readiness(client, db, days=7):
                     score = float(score)
                 except (TypeError, ValueError):
                     continue
-                if score < 0 or score > 100:
+                if not math.isfinite(score) or not 0 <= score <= 100:
                     print(
                         f"  Skipping out-of-range readiness {score} "
                         f"for {date_str} (expected 0-100)",

--- a/tests/test_garmin_sync.py
+++ b/tests/test_garmin_sync.py
@@ -1092,6 +1092,20 @@ class TestSyncTrainingReadinessRange:
 
         assert self._readiness_updates(cursor) == []
 
+    @pytest.mark.parametrize("bad_score", [float("nan"), float("inf"), float("-inf")])
+    def test_non_finite_score_is_skipped(
+        self, garmin_sync, mock_db, mock_garmin_client, bad_score
+    ):
+        """NaN / Infinity must not slip past the range guard."""
+        conn, cursor = mock_db
+        mock_garmin_client.get_training_readiness.return_value = {
+            "score": bad_score,
+            "level": "READY",
+        }
+        garmin_sync.sync_training_readiness(mock_garmin_client, conn, days=1)
+
+        assert self._readiness_updates(cursor) == []
+
     def test_boundary_scores_are_stored(
         self, garmin_sync, mock_db, mock_garmin_client
     ):

--- a/tests/test_garmin_sync.py
+++ b/tests/test_garmin_sync.py
@@ -1046,3 +1046,62 @@ class TestMatviewRefresh:
         db.rollback.assert_called_once()
         db.commit.assert_not_called()
         cur.close.assert_called_once()
+
+
+# ---------------------------------------------------------------------------
+# sync_training_readiness — 0-100 range guard (regression for app#258)
+# ---------------------------------------------------------------------------
+
+
+class TestSyncTrainingReadinessRange:
+    """Garmin Training Readiness must be stored only when within 0-100."""
+
+    @staticmethod
+    def _readiness_updates(cursor):
+        return [
+            c
+            for c in cursor.execute.call_args_list
+            if "garmin_training_readiness" in c[0][0]
+            and "UPDATE daily_metric" in c[0][0]
+        ]
+
+    def test_valid_score_is_stored(self, garmin_sync, mock_db, mock_garmin_client):
+        """An in-range score (75) is written to daily_metric."""
+        conn, cursor = mock_db
+        mock_garmin_client.get_training_readiness.return_value = {
+            "score": 75,
+            "level": "READY",
+        }
+        garmin_sync.sync_training_readiness(mock_garmin_client, conn, days=1)
+
+        updates = self._readiness_updates(cursor)
+        assert len(updates) == 1
+        assert 75 in updates[0][0][1]  # round(75) present in values tuple
+
+    @pytest.mark.parametrize("bad_score", [130, 530, -5, 1000])
+    def test_out_of_range_score_is_skipped(
+        self, garmin_sync, mock_db, mock_garmin_client, bad_score
+    ):
+        """Physiologically-impossible scores are not written."""
+        conn, cursor = mock_db
+        mock_garmin_client.get_training_readiness.return_value = {
+            "score": bad_score,
+            "level": "READY",
+        }
+        garmin_sync.sync_training_readiness(mock_garmin_client, conn, days=1)
+
+        assert self._readiness_updates(cursor) == []
+
+    def test_boundary_scores_are_stored(
+        self, garmin_sync, mock_db, mock_garmin_client
+    ):
+        """0 and 100 are valid boundaries and are stored."""
+        conn, cursor = mock_db
+        for boundary in (0, 100):
+            cursor.execute.reset_mock()
+            mock_garmin_client.get_training_readiness.return_value = {
+                "score": boundary,
+                "level": "READY",
+            }
+            garmin_sync.sync_training_readiness(mock_garmin_client, conn, days=1)
+            assert len(self._readiness_updates(cursor)) == 1


### PR DESCRIPTION
Companion to app #258.

Garmin's `get_training_readiness` endpoint occasionally returns malformed
scores outside the defined 0–100 scale (130, 530 observed in the
2026-05-31 live capture). These were stored into
`daily_metric.garmin_training_readiness` and polluted the app's
Engine-vs-Garmin validation table (an impossible 530/530 pair was counted
as a "Match").

## Changes
- `sync_training_readiness`: validate the score and skip values outside
  0–100, mirroring the existing VO2max 10–90 guard. Logs the skip.
- Fix a latent bug where a legitimate readiness of `0` was dropped by the
  `data.get("score") or ...` falsy check — now an explicit `None` check.

## Tests
- New `TestSyncTrainingReadinessRange` (6 cases): valid score stored,
  out-of-range (130/530/-5/1000) skipped, 0 and 100 boundaries stored.
- Full `tests/` suite: 242 passed.