### PR TITLE
fix(security): restrict token file perms and escape ingress path

### DIFF
--- a/pulsecoach/rootfs/app/ingress-proxy.js
+++ b/pulsecoach/rootfs/app/ingress-proxy.js
@@ -15,8 +15,29 @@ const http = require("http");
 const NEXT_PORT = parseInt(process.env.NEXT_INTERNAL_PORT || "3001", 10);
 const LISTEN_PORT = parseInt(process.env.PORT || "3000", 10);
 
+/**
+ * Escape a string for safe insertion into a double-quoted HTML attribute.
+ * The ingress path comes from the X-Ingress-Path request header, which is
+ * attacker-controllable if the proxy port is reached directly (bypassing HA),
+ * so it must be escaped before being reflected into the page.
+ */
+function escapeHtmlAttr(value) {
+  return String(value)
+    .replace(/&/g, "&amp;")
+    .replace(/"/g, "&quot;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;");
+}
+
 const server = http.createServer((clientReq, clientRes) => {
-  const ingressPath = clientReq.headers["x-ingress-path"] || "";
+  // The ingress path is supplied by the X-Ingress-Path header. It is only
+  // trustworthy when HA sets it; if the proxy port is reached directly the
+  // value is attacker-controlled. Accept only a well-formed path so it can be
+  // safely reflected into the rewritten HTML/URLs below; otherwise ignore it.
+  const rawIngressPath = clientReq.headers["x-ingress-path"] || "";
+  const ingressPath = /^\/[A-Za-z0-9_\-/]*$/.test(rawIngressPath)
+    ? rawIngressPath
+    : "";
 
   // Strip ingress prefix from incoming URL before forwarding to Next.js
   let forwardPath = clientReq.url;
@@ -89,7 +110,7 @@ const server = http.createServer((clientReq, clientRes) => {
           // Inject ingress path into a meta tag so client JS can read it
           body = body.replace(
             "<head>",
-            `<head><meta name="ingress-path" content="${ingressPath}">`,
+            `<head><meta name="ingress-path" content="${escapeHtmlAttr(ingressPath)}">`,
           );
         }
 

--- a/pulsecoach/rootfs/app/scripts/garmin-auth-server.py
+++ b/pulsecoach/rootfs/app/scripts/garmin-auth-server.py
@@ -37,8 +37,18 @@ _mfa_state = {
 
 def _save_tokens(client: "Garmin") -> None:
     """Save garth tokens to disk in native directory format."""
-    os.makedirs(TOKEN_DIR, exist_ok=True)
+    os.makedirs(TOKEN_DIR, mode=0o700, exist_ok=True)
+    # Don't chmod through a symlink — only tighten a real directory.
+    if not os.path.islink(TOKEN_DIR):
+        os.chmod(TOKEN_DIR, 0o700)
     client.garth.dump(TOKEN_DIR)
+    # Restrict token files to owner-only — they are credential material and
+    # the data dir may be reachable by other add-ons. Skip symlinks so a
+    # pre-planted link cannot redirect the chmod to an unrelated file.
+    for name in os.listdir(TOKEN_DIR):
+        path = os.path.join(TOKEN_DIR, name)
+        if os.path.isfile(path) and not os.path.islink(path):
+            os.chmod(path, 0o600)
     log.info("Tokens saved to %s", TOKEN_DIR)
 
 

--- a/pulsecoach/rootfs/app/scripts/garmin-sync.py
+++ b/pulsecoach/rootfs/app/scripts/garmin-sync.py
@@ -53,6 +53,21 @@ def _user_today():
     """Get today's date in the user's configured timezone."""
     return datetime.now(USER_TZ).date()
 
+
+def _ensure_secure_dir(path: str) -> None:
+    """Create ``path`` with mode 0700, tightening it if it already exists.
+
+    ``os.makedirs`` ignores its ``mode`` argument when the directory already
+    exists, so a directory created by an earlier version with broader bits
+    would stay world-/group-readable. The explicit ``chmod`` corrects that so
+    the hardening is effective on upgrades, not just fresh installs.
+    """
+    os.makedirs(path, mode=0o700, exist_ok=True)
+    # Don't chmod through a symlink — only tighten a real directory.
+    if not os.path.islink(path):
+        os.chmod(path, 0o700)
+
+
 SYNC_STATUS_FILE = os.path.join(TOKEN_DIR, ".sync_status")
 LAST_SYNC_FILE = os.path.join(TOKEN_DIR, ".last_sync")
 SKIN_TEMP_BACKFILL_MARKER = "/data/.skin_temp_backfill_done"
@@ -66,7 +81,7 @@ SKIN_TEMP_KEYS = (
 def _write_last_sync() -> None:
     """Record successful sync completion time for /auth/status."""
     try:
-        os.makedirs(TOKEN_DIR, exist_ok=True)
+        _ensure_secure_dir(TOKEN_DIR)
         with open(LAST_SYNC_FILE, "w") as f:
             f.write(datetime.now(timezone.utc).isoformat())
     except Exception:
@@ -76,7 +91,7 @@ def _write_last_sync() -> None:
 def _write_sync_status(phase, detail="", progress=0):
     """Write sync progress to a shared status file for the auth server."""
     import json as _json
-    os.makedirs(TOKEN_DIR, exist_ok=True)
+    _ensure_secure_dir(TOKEN_DIR)
     status = {
         "syncing": True,
         "phase": phase,
@@ -126,7 +141,7 @@ def _refresh_matview(db) -> None:
 
 def get_client():
     """Authenticate with Garmin Connect, preferring saved tokens."""
-    os.makedirs(TOKEN_DIR, exist_ok=True)
+    _ensure_secure_dir(TOKEN_DIR)
     native_token_path = os.path.join(TOKEN_DIR, "garmin_tokens.json")
     oauth1_path = os.path.join(TOKEN_DIR, "oauth1_token.json")
     oauth2_path = os.path.join(TOKEN_DIR, "oauth2_token.json")
@@ -198,8 +213,18 @@ def _migrate_garth_tokens(oauth2_path, native_token_path):
         "di_refresh_token": refresh_token,
         "di_client_id": client_id,
     }
-    with open(native_token_path, "w") as f:
+    # Create the file with 0600 from the start so the secret is never briefly
+    # exposed under the process umask between write and chmod. O_NOFOLLOW
+    # refuses to write through a symlink planted in place of the token file.
+    fd = os.open(
+        native_token_path,
+        os.O_WRONLY | os.O_CREAT | os.O_TRUNC | os.O_NOFOLLOW,
+        0o600,
+    )
+    with os.fdopen(fd, "w") as f:
         json.dump(new_tokens, f, indent=2)
+    # O_CREAT mode is ignored if the file already existed; enforce it anyway.
+    os.chmod(native_token_path, 0o600)
     print(f"Migrated garth tokens to native format (client_id={client_id})")
 
 
@@ -1611,7 +1636,7 @@ def main():
             pass
 
         try:
-            os.makedirs(TOKEN_DIR, exist_ok=True)
+            _ensure_secure_dir(TOKEN_DIR)
             with open(status_file, "w") as f:
                 json.dump(
                     {

--- a/pulsecoach/rootfs/app/scripts/strava-sync.py
+++ b/pulsecoach/rootfs/app/scripts/strava-sync.py
@@ -37,8 +37,22 @@ def _load_tokens():
 
 def _save_tokens(tokens):
     """Save Strava tokens to disk."""
-    TOKEN_DIR.mkdir(parents=True, exist_ok=True)
-    TOKEN_FILE.write_text(json.dumps(tokens, indent=2))
+    TOKEN_DIR.mkdir(mode=0o700, parents=True, exist_ok=True)
+    # Don't chmod through a symlink — only tighten a real directory.
+    if not TOKEN_DIR.is_symlink():
+        TOKEN_DIR.chmod(0o700)
+    # Create the file with 0600 from the start so the secret is never briefly
+    # exposed under the process umask between write and chmod. O_NOFOLLOW
+    # refuses to write through a symlink planted in place of the token file.
+    fd = os.open(
+        TOKEN_FILE,
+        os.O_WRONLY | os.O_CREAT | os.O_TRUNC | os.O_NOFOLLOW,
+        0o600,
+    )
+    with os.fdopen(fd, "w") as f:
+        json.dump(tokens, f, indent=2)
+    # O_CREAT mode is ignored if the file already existed; enforce it anyway.
+    os.chmod(TOKEN_FILE, 0o600)
 
 
 def refresh_access_token(client_id, client_secret, refresh_token):


### PR DESCRIPTION
## Summary
Defense-in-depth hardening from a security audit. **No behaviour change** for normal operation. Both Python test suites (38 + tests/) pass; JS `node --check` clean.

## Changes

### 🟠 Token file permissions
`garmin-auth-server.py`, `garmin-sync.py`, `strava-sync.py`
- Token directories created `0700`; credential files chmod'd to `0600` after write.
- Garmin/Strava OAuth tokens previously inherited the default umask and could be world-readable inside the container, where other add-ons may reach `/data`/`/share`.

### 🟠 Ingress-path XSS hardening
`ingress-proxy.js`
- HTML-escape the `X-Ingress-Path` header before reflecting it into the injected `<meta name="ingress-path">` tag.
- The header is attacker-controllable if the proxy port (`3000`) is reached directly (bypassing HA, which normally sets a well-formed value). Verified: a `"><script>` payload is now neutralised; normal `/api/hassio_ingress/<token>` paths are unchanged.

> `garmin-auth-server.py` is auth-adjacent — the change only tightens file permissions, not auth logic. Flagged for review per `AGENTS.md`.

## Validation
- `python3 -m py_compile` on all three scripts ✅
- `node --check ingress-proxy.js` ✅
- `pytest tests/` and `pytest pulsecoach/rootfs/app/tests/` → all pass ✅

## Follow-ups (documented, behaviour-sensitive — not in this PR)
From the same audit, deferred to avoid changing your running setup:
- **HIGH**: optional direct port `3000` + `DEV_BYPASS_AUTH` can expose the UI without HA ingress auth → consider removing `ports` from `config.json`.
- **HIGH**: tokens/DB backups copied to shared `/share` → make opt-in/encrypted.
- **MED**: container runs as root; global env exports secrets to all child services; `generate-garmin-tokens.py` uses `StrictHostKeyChecking=no` and `/tmp`.
- **MED**: pin Docker base images by digest and pip/npm deps by exact version.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>