### PR TITLE
fix(security): ingress-only access and token exposure hardening

### DIFF
--- a/pulsecoach/CHANGELOG.md
+++ b/pulsecoach/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Security
+
+- **Removed optional direct port mapping (`3000/tcp`).** The web UI relies
+  on Home Assistant ingress for authentication (the bundled app runs with
+  `DEV_BYPASS_AUTH=true`), so exposing the container port directly on the
+  host allowed unauthenticated access to the dashboard and API for anyone
+  who mapped the port. The UI is now reachable exclusively through the
+  authenticated HA ingress panel.
+
 ## [0.19.0] - 2026-06-08
 
 ### Fixed

--- a/pulsecoach/CHANGELOG.md
+++ b/pulsecoach/CHANGELOG.md
@@ -15,6 +15,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   host allowed unauthenticated access to the dashboard and API for anyone
   who mapped the port. The UI is now reachable exclusively through the
   authenticated HA ingress panel.
+- **Garmin tokens are no longer backed up to `/share/`.** `/share/` is
+  readable by other add-ons, so copying OAuth credential material there
+  widened its exposure. Tokens now stay in `/data/garmin-tokens/`
+  (owner-only permissions). On startup the add-on performs a one-time
+  restore of any legacy `/share/pulsecoach/garmin-tokens/` backup and then
+  deletes the exposed copies. Database backups to `/share/` are unchanged.
 
 ## [0.19.0] - 2026-06-08
 

--- a/pulsecoach/config.json
+++ b/pulsecoach/config.json
@@ -21,9 +21,6 @@
     "addon_config:rw",
     "share:rw"
   ],
-  "ports": {
-    "3000/tcp": null
-  },
   "options": {
     "garmin_email": "",
     "garmin_password": "",

--- a/pulsecoach/rootfs/app/scripts/garmin-auth-server.py
+++ b/pulsecoach/rootfs/app/scripts/garmin-auth-server.py
@@ -327,8 +327,15 @@ def import_tokens() -> tuple[Response, int] | Response:
 
     try:
         os.makedirs(TOKEN_DIR, mode=0o700, exist_ok=True)
-        if not os.path.islink(TOKEN_DIR):
-            os.chmod(TOKEN_DIR, 0o700)
+        # Defense-in-depth: if TOKEN_DIR itself is a symlink, an attacker
+        # could redirect credential writes into an arbitrary directory.
+        # Refuse to import rather than writing through the link.
+        if os.path.islink(TOKEN_DIR):
+            return jsonify(
+                success=False,
+                message="Token directory is a symlink; refusing to import",
+            ), 500
+        os.chmod(TOKEN_DIR, 0o700)
         # Owner-only token files, O_NOFOLLOW so a pre-planted symlink
         # cannot redirect the write to an unrelated file.
         for name, payload in (("oauth1_token.json", oauth1),

--- a/pulsecoach/rootfs/app/scripts/garmin-auth-server.py
+++ b/pulsecoach/rootfs/app/scripts/garmin-auth-server.py
@@ -326,11 +326,21 @@ def import_tokens() -> tuple[Response, int] | Response:
                        message="Both oauth1_token and oauth2_token required"), 400
 
     try:
-        os.makedirs(TOKEN_DIR, exist_ok=True)
-        with open(os.path.join(TOKEN_DIR, "oauth1_token.json"), "w") as f:
-            json.dump(oauth1, f)
-        with open(os.path.join(TOKEN_DIR, "oauth2_token.json"), "w") as f:
-            json.dump(oauth2, f)
+        os.makedirs(TOKEN_DIR, mode=0o700, exist_ok=True)
+        if not os.path.islink(TOKEN_DIR):
+            os.chmod(TOKEN_DIR, 0o700)
+        # Owner-only token files, O_NOFOLLOW so a pre-planted symlink
+        # cannot redirect the write to an unrelated file.
+        for name, payload in (("oauth1_token.json", oauth1),
+                              ("oauth2_token.json", oauth2)):
+            fd = os.open(
+                os.path.join(TOKEN_DIR, name),
+                os.O_WRONLY | os.O_CREAT | os.O_TRUNC | os.O_NOFOLLOW,
+                0o600,
+            )
+            with os.fdopen(fd, "w") as f:
+                json.dump(payload, f)
+            os.chmod(os.path.join(TOKEN_DIR, name), 0o600)
 
         # Verify tokens work
         client = _load_client()

--- a/pulsecoach/rootfs/etc/s6-overlay/s6-rc.d/pulsecoach/run
+++ b/pulsecoach/rootfs/etc/s6-overlay/s6-rc.d/pulsecoach/run
@@ -27,10 +27,24 @@ restore_from_share() {
     if [ -d "${SHARE_BACKUP}/garmin-tokens" ]; then
         if [ ! -f "/data/garmin-tokens/garmin_tokens.json" ] && [ ! -f "/data/garmin-tokens/oauth1_token.json" ]; then
             bashio::log.info "Restoring Garmin tokens from legacy /share/ backup..."
-            mkdir -p /data/garmin-tokens
-            chmod 700 /data/garmin-tokens
-            cp -a "${SHARE_BACKUP}/garmin-tokens/"* /data/garmin-tokens/ 2>/dev/null || true
-            find /data/garmin-tokens -type f -exec chmod 600 {} +
+            # /share/ is writable by other add-ons. Restore only the known
+            # token files and reject symlinks on both source and destination
+            # so a planted link cannot redirect later reads/writes outside
+            # /data (no blind `cp -a` of arbitrary /share/ entries).
+            if [ -L /data/garmin-tokens ]; then
+                bashio::log.warning "/data/garmin-tokens is a symlink; refusing to restore"
+            else
+                mkdir -p /data/garmin-tokens
+                chmod 700 /data/garmin-tokens
+                for tf in garmin_tokens.json oauth1_token.json oauth2_token.json session.json; do
+                    src="${SHARE_BACKUP}/garmin-tokens/${tf}"
+                    dst="/data/garmin-tokens/${tf}"
+                    if [ -f "${src}" ] && [ ! -L "${src}" ] && [ ! -L "${dst}" ]; then
+                        cp "${src}" "${dst}" 2>/dev/null || true
+                        chmod 600 "${dst}" 2>/dev/null || true
+                    fi
+                done
+            fi
         fi
         bashio::log.info "Removing legacy token backup from /share/ (tokens now stay in /data only)"
         rm -rf "${SHARE_BACKUP}/garmin-tokens"

--- a/pulsecoach/rootfs/etc/s6-overlay/s6-rc.d/pulsecoach/run
+++ b/pulsecoach/rootfs/etc/s6-overlay/s6-rc.d/pulsecoach/run
@@ -21,12 +21,22 @@ fi
 
 # ─── Restore tokens & database from /share/ (survives uninstall) ─────────────
 restore_from_share() {
-    # Restore Garmin tokens
-    if [ -d "${SHARE_BACKUP}/garmin-tokens" ] && [ ! -f "/data/garmin-tokens/garmin_tokens.json" ] && [ ! -f "/data/garmin-tokens/oauth1_token.json" ]; then
-        bashio::log.info "Restoring Garmin tokens from /share/ backup..."
-        mkdir -p /data/garmin-tokens
-        cp -a "${SHARE_BACKUP}/garmin-tokens/"* /data/garmin-tokens/ 2>/dev/null || true
+    # Legacy one-time token restore: older versions backed up Garmin tokens
+    # to /share/, which is readable by other add-ons. Restore once if /data
+    # has no tokens, then remove the exposed copies from /share/.
+    if [ -d "${SHARE_BACKUP}/garmin-tokens" ]; then
+        if [ ! -f "/data/garmin-tokens/garmin_tokens.json" ] && [ ! -f "/data/garmin-tokens/oauth1_token.json" ]; then
+            bashio::log.info "Restoring Garmin tokens from legacy /share/ backup..."
+            mkdir -p /data/garmin-tokens
+            chmod 700 /data/garmin-tokens
+            cp -a "${SHARE_BACKUP}/garmin-tokens/"* /data/garmin-tokens/ 2>/dev/null || true
+            find /data/garmin-tokens -type f -exec chmod 600 {} +
+        fi
+        bashio::log.info "Removing legacy token backup from /share/ (tokens now stay in /data only)"
+        rm -rf "${SHARE_BACKUP}/garmin-tokens"
     fi
+    # Same cleanup for pre-rename backups
+    rm -rf /share/garmincoach/garmin-tokens 2>/dev/null || true
     # Restore PostgreSQL dump (after DB is ready, called later)
 }
 
@@ -50,12 +60,9 @@ restore_database() {
 }
 
 backup_to_share() {
-    bashio::log.info "Backing up tokens & database to /share/..."
-    mkdir -p "${SHARE_BACKUP}/garmin-tokens"
-    # Backup tokens
-    if [ -d "/data/garmin-tokens" ]; then
-        cp -a /data/garmin-tokens/* "${SHARE_BACKUP}/garmin-tokens/" 2>/dev/null || true
-    fi
+    bashio::log.info "Backing up database to /share/..."
+    # NOTE: tokens are deliberately NOT backed up — /share/ is readable by
+    # other add-ons, so credential material stays in /data only.
     # Backup database (compressed)
     if pg_isready -h 127.0.0.1 -p 5432 -q 2>/dev/null; then
         pg_dump -h 127.0.0.1 -U postgres pulsecoach 2>/dev/null | \


### PR DESCRIPTION
## Summary

P0 security fixes from a comprehensive security review of the add-on:

1. **Remove direct port mapping (`3000/tcp`)** — `pulsecoach/config.json`. The add-on relies on HA ingress for authentication (the bundled app runs with `DEV_BYPASS_AUTH=true`), so an exposed host port granted **unauthenticated access** to the dashboard and API. The UI is now ingress-only.
2. **Stop backing up Garmin tokens to `/share/`** — `s6-rc.d/pulsecoach/run`. `/share/` is readable by other add-ons; OAuth credential material now stays in `/data` only. A one-time legacy restore (with `0700`/`0600` perms) is kept for upgrading users, after which the exposed `/share` copies are deleted. DB dumps to `/share/` are unchanged.
3. **Owner-only perms on imported tokens** — `garmin-auth-server.py` `/auth/import-tokens` now creates the token dir with `0700` and writes files via `O_NOFOLLOW` fds with `0600`, matching `_save_tokens()` and the Strava sync.

## Validation
- `pytest tests/`: **245/245 passed**
- `pre-commit run` on changed files: all hooks passed
- `config.json` validated as JSON; run script passes `bash -n` / shellcheck (no new findings)

## Follow-up (not in this PR)
- Internal shared-token auth for the loopback-only `garmin-auth-server` endpoints (requires coordinated app-repo change).