### PR TITLE
chore: release 0.19.0

### DIFF
--- a/pulsecoach/CHANGELOG.md
+++ b/pulsecoach/CHANGELOG.md
@@ -7,6 +7,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.19.0] - 2026-06-08
+
+### Fixed
+
+- **Dashboards render real data again.** Pins the bundled app to its
+  `v0.19.0` tag, which restores the `DEV_BYPASS_AUTH` single-user auth mode
+  (app #278). A prior change had gated that bypass to non-production, so
+  with the add-on running `NODE_ENV=production` every authenticated query
+  returned `UNAUTHORIZED` and the dashboards rendered empty.
+
+### Changed
+
+- **Richer demo data on first run.** The bundled app now seeds VO2max
+  history and no longer wipes the 90-day demo history during e2e seeding
+  (app #277), so HRV, Trends and Fitness show populated charts. Refreshed
+  the README screenshots to match.
+
 ## [0.18.1] - 2026-05-31
 
 ### Fixed

--- a/pulsecoach/Dockerfile
+++ b/pulsecoach/Dockerfile
@@ -15,7 +15,7 @@ WORKDIR /build
 # Clone the app source from GitHub
 # Use build arg timestamp for cache busting instead of GitHub API (avoids 403 rate limits)
 ARG APP_REPO=askb/ha-garmin-fitness-coach-app
-ARG APP_REF=v0.18.1
+ARG APP_REF=v0.19.0
 ARG CACHEBUST=1
 RUN echo "Cache bust: ${CACHEBUST}" && \
     git clone --depth=1 --branch="${APP_REF}" \
@@ -91,4 +91,4 @@ LABEL \
     io.hass.description="AI-powered sport scientist for Garmin athletes" \
     io.hass.arch="${BUILD_ARCH}" \
     io.hass.type="addon" \
-    io.hass.version="0.18.1"
+    io.hass.version="0.19.0"

--- a/pulsecoach/config.json
+++ b/pulsecoach/config.json
@@ -1,6 +1,6 @@
 {
   "name": "PulseCoach",
-  "version": "0.18.1",
+  "version": "0.19.0",
   "slug": "pulsecoach",
   "image": "ghcr.io/askb/pulsecoach-addon-{arch}",
   "description": "AI-powered sport scientist — training analysis, coaching, and recovery optimization from your Garmin data",


### PR DESCRIPTION
Minor release. Bumps the add-on to **0.19.0** and pins `APP_REF` to the app's **v0.19.0** tag so the bundled app ships:

- **Restored `DEV_BYPASS_AUTH` single-user mode (app #278)** — the add-on's dashboards authorize and render again (a prior change had made every query return `UNAUTHORIZED` under `NODE_ENV=production`).
- **VO2max seed + e2e-history fix (app #277)** — HRV / Trends / Fitness show populated charts.

Also refreshes the README screenshots (#209, already merged). Tag `v0.19.0` will be pushed after merge to trigger the release/build workflow.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>