### PR TITLE
test(screenshots): add rendered-content gate for charts and validation

### DIFF
--- a/.github/workflows/e2e-screenshots.yml
+++ b/.github/workflows/e2e-screenshots.yml
@@ -155,6 +155,17 @@ jobs:
         working-directory: tools/screenshots
         run: node scripts/validate-screens.mjs "screenshots/${{ matrix.persona }}"
 
+      - name: Validate rendered content
+        working-directory: tools/screenshots
+        # Content gate (tests/content.spec.ts): asserts charts actually
+        # render their animation-gated geometry (#257) and that the
+        # validation table holds no out-of-range readiness/VO2max values
+        # flagged as agreement (#258). This is what catches regressions the
+        # size-only screenshot validator cannot see.
+        env:
+          BASE_URL: "http://localhost:3000"
+        run: npm run validate:content
+
       - name: Upload screenshots
         if: always()
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1

--- a/tools/screenshots/content-checks.mjs
+++ b/tools/screenshots/content-checks.mjs
@@ -1,0 +1,84 @@
+// SPDX-FileCopyrightText: 2026 Anil Belur <askb23@gmail.com>
+// SPDX-License-Identifier: Apache-2.0
+//
+// Single source of truth for the *content* gate consumed by
+// tests/content.spec.ts. Where routes.mjs + validate-screens.mjs only
+// assert that a screenshot file exists and is non-trivial in size, this
+// manifest encodes what must actually be *rendered* on each screen, so
+// regressions that still produce a large PNG — empty charts (#257) and
+// physiologically-impossible values (#258) — fail CI instead of slipping
+// through to a human eyeballing screenshots.
+//
+// Recharts geometry class names are stable across 2.x/3.x:
+//   bar   → g.recharts-bar-rectangle  (one per datum per stacked series)
+//   area  → path.recharts-area-area
+//   pie   → path.recharts-pie-sector
+//   radar → path.recharts-radar-polygon
+//   line  → path.recharts-line-curve
+//   dot   → path.recharts-scatter-symbol / circle.recharts-dot
+//
+// The #257 bug was that Bar/Area/Pie/Radar geometry is created only after
+// Recharts' entry-animation frame fires; under React 19 concurrent
+// rendering that frame could be dropped on chart-heavy pages, so the
+// geometry never materialised even though axes, legends and the
+// surrounding card all painted. Asserting that the *animation-gated*
+// geometry exists (count > 0, non-zero box) is therefore the precise
+// regression test, and the fix (`isAnimationActive={false}`) is what
+// makes it pass deterministically.
+
+export const GEOMETRY_SELECTORS = {
+  bar: ".recharts-bar-rectangle",
+  area: ".recharts-area-area",
+  pie: ".recharts-pie-sector",
+  radar: ".recharts-radar-polygon",
+  line: ".recharts-line-curve",
+};
+
+// Each entry: the route to visit, how long to let charts settle, and the
+// minimum count of each animation-gated geometry kind that MUST be
+// present.
+//
+// Scope rationale — these three routes are the ones that (a) were the
+// concrete #257 victims or share its exact rendering path AND (b) carry
+// Bar/Area geometry that the seed reliably populates for *all four*
+// personas (athlete, recreational, beginner, detrained) from 90 days of
+// data, so the gate is deterministic rather than coupled to data volume:
+//
+//   zones    — "Weekly Time in Zones" + "Weekly Training Volume by Sport"
+//              stacked bars (the original empty-chart report).
+//   sleep    — "Sleep Stages · Last 14 Nights" stacked bars (also blank in
+//              the QA capture; 90 nights of sleep guarantee bars).
+//   training — Performance Management Chart area + "Daily Strain/Stress —
+//              Last 14 Days" bars (14 days always present).
+//
+// Routes deliberately NOT gated here: fitness/hrv/vitals/trends render
+// Line/Scatter/dot geometry (not the animation-gated Bar/Area the #257 fix
+// touched) and/or depend on sparse single-metric data, so a geometry-count
+// assertion there would be flaky without testing the actual regression.
+//
+// `require` counts are intentionally the conservative floor (>=1): the bug
+// produced exactly zero painted bars/areas, so any positive count proves
+// the animation-gated geometry materialised. `isAnimationActive={false}`
+// makes that deterministic.
+export const CHART_CONTENT_CHECKS = [
+  { name: "zones", path: "/zones", wait: 6000, require: { bar: 1 } },
+  { name: "sleep", path: "/sleep", wait: 5000, require: { bar: 1 } },
+  { name: "training", path: "/training", wait: 8000, require: { bar: 1, area: 1 } },
+];
+
+// /validation renders the Engine-vs-Garmin reconciliation tables. Readiness
+// and VO2max both live on a 0–100 scale (READINESS_RANGE / VO2MAX_RANGE in
+// packages/api/src/router/data-quality.ts). #258 was that Garmin sometimes
+// emits values outside that range (e.g. 130, 530) and the table reported
+// them as "Match", inflating the agreement %. The invariant we gate on:
+// any Garmin/Engine value outside [0, 100] MUST be flagged "Out of range"
+// (status ⚪ invalid) — never Match / Minor / Diverged.
+export const VALIDATION_CHECK = {
+  name: "validation",
+  path: "/validation",
+  wait: 6000,
+  range: { min: 0, max: 100 },
+  // Status label that an out-of-range row must carry (from
+  // RVC_STATUS_LABEL in validation/page.tsx).
+  invalidLabel: "Out of range",
+};

--- a/tools/screenshots/package.json
+++ b/tools/screenshots/package.json
@@ -6,10 +6,11 @@
   "license": "Apache-2.0",
   "type": "module",
   "scripts": {
-    "screenshot": "playwright test",
-    "screenshot:desktop": "playwright test --project=desktop",
-    "screenshot:mobile": "playwright test --project=mobile",
-    "screenshot:dark": "PULSECOACH_THEME=dark playwright test --project=desktop",
+    "screenshot": "playwright test tests/dashboard.spec.ts",
+    "screenshot:desktop": "playwright test tests/dashboard.spec.ts --project=desktop",
+    "screenshot:mobile": "playwright test tests/dashboard.spec.ts --project=mobile",
+    "screenshot:dark": "PULSECOACH_THEME=dark playwright test tests/dashboard.spec.ts --project=desktop",
+    "validate:content": "playwright test tests/content.spec.ts --project=desktop",
     "install-browsers": "playwright install chromium"
   },
   "devDependencies": {

--- a/tools/screenshots/tests/content.spec.ts
+++ b/tools/screenshots/tests/content.spec.ts
@@ -1,0 +1,184 @@
+// SPDX-FileCopyrightText: 2026 Anil Belur <askb23@gmail.com>
+// SPDX-License-Identifier: Apache-2.0
+//
+// Content gate for the PulseCoach dashboard. This is the automated
+// counterpart to the screenshot capture: instead of writing a PNG and
+// trusting a human to notice an empty chart or an impossible number, it
+// asserts on the live, seeded DOM so those regressions fail CI.
+//
+// Covers two classes of bug found by manual screenshot review and which
+// the size-only validator (scripts/validate-screens.mjs) could not catch:
+//
+//   #257  Stacked Bar/Area charts rendered empty (geometry never painted)
+//         while the surrounding card, axes and legend still produced a
+//         large PNG. We assert the animation-gated geometry exists and has
+//         a non-zero box.
+//
+//   #258  Garmin readiness/VO2max values outside the 0–100 scale (e.g.
+//         130, 530) were reported as "Match" in the validation table. We
+//         assert every rendered value is in range, or else flagged
+//         "Out of range".
+//
+// Runs against the same container the capture job seeds (BASE_URL), so it
+// needs no extra fixtures. Desktop project only — these are data
+// assertions, not viewport-specific, so there is no value in running them
+// twice.
+
+import { expect, test } from "@playwright/test";
+import {
+  CHART_CONTENT_CHECKS,
+  GEOMETRY_SELECTORS,
+  VALIDATION_CHECK,
+} from "../content-checks.mjs";
+
+test.describe.configure({ mode: "serial" });
+
+// These are content assertions, not viewport assertions. The
+// `validate:content` npm script pins `--project=desktop`; this in-test
+// guard is a belt-and-braces no-op there but prevents accidental
+// double-execution if the spec is ever run without a project filter.
+function desktopOnly(testInfo) {
+  test.skip(
+    testInfo.project.name !== "desktop",
+    "content assertions run on desktop only",
+  );
+}
+
+// Called after the test body has already navigated to the route. Waits for
+// Recharts to mount and paint before assertions fire — never navigates.
+async function settleCharts(page, waitMs) {
+  await page.waitForLoadState("networkidle").catch(() => undefined);
+  // At least one chart surface should mount on these routes; give it a
+  // generous budget before the fixed settle so slow tRPC prefetches land.
+  await page
+    .waitForSelector(".recharts-surface", { timeout: 20_000 })
+    .catch(() => undefined);
+  // Scroll the full page so any below-the-fold chart card that defers
+  // mounting until it scrolls into view gets a chance to render.
+  await page
+    .evaluate(async () => {
+      const step = 600;
+      for (let y = 0; y <= document.body.scrollHeight; y += step) {
+        window.scrollTo(0, y);
+        await new Promise((r) => setTimeout(r, 200));
+      }
+      window.scrollTo(0, 0);
+    })
+    .catch(() => undefined);
+  await page.waitForTimeout(waitMs);
+}
+
+for (const check of CHART_CONTENT_CHECKS) {
+  test(`content: ${check.name} charts render geometry`, async ({ page }, testInfo) => {
+    desktopOnly(testInfo);
+    await page.goto(check.path, { waitUntil: "networkidle" });
+    await settleCharts(page, check.wait ?? 5000);
+
+    for (const [kind, min] of Object.entries(check.require)) {
+      const selector = GEOMETRY_SELECTORS[kind];
+      expect(
+        selector,
+        `unknown geometry kind "${kind}" in content-checks.mjs`,
+      ).toBeTruthy();
+
+      const locator = page.locator(selector);
+      const count = await locator.count();
+
+      // #257: the animation-gated geometry must actually exist. An empty
+      // chart produces 0 here while still yielding a >5KB screenshot.
+      expect(
+        count,
+        `${check.name}: expected ≥${min} <${kind}> element(s) ` +
+          `("${selector}") but found ${count} — chart likely rendered empty (#257)`,
+      ).toBeGreaterThanOrEqual(min);
+
+      // Belt-and-braces: at least one element must have a non-zero
+      // bounding box, catching a "present in DOM but collapsed to zero
+      // height" degenerate render. We scan all elements rather than just
+      // the first because a stacked series can legitimately start with a
+      // zero-value segment (e.g. a HR zone with no time) whose box is flat.
+      let painted = false;
+      for (let i = 0; i < count; i++) {
+        const box = await locator.nth(i).boundingBox();
+        if (box && box.width > 0 && box.height > 0) {
+          painted = true;
+          break;
+        }
+      }
+      expect(
+        painted,
+        `${check.name}: every <${kind}> element has a zero-area box — ` +
+          `chart geometry is present but not painted`,
+      ).toBeTruthy();
+    }
+  });
+}
+
+test("content: validation table values are within physiological range (#258)", async ({
+  page,
+}, testInfo) => {
+  desktopOnly(testInfo);
+  const { path: route, wait, range, invalidLabel } = VALIDATION_CHECK;
+  await page.goto(route, { waitUntil: "networkidle" });
+  await page.waitForLoadState("networkidle").catch(() => undefined);
+  await page.waitForTimeout(wait ?? 5000);
+
+  // Each reconciliation row: [Date, Garmin, Engine, Δ, Status]. Read every
+  // row across both tables (VO2max + Readiness) on the page.
+  const rows = page.locator("table tbody tr");
+  const rowCount = await rows.count();
+
+  // Seeded personas always have reconciliation data; zero rows would mean
+  // the validation query silently returned nothing — surface that rather
+  // than passing vacuously.
+  expect(
+    rowCount,
+    "validation page rendered no reconciliation rows — seeded data missing or query broken",
+  ).toBeGreaterThan(0);
+
+  const parseNum = (text) => {
+    const m = (text ?? "").replace(/[^0-9.+-]/g, "");
+    if (m === "" || m === "+" || m === "-" || m === ".") return null;
+    const n = Number(m);
+    return Number.isFinite(n) ? n : null;
+  };
+
+  let outOfRangeSeen = 0;
+
+  for (let i = 0; i < rowCount; i++) {
+    const cells = rows.nth(i).locator("td");
+    if ((await cells.count()) < 5) continue;
+
+    const garmin = parseNum(await cells.nth(1).innerText());
+    const engine = parseNum(await cells.nth(2).innerText());
+    const status = (await cells.nth(4).innerText()).trim();
+
+    for (const [label, value] of [
+      ["Garmin", garmin],
+      ["Engine", engine],
+    ]) {
+      if (value === null) continue;
+      const inRange = value >= range.min && value <= range.max;
+      if (!inRange) {
+        outOfRangeSeen++;
+        // #258 core invariant: an impossible value must be flagged
+        // "Out of range", never counted as agreement.
+        expect(
+          status,
+          `validation row ${i + 1}: ${label} value ${value} is outside ` +
+            `[${range.min}, ${range.max}] but status is "${status}" — ` +
+            `out-of-range data must be flagged "${invalidLabel}" (#258)`,
+        ).toContain(invalidLabel);
+      }
+    }
+  }
+
+  // Informational: with healthy seed data we expect everything in range,
+  // so this is normally 0. It is not an assertion (a future seed could
+  // intentionally include a malformed value to exercise the invalid path),
+  // but logging it makes the gate's behaviour visible in CI output.
+  console.log(
+    `validation: checked ${rowCount} row(s); ${outOfRangeSeen} out-of-range ` +
+      `value(s), all correctly flagged "${invalidLabel}".`,
+  );
+});


### PR DESCRIPTION
## Why

The screenshot pipeline only checked that each PNG existed and exceeded a
minimum byte size (`scripts/validate-screens.mjs`). An empty chart or an
impossible number still produces a large screenshot, so two regressions
slipped past manual review:

- **#257** — stacked Bar/Area charts (zones "Weekly Time in Zones", sleep
  "Sleep Stages") rendered empty while axes, legend and "Key Insights"
  still painted.
- **#258** — Garmin readiness/VO2max values outside `[0, 100]` (e.g. 130,
  530) were reported as "Match", inflating the agreement %.

Per the directive that *everything should be testable through seeded data
and gating — never manual screenshot review*, this adds an automated
content gate.

## What

- `tools/screenshots/content-checks.mjs` — manifest of the animation-gated
  geometry that must render per route, plus the validation range invariant.
- `tools/screenshots/tests/content.spec.ts` — Playwright spec asserting on
  the live seeded DOM:
  - **#257**: zones / sleep / training must paint ≥1 Bar (and training ≥1
    Area), with a non-zero bounding box. These three routes reliably carry
    Bar/Area data for all four personas from the 90-day seed; the bug
    produced exactly zero painted bars, so a `>=1` floor is both
    deterministic (`isAnimationActive={false}`) and a true regression test.
  - **#258**: every Garmin/Engine value outside `[0, 100]` must carry the
    "Out of range" status — never Match/Minor/Diverged.
- `package.json` — pin `screenshot:*` to `dashboard.spec.ts`; add
  `validate:content`.
- `e2e-screenshots.yml` — run the content gate after the structural
  validator so every persona self-validates in CI.

## Verification

Ran against a seeded `ghcr.io/askb/pulsecoach-addon-amd64:0.18.1`
container (athlete persona): all four content tests pass. Selectors were
calibrated against the real Recharts DOM (geometry is per-series/per-datum
and data-volume dependent, so counts were lowered to a conservative `>=1`
floor and routes that render Line/Scatter/dot geometry — fitness, hrv,
vitals, trends — were excluded to keep the gate deterministic).

This PR touches `tools/screenshots/**` so `e2e-screenshots.yml` runs all
four personas and self-validates the new gate.

Refs #257, #258.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>