### PR TITLE
ci: raise aarch64 build timeout to 120 minutes

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -28,7 +28,9 @@ jobs:
     permissions:
       contents: read
       packages: write
-    timeout-minutes: 60
+    # aarch64 builds run under QEMU emulation and are far slower than the
+    # native amd64 build, so give them a much larger timeout budget.
+    timeout-minutes: ${{ matrix.arch == 'aarch64' && 120 || 30 }}
     strategy:
       matrix:
         arch: [amd64, aarch64]

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -60,7 +60,9 @@ jobs:
     permissions:
       contents: read
       packages: write
-    timeout-minutes: 30
+    # aarch64 builds run under QEMU emulation and are far slower than the
+    # native amd64 build, so give them a much larger timeout budget.
+    timeout-minutes: ${{ matrix.arch == 'aarch64' && 120 || 30 }}
     strategy:
       matrix:
         include:


### PR DESCRIPTION
## Summary

The aarch64 addon image is built under QEMU emulation, which is ~an order of magnitude slower than the native amd64 build. The shared job timeout (`60` in `build.yml`, `30` in `release.yaml`) was being hit and **cancelling the aarch64 leg** — e.g. PR #199's aarch64 build was cancelled at `1h00m` (`The operation was canceled.`) while amd64 finished in ~4 min.

## Change

Make `timeout-minutes` arch-aware in both build workflows:

```yaml
timeout-minutes: ${{ matrix.arch == 'aarch64' && 120 || 30 }}
```

- **aarch64** → 120 min budget (no more spurious cancellations)
- **amd64** → tightened to 30 min (still catches genuine hangs on the fast native build)

## Validation

- `actionlint` ✅ passed
- YAML parses ✅

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>