### PR TITLE
chore: release 0.18.1

### DIFF
--- a/pulsecoach/CHANGELOG.md
+++ b/pulsecoach/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.18.1] - 2026-05-31
+
 ### Fixed
 
 - **Reject out-of-range Garmin Training Readiness at sync.** Garmin
@@ -17,6 +19,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   where a legitimate readiness of `0` was discarded as falsy. Prevents the
   app's Engine-vs-Garmin validation table from reporting bad data as
   agreement (companion to app #258).
+- **Bundled app updated to v0.18.1**, which renders previously-empty stacked
+  Bar/Area charts (Weekly Time in Zones, Sleep Stages, etc.) and flags
+  out-of-range readiness/VO2max values in the data-validation table
+  (app #257, #258).
+
+### Changed
+
+- CI: raised the aarch64 image build timeout to 120 minutes. The QEMU-emulated
+  aarch64 build is far slower than the native amd64 build and was being
+  cancelled by the shared job timeout.
 
 ## [0.18.0] - 2026-05-31
 

--- a/pulsecoach/Dockerfile
+++ b/pulsecoach/Dockerfile
@@ -15,7 +15,7 @@ WORKDIR /build
 # Clone the app source from GitHub
 # Use build arg timestamp for cache busting instead of GitHub API (avoids 403 rate limits)
 ARG APP_REPO=askb/ha-garmin-fitness-coach-app
-ARG APP_REF=v0.18.0
+ARG APP_REF=v0.18.1
 ARG CACHEBUST=1
 RUN echo "Cache bust: ${CACHEBUST}" && \
     git clone --depth=1 --branch="${APP_REF}" \

--- a/pulsecoach/Dockerfile
+++ b/pulsecoach/Dockerfile
@@ -91,4 +91,4 @@ LABEL \
     io.hass.description="AI-powered sport scientist for Garmin athletes" \
     io.hass.arch="${BUILD_ARCH}" \
     io.hass.type="addon" \
-    io.hass.version="0.18.0"
+    io.hass.version="0.18.1"

--- a/pulsecoach/config.json
+++ b/pulsecoach/config.json
@@ -1,6 +1,6 @@
 {
   "name": "PulseCoach",
-  "version": "0.18.0",
+  "version": "0.18.1",
   "slug": "pulsecoach",
   "image": "ghcr.io/askb/pulsecoach-addon-{arch}",
   "description": "AI-powered sport scientist — training analysis, coaching, and recovery optimization from your Garmin data",


### PR DESCRIPTION
## Summary

Patch release on the unified version line.

- Bumps `pulsecoach/config.json` `0.18.0` → `0.18.1`
- Pins `APP_REF` → **v0.18.1** so the bundled app ships:
  - **#257** empty stacked Bar/Area charts now render
  - **#258** out-of-range readiness/VO2max flagged in the validation table
- Promotes to the `0.18.1` CHANGELOG entry:
  - sync-side readiness 0–100 guard (#199)
  - aarch64 build-timeout bump to 120 min (#200)

App release: askb/ha-garmin-fitness-coach-app#261 (tag `v0.18.1`).

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>