### PR TITLE
fix: garmin token detection, sync backoff and strava reliability

### DIFF
--- a/pulsecoach/.dockerignore
+++ b/pulsecoach/.dockerignore
@@ -1,0 +1,10 @@
+# SPDX-FileCopyrightText: 2026 Anil Belur <askb23@gmail.com>
+# SPDX-License-Identifier: Apache-2.0
+
+.git
+**/__pycache__
+**/.pytest_cache
+**/.ruff_cache
+rootfs/app/tests
+**/node_modules
+*.log

--- a/pulsecoach/rootfs/app/scripts/garmin-auth-server.py
+++ b/pulsecoach/rootfs/app/scripts/garmin-auth-server.py
@@ -35,6 +35,15 @@ _mfa_state = {
 }
 
 
+def _has_saved_garmin_tokens(token_dir: str | None = None) -> bool:
+    """Return true if either native or legacy Garmin token files exist."""
+    token_dir = token_dir or TOKEN_DIR
+    return os.path.exists(os.path.join(token_dir, "garmin_tokens.json")) or (
+        os.path.exists(os.path.join(token_dir, "oauth1_token.json"))
+        and os.path.exists(os.path.join(token_dir, "oauth2_token.json"))
+    )
+
+
 def _save_tokens(client: "Garmin") -> None:
     """Save garth tokens to disk in native directory format."""
     os.makedirs(TOKEN_DIR, mode=0o700, exist_ok=True)
@@ -263,8 +272,8 @@ def trigger_sync() -> tuple[Response, int] | Response:
     except Exception:
         pass
 
-    # Check if tokens exist
-    if not os.path.exists(os.path.join(TOKEN_DIR, "oauth1_token.json")):
+    # Check if either native garminconnect tokens or legacy garth tokens exist.
+    if not _has_saved_garmin_tokens():
         return jsonify(success=False, message="Not connected to Garmin"), 400
 
     # Launch sync in background. Capture stdout/stderr to a rotated log so

--- a/pulsecoach/rootfs/app/scripts/garmin-sync.py
+++ b/pulsecoach/rootfs/app/scripts/garmin-sync.py
@@ -45,8 +45,24 @@ USER_ID = os.environ.get("GARMIN_USER_ID", "seed-user-001")
 GARMIN_MAX_RETRY_ATTEMPTS = 5
 GARMIN_RETRY_BASE_DELAY_SECONDS = 1.0
 GARMIN_RETRY_MAX_DELAY_SECONDS = 60.0
-GARMIN_INITIAL_BACKFILL_DAY_DELAY_SECONDS = float(
-    os.environ.get("GARMIN_INITIAL_BACKFILL_DAY_DELAY_SECONDS", "0.25")
+def _env_float(name: str, default: float) -> float:
+    """Parse a float environment variable, falling back to default if unset
+    or non-numeric, so a bad value cannot crash the sync at import time."""
+    raw = os.environ.get(name)
+    if not raw:
+        return default
+    try:
+        return float(raw)
+    except (TypeError, ValueError):
+        print(
+            f"WARNING: Invalid {name}='{raw}', falling back to {default}",
+            file=sys.stderr,
+        )
+        return default
+
+
+GARMIN_INITIAL_BACKFILL_DAY_DELAY_SECONDS = _env_float(
+    "GARMIN_INITIAL_BACKFILL_DAY_DELAY_SECONDS", 0.25
 )
 T = TypeVar("T")
 
@@ -155,6 +171,9 @@ def _garmin_api_call(
                     GARMIN_RETRY_BASE_DELAY_SECONDS * (2 ** (attempt - 1)),
                 )
             delay = retry_after + random.uniform(0, GARMIN_RETRY_BASE_DELAY_SECONDS)
+            # Bound the delay even when an upstream Retry-After header asks
+            # for an arbitrarily long wait, so backoff stays truly bounded.
+            delay = min(delay, GARMIN_RETRY_MAX_DELAY_SECONDS)
             print(
                 f"  Garmin API retry {attempt}/{GARMIN_MAX_RETRY_ATTEMPTS} "
                 f"for {description} after {delay:.1f}s",

--- a/pulsecoach/rootfs/app/scripts/garmin-sync.py
+++ b/pulsecoach/rootfs/app/scripts/garmin-sync.py
@@ -13,11 +13,14 @@ Supports two auth modes:
 import json
 import math
 import os
+import random
 import re
 import sys
+import time
 from datetime import datetime, timedelta, timezone
+from email.utils import parsedate_to_datetime
 from pathlib import Path
-from typing import Any
+from typing import Any, Callable, TypeVar
 from zoneinfo import ZoneInfo
 
 try:
@@ -39,6 +42,13 @@ GARMIN_PASSWORD = os.environ.get("GARMIN_PASSWORD", "")
 TOKEN_DIR = "/data/garmin-tokens"
 # Must match the userId used by the Next.js app (DEV_BYPASS_AUTH seed user)
 USER_ID = os.environ.get("GARMIN_USER_ID", "seed-user-001")
+GARMIN_MAX_RETRY_ATTEMPTS = 5
+GARMIN_RETRY_BASE_DELAY_SECONDS = 1.0
+GARMIN_RETRY_MAX_DELAY_SECONDS = 60.0
+GARMIN_INITIAL_BACKFILL_DAY_DELAY_SECONDS = float(
+    os.environ.get("GARMIN_INITIAL_BACKFILL_DAY_DELAY_SECONDS", "0.25")
+)
+T = TypeVar("T")
 
 # Timezone for date boundary calculations (e.g., "Australia/Brisbane")
 _tz_name = os.environ.get("USER_TIMEZONE", "UTC")
@@ -75,6 +85,84 @@ def _has_saved_garmin_tokens(token_dir: str | None = None) -> bool:
         os.path.exists(os.path.join(token_dir, "oauth1_token.json"))
         and os.path.exists(os.path.join(token_dir, "oauth2_token.json"))
     )
+
+
+def _exception_status_code(exc: Exception) -> int | None:
+    """Extract an HTTP status code from common client exception shapes."""
+    response = getattr(exc, "response", None)
+    status = getattr(response, "status_code", None)
+    if status is None:
+        status = getattr(exc, "status_code", None)
+    try:
+        return int(status)
+    except (TypeError, ValueError):
+        return None
+
+
+def _retry_after_seconds(exc: Exception) -> float | None:
+    """Extract Retry-After seconds from an exception response, if present."""
+    response = getattr(exc, "response", None)
+    headers = getattr(response, "headers", None) or getattr(exc, "headers", None)
+    if not headers:
+        return None
+    retry_after = headers.get("Retry-After") if hasattr(headers, "get") else None
+    if not retry_after:
+        return None
+    try:
+        return max(0.0, float(retry_after))
+    except (TypeError, ValueError):
+        try:
+            retry_at = parsedate_to_datetime(str(retry_after))
+            if retry_at.tzinfo is None:
+                retry_at = retry_at.replace(tzinfo=timezone.utc)
+            return max(0.0, (retry_at - datetime.now(timezone.utc)).total_seconds())
+        except (TypeError, ValueError, IndexError, OverflowError):
+            return None
+
+
+def _is_garmin_retryable(exc: Exception) -> bool:
+    """Return true for Garmin rate-limit and transient server failures."""
+    status = _exception_status_code(exc)
+    if status == 429 or status in {500, 502, 503, 504}:
+        return True
+    message = str(exc).lower()
+    return (
+        "rate limit" in message
+        or "rate-limit" in message
+        or "too many requests" in message
+        or "http 429" in message
+        or "status code: 429" in message
+    )
+
+
+def _garmin_api_call(
+    description: str,
+    func: Callable[..., T],
+    *args: Any,
+    **kwargs: Any,
+) -> T:
+    """Call a Garmin API method with bounded exponential backoff."""
+    for attempt in range(1, GARMIN_MAX_RETRY_ATTEMPTS + 1):
+        try:
+            return func(*args, **kwargs)
+        except Exception as exc:
+            if attempt >= GARMIN_MAX_RETRY_ATTEMPTS or not _is_garmin_retryable(exc):
+                raise
+            retry_after = _retry_after_seconds(exc)
+            if retry_after is None:
+                retry_after = min(
+                    GARMIN_RETRY_MAX_DELAY_SECONDS,
+                    GARMIN_RETRY_BASE_DELAY_SECONDS * (2 ** (attempt - 1)),
+                )
+            delay = retry_after + random.uniform(0, GARMIN_RETRY_BASE_DELAY_SECONDS)
+            print(
+                f"  Garmin API retry {attempt}/{GARMIN_MAX_RETRY_ATTEMPTS} "
+                f"for {description} after {delay:.1f}s",
+                file=sys.stderr,
+            )
+            time.sleep(delay)
+
+    raise RuntimeError(f"Garmin API retry loop exhausted for {description}")
 
 
 SYNC_STATUS_FILE = os.path.join(TOKEN_DIR, ".sync_status")
@@ -325,7 +413,11 @@ def _fetch_dedicated_skin_temp(client: Any, date_str: str) -> float | None:
         if not callable(method):
             continue
         try:
-            payload = method(date_str)
+            payload = _garmin_api_call(
+                f"{method_name} skin temperature for {date_str}",
+                method,
+                date_str,
+            )
         except Exception as e:
             print(f"  {method_name} skin temp unavailable for {date_str}: {e}")
             continue
@@ -341,25 +433,43 @@ def sync_daily_stats(client: Any, db: Any, date_str: str) -> bool:
     """Sync daily health stats for a given date."""
     cur = db.cursor()
     try:
-        stats = client.get_stats(date_str)
-        sleep_data = client.get_sleep_data(date_str)
-        hrv = client.get_hrv_data(date_str)
-        stress = client.get_stress_data(date_str)
+        stats = _garmin_api_call(
+            f"get_stats for {date_str}", client.get_stats, date_str
+        )
+        sleep_data = _garmin_api_call(
+            f"get_sleep_data for {date_str}", client.get_sleep_data, date_str
+        )
+        hrv = _garmin_api_call(
+            f"get_hrv_data for {date_str}", client.get_hrv_data, date_str
+        )
+        stress = _garmin_api_call(
+            f"get_stress_data for {date_str}", client.get_stress_data, date_str
+        )
 
         # Fetch SpO2, respiration, and body composition (gracefully handle API errors)
         spo2_data = None
         respiration_data = None
         body_comp_data = None
         try:
-            spo2_data = client.get_spo2_data(date_str)
+            spo2_data = _garmin_api_call(
+                f"get_spo2_data for {date_str}", client.get_spo2_data, date_str
+            )
         except Exception as e:
             print(f"  SpO2 data unavailable for {date_str}: {e}")
         try:
-            respiration_data = client.get_respiration_data(date_str)
+            respiration_data = _garmin_api_call(
+                f"get_respiration_data for {date_str}",
+                client.get_respiration_data,
+                date_str,
+            )
         except Exception as e:
             print(f"  Respiration data unavailable for {date_str}: {e}")
         try:
-            body_comp_data = client.get_body_composition(date_str)
+            body_comp_data = _garmin_api_call(
+                f"get_body_composition for {date_str}",
+                client.get_body_composition,
+                date_str,
+            )
         except Exception as e:
             print(f"  Body composition data unavailable for {date_str}: {e}")
 
@@ -761,7 +871,12 @@ def sync_activities(client, db, days=7):
         start = 0
         while True:
             try:
-                activities = client.get_activities(start, batch_size)
+                activities = _garmin_api_call(
+                    f"get_activities start={start} limit={batch_size}",
+                    client.get_activities,
+                    start,
+                    batch_size,
+                )
             except Exception as fetch_exc:
                 print(
                     f"  get_activities(start={start}, "
@@ -1020,9 +1135,19 @@ def backfill_stress_and_sleep(client, db):
         filled = 0
         for date_str in dates:
             try:
-                stress = client.get_stress_data(date_str)
-                sleep_data = client.get_sleep_data(date_str)
-                stats = client.get_stats(date_str)
+                stress = _garmin_api_call(
+                    f"get_stress_data for {date_str}",
+                    client.get_stress_data,
+                    date_str,
+                )
+                sleep_data = _garmin_api_call(
+                    f"get_sleep_data for {date_str}",
+                    client.get_sleep_data,
+                    date_str,
+                )
+                stats = _garmin_api_call(
+                    f"get_stats for {date_str}", client.get_stats, date_str
+                )
                 sleep_dto = sleep_data.get("dailySleepDTO", {}) if sleep_data else {}
 
                 stress_val = None
@@ -1100,7 +1225,11 @@ def sync_vo2max(client, db, days=7):
                 date_str = d.isoformat()
                 dates_queried += 1
                 try:
-                    metrics = client.get_max_metrics(date_str)
+                    metrics = _garmin_api_call(
+                        f"get_max_metrics for {date_str}",
+                        client.get_max_metrics,
+                        date_str,
+                    )
                 except Exception as exc:
                     # Used to silently swallow ALL per-date failures, which
                     # made it impossible to tell from logs whether sparse
@@ -1313,7 +1442,11 @@ def sync_training_readiness(client, db, days=7):
         for days_ago in range(days):
             date_str = (today - timedelta(days=days_ago)).isoformat()
             try:
-                data = _first_dict(client.get_training_readiness(date_str))
+                data = _first_dict(_garmin_api_call(
+                    f"get_training_readiness for {date_str}",
+                    client.get_training_readiness,
+                    date_str,
+                ))
                 if not data:
                     continue
 
@@ -1409,7 +1542,11 @@ def sync_training_status(client, db, days=7):
         for days_ago in range(days):
             date_str = (today - timedelta(days=days_ago)).isoformat()
             try:
-                data = _first_dict(client.get_training_status(date_str))
+                data = _first_dict(_garmin_api_call(
+                    f"get_training_status for {date_str}",
+                    client.get_training_status,
+                    date_str,
+                ))
                 if not data:
                     continue
 
@@ -1542,7 +1679,8 @@ def main():
 
     # First sync: full history from 2019. Subsequent syncs: 7 days only.
     HISTORY_MARKER = os.path.join(TOKEN_DIR, ".initial_sync_done")
-    if os.path.exists(HISTORY_MARKER):
+    initial_backfill = not os.path.exists(HISTORY_MARKER)
+    if not initial_backfill:
         sync_days = 7
     else:
         # Calculate days from 2019-01-01 to today
@@ -1559,6 +1697,12 @@ def main():
         _write_sync_status("daily_stats", f"Syncing {date_str}",
                            int((days_ago / sync_days) * 50))
         sync_daily_stats(client, db, date_str)
+        if (
+            initial_backfill
+            and GARMIN_INITIAL_BACKFILL_DAY_DELAY_SECONDS > 0
+            and days_ago < sync_days - 1
+        ):
+            time.sleep(GARMIN_INITIAL_BACKFILL_DAY_DELAY_SECONDS)
 
     _write_sync_status("backfill_skin_temp", "Backfilling skin temperature...", 50)
     backfill_skin_temp(client, db)

--- a/pulsecoach/rootfs/app/scripts/garmin-sync.py
+++ b/pulsecoach/rootfs/app/scripts/garmin-sync.py
@@ -68,6 +68,15 @@ def _ensure_secure_dir(path: str) -> None:
         os.chmod(path, 0o700)
 
 
+def _has_saved_garmin_tokens(token_dir: str | None = None) -> bool:
+    """Return true if either native or legacy Garmin token files exist."""
+    token_dir = token_dir or TOKEN_DIR
+    return os.path.exists(os.path.join(token_dir, "garmin_tokens.json")) or (
+        os.path.exists(os.path.join(token_dir, "oauth1_token.json"))
+        and os.path.exists(os.path.join(token_dir, "oauth2_token.json"))
+    )
+
+
 SYNC_STATUS_FILE = os.path.join(TOKEN_DIR, ".sync_status")
 LAST_SYNC_FILE = os.path.join(TOKEN_DIR, ".last_sync")
 SKIN_TEMP_BACKFILL_MARKER = "/data/.skin_temp_backfill_done"
@@ -1516,10 +1525,7 @@ def sync_training_status(client, db, days=7):
 
 
 def main():
-    has_tokens = (
-        os.path.exists(os.path.join(TOKEN_DIR, "oauth1_token.json"))
-        and os.path.exists(os.path.join(TOKEN_DIR, "oauth2_token.json"))
-    )
+    has_tokens = _has_saved_garmin_tokens()
 
     if not has_tokens and (not GARMIN_EMAIL or not GARMIN_PASSWORD):
         print("No Garmin tokens or credentials configured, skipping sync")

--- a/pulsecoach/rootfs/app/scripts/strava-sync.py
+++ b/pulsecoach/rootfs/app/scripts/strava-sync.py
@@ -259,6 +259,10 @@ def sync_activities(db, activities):
             print(f"  [strava-sync] Error syncing activity {strava_id}: {e}")
             try:
                 cur.execute("ROLLBACK TO SAVEPOINT strava_activity_upsert")
+                # ROLLBACK TO SAVEPOINT keeps the savepoint defined; release it
+                # so repeated row failures don't accumulate nested savepoints
+                # within the same transaction.
+                cur.execute("RELEASE SAVEPOINT strava_activity_upsert")
             except Exception:
                 db.rollback()
             continue

--- a/pulsecoach/rootfs/app/scripts/strava-sync.py
+++ b/pulsecoach/rootfs/app/scripts/strava-sync.py
@@ -14,6 +14,7 @@ import sys
 import time
 from datetime import datetime, timezone
 from pathlib import Path
+from typing import Any
 
 import psycopg2
 import requests
@@ -25,7 +26,8 @@ TOKEN_FILE = TOKEN_DIR / "strava_tokens.json"
 STRAVA_API_BASE = "https://www.strava.com/api/v3"
 STRAVA_TOKEN_URL = "https://www.strava.com/api/v3/oauth/token"
 
-USER_ID = "default"
+LEGACY_USER_ID = "default"
+USER_ID = os.environ.get("GARMIN_USER_ID", "seed-user-001")
 
 
 def _load_tokens():
@@ -168,6 +170,38 @@ def ensure_strava_column(db):
     db.commit()
 
 
+def migrate_legacy_strava_user_id(db: Any) -> None:
+    """Move legacy Strava activity rows onto the shared PulseCoach user id."""
+    if USER_ID == LEGACY_USER_ID:
+        return
+
+    cur = db.cursor()
+    try:
+        cur.execute("""
+            UPDATE activity
+            SET user_id = %s
+            WHERE user_id = %s
+              AND (
+                source_platform = 'strava'
+                OR strava_activity_id IS NOT NULL
+              )
+        """, (USER_ID, LEGACY_USER_ID))
+        migrated = getattr(cur, "rowcount", 0)
+        if not isinstance(migrated, int):
+            migrated = 0
+        db.commit()
+        if migrated:
+            print(
+                f"[strava-sync] Migrated {migrated} legacy Strava "
+                "activities to shared user id"
+            )
+    except Exception as exc:
+        db.rollback()
+        print(f"[strava-sync] Legacy user id migration skipped: {exc}")
+    finally:
+        cur.close()
+
+
 def sync_activities(db, activities):
     """Upsert Strava activities into the activity table."""
     cur = db.cursor()
@@ -189,6 +223,7 @@ def sync_activities(db, activities):
         trimp = _compute_trimp(duration_min, avg_hr, max_hr)
 
         try:
+            cur.execute("SAVEPOINT strava_activity_upsert")
             cur.execute("""
                 INSERT INTO activity (
                     user_id, strava_activity_id, sport_type,
@@ -218,10 +253,14 @@ def sync_activities(db, activities):
                 act.get("average_watts"), act.get("average_cadence"),
                 "strava", datetime.now(timezone.utc).isoformat(),
             ))
+            cur.execute("RELEASE SAVEPOINT strava_activity_upsert")
             synced += 1
         except Exception as e:
             print(f"  [strava-sync] Error syncing activity {strava_id}: {e}")
-            db.rollback()
+            try:
+                cur.execute("ROLLBACK TO SAVEPOINT strava_activity_upsert")
+            except Exception:
+                db.rollback()
             continue
 
     db.commit()
@@ -249,6 +288,7 @@ def main():
     db = psycopg2.connect(DATABASE_URL)
     try:
         ensure_strava_column(db)
+        migrate_legacy_strava_user_id(db)
 
         # Determine sync window: last 7 days for incremental, full history for first sync
         marker = TOKEN_DIR / ".strava_initial_sync_done"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@
 
 [project]
 name = "ha-garmin-fitness-coach-addon"
-version = "0.1.0"
+version = "0.19.0"
 description = "Home Assistant addon for AI-powered Garmin fitness coaching"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/tests/unit/test_garmin_sync.py
+++ b/tests/unit/test_garmin_sync.py
@@ -511,16 +511,16 @@ class TestSyncTrainingReadiness:
         """If one date raises, the loop continues for the remaining days."""
         conn, cursor = mock_pg_db
         client = MagicMock()
-        # First call fails, second succeeds
+        # First day raises a non-retryable error; second day succeeds.
         client.get_training_readiness.side_effect = [
-            Exception("API rate-limited"),
+            Exception("API unavailable"),
             {"score": 60, "level": "GOOD"},
         ]
         with patch.object(garmin_sync.time, "sleep"), \
              patch.object(garmin_sync.random, "uniform", return_value=0.0):
             garmin_sync.sync_training_readiness(client, conn, days=2)
 
-        assert client.get_training_readiness.call_count == 3
+        assert client.get_training_readiness.call_count == 2
         # Only one UPDATE should be issued (for the day that succeeded)
         update_calls = [
             c for c in cursor.execute.call_args_list

--- a/tests/unit/test_garmin_sync.py
+++ b/tests/unit/test_garmin_sync.py
@@ -112,6 +112,24 @@ class TestGetClient:
         assert mock_client.login.call_count == 2
 
 
+@pytest.mark.unit
+class TestTokenDetection:
+    """Tests for saved-token detection shared by main()."""
+
+    def test_accepts_native_token_file(self, garmin_sync, tmp_path):
+        """Native garminconnect tokens are sufficient for saved-token mode."""
+        (tmp_path / "garmin_tokens.json").touch()
+
+        assert garmin_sync._has_saved_garmin_tokens(str(tmp_path))
+
+    def test_accepts_legacy_token_pair(self, garmin_sync, tmp_path):
+        """Legacy oauth1/oauth2 garth tokens are still accepted."""
+        (tmp_path / "oauth1_token.json").touch()
+        (tmp_path / "oauth2_token.json").touch()
+
+        assert garmin_sync._has_saved_garmin_tokens(str(tmp_path))
+
+
 # ── Daily stats sync ─────────────────────────────────────────────────────────
 
 
@@ -292,6 +310,36 @@ class TestMain:
 
         assert mock_daily.call_count == 7
         mock_act.assert_called_once()
+
+    def test_syncs_with_native_tokens_without_credentials(
+        self, garmin_sync, mock_pg_db, mock_garmin_client, tmp_path
+    ):
+        """main() should not skip when only native token files are present."""
+        conn, _ = mock_pg_db
+        (tmp_path / "garmin_tokens.json").touch()
+        (tmp_path / ".initial_sync_done").touch()
+
+        with patch.object(garmin_sync, "GARMIN_EMAIL", ""), \
+             patch.object(garmin_sync, "GARMIN_PASSWORD", ""), \
+             patch.object(garmin_sync, "TOKEN_DIR", str(tmp_path)), \
+             patch.object(garmin_sync, "get_client", return_value=mock_garmin_client) as get_client, \
+             patch.object(garmin_sync, "get_db", return_value=conn), \
+             patch.object(garmin_sync, "_write_sync_status"), \
+             patch.object(garmin_sync, "_clear_sync_status"), \
+             patch.object(garmin_sync, "_write_last_sync"), \
+             patch.object(garmin_sync, "sync_daily_stats"), \
+             patch.object(garmin_sync, "sync_activities"), \
+             patch.object(garmin_sync, "backfill_skin_temp"), \
+             patch.object(garmin_sync, "backfill_from_raw_json"), \
+             patch.object(garmin_sync, "backfill_activity_started_at_utc"), \
+             patch.object(garmin_sync, "backfill_stress_and_sleep"), \
+             patch.object(garmin_sync, "sync_vo2max"), \
+             patch.object(garmin_sync, "sync_training_readiness"), \
+             patch.object(garmin_sync, "sync_training_status"), \
+             patch.object(garmin_sync, "_refresh_matview"):
+            garmin_sync.main()
+
+        get_client.assert_called_once()
 
 
 # ── Date range calculation ───────────────────────────────────────────────────

--- a/tests/unit/test_garmin_sync.py
+++ b/tests/unit/test_garmin_sync.py
@@ -130,6 +130,37 @@ class TestTokenDetection:
         assert garmin_sync._has_saved_garmin_tokens(str(tmp_path))
 
 
+@pytest.mark.unit
+class TestGarminApiRetry:
+    """Tests for Garmin API retry/backoff helper."""
+
+    def test_retries_rate_limit_then_returns(self, garmin_sync):
+        """HTTP 429 failures are retried with bounded backoff."""
+
+        class Response:
+            status_code = 429
+            headers = {}
+
+        class RateLimited(Exception):
+            response = Response()
+
+        calls = {"count": 0}
+
+        def flaky_call():
+            calls["count"] += 1
+            if calls["count"] == 1:
+                raise RateLimited("Too Many Requests")
+            return {"ok": True}
+
+        with patch.object(garmin_sync.time, "sleep") as sleep, \
+             patch.object(garmin_sync.random, "uniform", return_value=0.0):
+            result = garmin_sync._garmin_api_call("test endpoint", flaky_call)
+
+        assert result == {"ok": True}
+        assert calls["count"] == 2
+        sleep.assert_called_once()
+
+
 # ── Daily stats sync ─────────────────────────────────────────────────────────
 
 
@@ -485,9 +516,11 @@ class TestSyncTrainingReadiness:
             Exception("API rate-limited"),
             {"score": 60, "level": "GOOD"},
         ]
-        garmin_sync.sync_training_readiness(client, conn, days=2)
+        with patch.object(garmin_sync.time, "sleep"), \
+             patch.object(garmin_sync.random, "uniform", return_value=0.0):
+            garmin_sync.sync_training_readiness(client, conn, days=2)
 
-        assert client.get_training_readiness.call_count == 2
+        assert client.get_training_readiness.call_count == 3
         # Only one UPDATE should be issued (for the day that succeeded)
         update_calls = [
             c for c in cursor.execute.call_args_list

--- a/tests/unit/test_strava_sync.py
+++ b/tests/unit/test_strava_sync.py
@@ -1,0 +1,97 @@
+# SPDX-FileCopyrightText: 2026 Anil Belur <askb23@gmail.com>
+# SPDX-License-Identifier: Apache-2.0
+"""Unit tests for strava-sync.py reliability behavior."""
+
+import importlib.util
+import os
+import sys
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+SCRIPT_PATH = (
+    Path(__file__).resolve().parents[2]
+    / "pulsecoach"
+    / "rootfs"
+    / "app"
+    / "scripts"
+    / "strava-sync.py"
+)
+
+
+@pytest.fixture()
+def strava_sync():
+    """Import strava-sync.py as a module with network/database deps mocked."""
+    with patch.dict(
+        sys.modules,
+        {"psycopg2": MagicMock(), "requests": MagicMock()},
+    ):
+        spec = importlib.util.spec_from_file_location("strava_sync", SCRIPT_PATH)
+        mod = importlib.util.module_from_spec(spec)
+        spec.loader.exec_module(mod)
+        yield mod
+
+
+@pytest.mark.unit
+def test_default_user_id_matches_garmin_sync(strava_sync):
+    """Strava rows should share the same seeded app user as Garmin rows."""
+    assert strava_sync.USER_ID == "seed-user-001"
+
+
+@pytest.mark.unit
+def test_user_id_env_override_matches_garmin_sync():
+    """GARMIN_USER_ID override is honored by Strava sync too."""
+    with patch.dict(os.environ, {"GARMIN_USER_ID": "custom-user"}), \
+         patch.dict(sys.modules, {"psycopg2": MagicMock(), "requests": MagicMock()}):
+        spec = importlib.util.spec_from_file_location("strava_sync_env", SCRIPT_PATH)
+        mod = importlib.util.module_from_spec(spec)
+        spec.loader.exec_module(mod)
+
+    assert mod.USER_ID == "custom-user"
+
+
+@pytest.mark.unit
+def test_migrates_legacy_default_user_rows(strava_sync):
+    """Legacy Strava rows under default are moved to the shared user id."""
+    db = MagicMock()
+    cur = MagicMock()
+    cur.rowcount = 2
+    db.cursor.return_value = cur
+
+    strava_sync.migrate_legacy_strava_user_id(db)
+
+    sql, params = cur.execute.call_args.args
+    assert "UPDATE activity" in sql
+    assert params == ("seed-user-001", "default")
+    db.commit.assert_called_once()
+    db.rollback.assert_not_called()
+    cur.close.assert_called_once()
+
+
+@pytest.mark.unit
+def test_sync_activities_uses_savepoints_for_row_failures(strava_sync):
+    """A bad row should not roll back previously counted successful rows."""
+    db = MagicMock()
+    cur = MagicMock()
+    db.cursor.return_value = cur
+
+    def execute(sql, params=None):
+        if "INSERT INTO activity" in sql and params[1] == 2:
+            raise Exception("row failed")
+
+    cur.execute.side_effect = execute
+    activities = [
+        {"id": 1, "type": "Run", "start_date": "2026-01-01T00:00:00Z"},
+        {"id": 2, "type": "Run", "start_date": "2026-01-02T00:00:00Z"},
+        {"id": 3, "type": "Run", "start_date": "2026-01-03T00:00:00Z"},
+    ]
+
+    synced = strava_sync.sync_activities(db, activities)
+
+    executed_sql = [call.args[0] for call in cur.execute.call_args_list]
+    assert synced == 2
+    assert "SAVEPOINT strava_activity_upsert" in executed_sql
+    assert "ROLLBACK TO SAVEPOINT strava_activity_upsert" in executed_sql
+    db.rollback.assert_not_called()
+    db.commit.assert_called_once()


### PR DESCRIPTION
## Summary
- Fixed saved-token detection so Garmin sync and manual sync accept either native `garmin_tokens.json` or the legacy oauth1/oauth2 token pair.
- Added bounded Garmin API retry/backoff for rate limits and transient server failures, plus a short initial-backfill day delay.
- Aligned Strava activity rows with the shared `GARMIN_USER_ID` default, migrated legacy `default` rows, and isolated row failures with savepoints.
- Added `pulsecoach/.dockerignore` for the Docker build context used by `.github/workflows/build.yml` and `pulsecoach/build.json`.
- Synced `pyproject.toml` version to `pulsecoach/config.json` (`0.19.0`).

## Verification
- `python3 -m py_compile pulsecoach/rootfs/app/scripts/garmin-sync.py pulsecoach/rootfs/app/scripts/garmin-auth-server.py pulsecoach/rootfs/app/scripts/strava-sync.py tests/unit/test_garmin_sync.py tests/unit/test_strava_sync.py`
- `python3 -m pytest tests/` — 253 passed
- `pre-commit run --files <changed files>` — passed

## Review findings
All requested P1 items were confirmed present on current `origin/main`; none were skipped as already fixed.