### PR TITLE
feat: meeting stress leaderboard from calendar + Garmin HR

### DIFF
--- a/pulsecoach/rootfs/app/scripts/garmin-auth-server.py
+++ b/pulsecoach/rootfs/app/scripts/garmin-auth-server.py
@@ -431,8 +431,11 @@ def trigger_meeting_stress() -> tuple[Response, int] | Response:
             message=f"Drop your calendar export at {events_file} first "
                     "(see scripts/ics_to_events.py in the repo)",
         ), 400
-    if not os.path.exists(os.path.join(TOKEN_DIR, "oauth1_token.json")) and \
-            not os.path.exists(os.path.join(TOKEN_DIR, "garmin_tokens.json")):
+    has_tokens = any(
+        os.path.exists(os.path.join(TOKEN_DIR, name))
+        for name in ("garmin_tokens.json", "oauth1_token.json", "oauth2_token.json")
+    )
+    if not has_tokens:
         return jsonify(success=False, message="Not connected to Garmin"), 400
 
     status_file = os.path.join(TOKEN_DIR, ".meeting_stress_status")

--- a/pulsecoach/rootfs/app/scripts/garmin-auth-server.py
+++ b/pulsecoach/rootfs/app/scripts/garmin-auth-server.py
@@ -414,5 +414,83 @@ def recompute_status() -> Response:
     return jsonify({"running": False})
 
 
+@app.route("/auth/meeting-stress", methods=["POST"])
+def trigger_meeting_stress() -> tuple[Response, int] | Response:
+    """Score calendar meetings against Garmin HR (background run).
+
+    Reads /share/pulsecoach/calendar_events.json; writes leaderboard JSON+CSVs
+    back to /share/pulsecoach/.
+    """
+    import subprocess
+    import time
+
+    events_file = "/share/pulsecoach/calendar_events.json"
+    if not os.path.exists(events_file):
+        return jsonify(
+            success=False,
+            message=f"Drop your calendar export at {events_file} first "
+                    "(see scripts/ics_to_events.py in the repo)",
+        ), 400
+    if not os.path.exists(os.path.join(TOKEN_DIR, "oauth1_token.json")) and \
+            not os.path.exists(os.path.join(TOKEN_DIR, "garmin_tokens.json")):
+        return jsonify(success=False, message="Not connected to Garmin"), 400
+
+    status_file = os.path.join(TOKEN_DIR, ".meeting_stress_status")
+    try:
+        if os.path.exists(status_file):
+            with open(status_file) as f:
+                if json.load(f).get("running"):
+                    return jsonify(success=False, message="Already running"), 409
+    except Exception:
+        pass
+
+    try:
+        with open(status_file, "w") as f:
+            json.dump({"running": True, "started": time.time()}, f)
+        log_fh = open("/data/meeting-stress.log", "w", buffering=1)
+        try:
+            subprocess.Popen(
+                ["python3", "/app/scripts/meeting-stress.py",
+                 "--events", events_file, "--fetch", "--no-color"],
+                env=os.environ.copy(),
+                stdout=log_fh,
+                stderr=subprocess.STDOUT,
+            )
+        finally:
+            log_fh.close()
+        log.info("Meeting stress run triggered")
+        return jsonify(success=True, message="Meeting stress run started",
+                       results="/share/pulsecoach/meeting_stress.json")
+    except Exception as exc:
+        try:
+            with open(status_file, "w") as f:
+                json.dump({"running": False, "error": str(exc)}, f)
+        except OSError:
+            pass
+        log.error("Failed to trigger meeting stress: %s", exc)
+        return jsonify(success=False, message=f"Failed: {exc}"), 500
+
+
+@app.route("/auth/meeting-stress-status", methods=["GET"])
+def meeting_stress_status() -> Response:
+    """Running state + latest leaderboard, if any."""
+    out: dict = {"running": False}
+    status_file = os.path.join(TOKEN_DIR, ".meeting_stress_status")
+    try:
+        if os.path.exists(status_file):
+            with open(status_file) as f:
+                out.update(json.load(f))
+    except Exception:
+        pass
+    try:
+        results = "/share/pulsecoach/meeting_stress.json"
+        if os.path.exists(results):
+            with open(results) as f:
+                out["results"] = json.load(f)
+    except Exception:
+        pass
+    return jsonify(out)
+
+
 if __name__ == "__main__":
     app.run(host="127.0.0.1", port=8099)

--- a/pulsecoach/rootfs/app/scripts/meeting-stress.py
+++ b/pulsecoach/rootfs/app/scripts/meeting-stress.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 # SPDX-License-Identifier: Apache-2.0
-# SPDX-FileCopyrightText: 2026 The Linux Foundation
+# SPDX-FileCopyrightText: 2026 Anil Belur <askb23@gmail.com>
 ##############################################################################
 # Meeting Stress Leaderboard — which coworker spikes my heart rate.
 #
@@ -254,6 +254,8 @@ def write_csvs(meetings: list[dict], people: list[dict], outdir: str) -> None:
 def load_hr_cache(cache_dir: str) -> HrSeries:
     """Load every cache/hr_*.json ([[epoch_s, bpm], ...]) into one sorted series."""
     series: HrSeries = []
+    if not os.path.isdir(cache_dir):
+        return series  # first run without --fetch: fall through to friendly error
     for name in sorted(os.listdir(cache_dir)):
         if name.startswith("hr_") and name.endswith(".json"):
             with open(os.path.join(cache_dir, name)) as f:
@@ -282,7 +284,8 @@ def _migrate_garth_tokens(token_dir: str) -> None:
     client_id = ""
     try:
         part = access_token.split(".")[1]
-        jwt = json.loads(base64.b64decode(part + "=" * (4 - len(part) % 4)))
+        pad = -len(part) % 4
+        jwt = json.loads(base64.urlsafe_b64decode(part + "=" * pad))
         client_id = jwt.get("client_id", "")
     except Exception:
         pass

--- a/pulsecoach/rootfs/app/scripts/meeting-stress.py
+++ b/pulsecoach/rootfs/app/scripts/meeting-stress.py
@@ -230,6 +230,9 @@ def print_report(meetings: list[dict], people: list[dict], color: bool) -> None:
 
 
 def write_csvs(meetings: list[dict], people: list[dict], outdir: str) -> None:
+    with open(os.path.join(outdir, "meeting_stress.json"), "w") as f:
+        json.dump({"generated": datetime.now(timezone.utc).isoformat(),
+                   "meetings": meetings, "people": people}, f, indent=1)
     with open(os.path.join(outdir, "meeting_scores.csv"), "w", newline="") as f:
         w = csv.writer(f)
         w.writerow(["dbpm", "z", "elev", "title", "attendees"])
@@ -379,14 +382,20 @@ def make_demo(seed: int = 7) -> tuple[list[dict], HrSeries]:
 # CLI
 # --------------------------------------------------------------------------- #
 def main(argv: list[str] | None = None) -> int:
+    share = "/share/pulsecoach"
+    default_events = os.path.join(share, "calendar_events.json")
+
     ap = argparse.ArgumentParser(description=__doc__)
-    ap.add_argument("--events", help="calendar_events.json")
-    ap.add_argument("--hr-cache", default="cache", help="dir of hr_YYYY-MM-DD.json files")
+    ap.add_argument("--events",
+                    default=default_events if os.path.exists(default_events) else None,
+                    help="calendar_events.json (default: /share/pulsecoach/ if present)")
+    ap.add_argument("--hr-cache", default="/data/hr-cache" if os.path.isdir("/data") else "cache",
+                    help="dir of hr_YYYY-MM-DD.json files")
     ap.add_argument("--fetch", action="store_true", help="pull HR live from Garmin (needs tokens)")
     ap.add_argument("--demo", action="store_true", help="run on synthetic post-like data")
     ap.add_argument("--lambda", dest="lam", type=float, default=DEFAULT_LAMBDA)
     ap.add_argument("--max-attendees", type=int, default=DEFAULT_MAX_ATTENDEES)
-    ap.add_argument("--outdir", default=".")
+    ap.add_argument("--outdir", default=share if os.path.isdir(share) else ".")
     ap.add_argument("--no-color", action="store_true")
     args = ap.parse_args(argv)
 
@@ -421,5 +430,21 @@ def main(argv: list[str] | None = None) -> int:
     return 0
 
 
+def _clear_status() -> None:
+    """Clear the auth-server's run lock (same convention as metrics-compute)."""
+    path = os.path.join(os.environ.get("GARMIN_TOKEN_DIR", "/data/garmin-tokens"),
+                        ".meeting_stress_status")
+    try:
+        if os.path.exists(path):
+            with open(path, "w") as f:
+                json.dump({"running": False, "finished": datetime.now(timezone.utc).isoformat()}, f)
+    except OSError:
+        pass
+
+
 if __name__ == "__main__":
-    raise SystemExit(main())
+    try:
+        code = main()
+    finally:
+        _clear_status()
+    raise SystemExit(code)

--- a/scripts/ics_to_events.py
+++ b/scripts/ics_to_events.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 # SPDX-License-Identifier: Apache-2.0
-# SPDX-FileCopyrightText: 2026 The Linux Foundation
+# SPDX-FileCopyrightText: 2026 Anil Belur <askb23@gmail.com>
 ##############################################################################
 # Convert a Google Calendar .ics export into calendar_events.json for
 # meeting_stress.py. Expands recurring events (RRULE/EXDATE), keeps only
@@ -25,10 +25,15 @@ except ImportError:
     raise SystemExit(1)
 
 
+def _strip_mailto(value: str) -> str:
+    """Remove mailto: prefix case-insensitively (Google exports use MAILTO: too)."""
+    return value[7:] if value[:7].lower() == "mailto:" else value
+
+
 def _name(att) -> str:
     """Prefer CN display name, fall back to the email local part."""
     cn = att.params.get("CN", "")
-    email = str(att).removeprefix("mailto:")
+    email = _strip_mailto(str(att))
     if cn and "@" not in cn:
         return cn
     return email.split("@")[0]
@@ -54,7 +59,7 @@ def convert(ics_path: str, self_email: str, start: date, end: date) -> list[dict
             raw = [raw]
         attendees = []
         for att in raw:
-            email = str(att).removeprefix("mailto:").lower()
+            email = _strip_mailto(str(att)).lower()
             if att.params.get("PARTSTAT", "").upper() == "DECLINED":
                 continue  # they weren't there
             if att.params.get("CUTYPE", "").upper() in ("RESOURCE", "ROOM"):

--- a/scripts/ics_to_events.py
+++ b/scripts/ics_to_events.py
@@ -1,0 +1,100 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: 2026 The Linux Foundation
+##############################################################################
+# Convert a Google Calendar .ics export into calendar_events.json for
+# meeting_stress.py. Expands recurring events (RRULE/EXDATE), keeps only
+# attendees who did not decline, and drops yourself + room resources.
+#
+# One-off preprocessing tool; needs: pip install icalendar recurring-ical-events
+##############################################################################
+"""ICS export -> calendar_events.json (attendee display names, recurrences expanded)."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from datetime import date, datetime, time, timedelta, timezone
+
+try:
+    import icalendar
+    import recurring_ical_events
+except ImportError:
+    print("pip install icalendar recurring-ical-events", file=sys.stderr)
+    raise SystemExit(1)
+
+
+def _name(att) -> str:
+    """Prefer CN display name, fall back to the email local part."""
+    cn = att.params.get("CN", "")
+    email = str(att).removeprefix("mailto:")
+    if cn and "@" not in cn:
+        return cn
+    return email.split("@")[0]
+
+
+def convert(ics_path: str, self_email: str, start: date, end: date) -> list[dict]:
+    with open(ics_path, "rb") as f:
+        cal = icalendar.Calendar.from_ical(f.read())
+
+    events = []
+    for ev in recurring_ical_events.of(cal).between(start, end):
+        dtstart, dtend = ev.get("DTSTART"), ev.get("DTEND")
+        if not dtstart or not dtend:
+            continue
+        s, e = dtstart.dt, dtend.dt
+        if not isinstance(s, datetime):  # all-day event -> skip (no HR window)
+            continue
+        if s.tzinfo is None:
+            s, e = s.replace(tzinfo=timezone.utc), e.replace(tzinfo=timezone.utc)
+
+        raw = ev.get("ATTENDEE", [])
+        if not isinstance(raw, list):
+            raw = [raw]
+        attendees = []
+        for att in raw:
+            email = str(att).removeprefix("mailto:").lower()
+            if att.params.get("PARTSTAT", "").upper() == "DECLINED":
+                continue  # they weren't there
+            if att.params.get("CUTYPE", "").upper() in ("RESOURCE", "ROOM"):
+                continue  # meeting rooms aren't coworkers
+            if email == self_email.lower():
+                continue  # you attend everything; collinear with intercept
+            attendees.append(_name(att))
+        if not attendees:
+            continue
+
+        events.append({
+            "start": s.isoformat(),
+            "end": e.isoformat(),
+            "title": str(ev.get("SUMMARY", "(untitled)")),
+            "attendees": sorted(set(attendees)),
+        })
+
+    events.sort(key=lambda ev: ev["start"])
+    return events
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument("ics", help="path to exported .ics file")
+    ap.add_argument("--self", required=True, dest="self_email",
+                    help="your email (excluded from attendee lists)")
+    ap.add_argument("--days", type=int, default=30, help="how far back from today")
+    ap.add_argument("--out", default="calendar_events.json")
+    args = ap.parse_args()
+
+    end = date.today() + timedelta(days=1)
+    start = end - timedelta(days=args.days + 1)
+    events = convert(args.ics, args.self_email, start, end)
+
+    with open(args.out, "w") as f:
+        json.dump(events, f, indent=1)
+    people = sorted({p for ev in events for p in ev["attendees"]})
+    print(f"{len(events)} meetings ({start}..{end}), {len(people)} distinct attendees -> {args.out}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/meeting_stress.py
+++ b/scripts/meeting_stress.py
@@ -1,0 +1,396 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: 2026 The Linux Foundation
+##############################################################################
+# Meeting Stress Leaderboard — which coworker spikes my heart rate.
+#
+# Joins per-~2min Garmin heart rate against calendar events + attendees,
+# scores each meeting vs a local 90-min baseline (dbpm / z / elev), then fits
+# a ridge regression over attendee presence to de-confound who-attends-with-whom.
+#
+# Inputs are files only: a calendar_events.json and an HR series (cache files
+# or --demo synthetic). No audio, no recording, no calendar auth.
+#
+# stdlib only (matches repo scripts); ridge is a hand-rolled ~kxk solve.
+##############################################################################
+"""Meeting stress leaderboard from calendar attendees + Garmin heart rate."""
+
+from __future__ import annotations
+
+import argparse
+import bisect
+import csv
+import json
+import math
+import os
+import random
+import sys
+from datetime import datetime, timedelta, timezone
+
+BASELINE_MIN = 90          # +/- minutes of local baseline around each meeting
+MIN_BASELINE_SAMPLES = 5   # need this many HR points to trust a baseline
+DEFAULT_LAMBDA = 1.0       # ridge penalty
+DEFAULT_MAX_ATTENDEES = 8  # bigger meetings (town-halls) are noise
+MIN_RANK_MEETINGS = 3      # below this, a person's rank is "thin data"
+
+HrSeries = list[tuple[int, float]]  # (epoch_seconds, bpm), sorted by ts
+
+
+# --------------------------------------------------------------------------- #
+# Parsing / HR window helpers
+# --------------------------------------------------------------------------- #
+def parse_ts(value: str) -> int:
+    """ISO-8601 (with offset or trailing Z) -> epoch seconds (UTC)."""
+    if value.endswith("Z"):
+        value = value[:-1] + "+00:00"
+    dt = datetime.fromisoformat(value)
+    if dt.tzinfo is None:
+        dt = dt.replace(tzinfo=timezone.utc)
+    return int(dt.timestamp())
+
+
+def _bpm_between(series: HrSeries, lo: int, hi: int) -> list[float]:
+    """HR values with lo <= ts < hi (series sorted by ts)."""
+    keys = [ts for ts, _ in series]
+    i = bisect.bisect_left(keys, lo)
+    j = bisect.bisect_left(keys, hi)
+    return [bpm for _, bpm in series[i:j]]
+
+
+def _bpm_baseline(series: HrSeries, lo: int, hi: int, busy: list[tuple[int, int]]) -> list[float]:
+    """HR in [lo, hi) excluding any time covered by a meeting interval in `busy`."""
+    keys = [ts for ts, _ in series]
+    i = bisect.bisect_left(keys, lo)
+    j = bisect.bisect_left(keys, hi)
+    out = []
+    for ts, bpm in series[i:j]:
+        if not any(s <= ts < e for s, e in busy):
+            out.append(bpm)
+    return out
+
+
+def _mean(xs: list[float]) -> float:
+    return sum(xs) / len(xs)
+
+
+def _pstdev(xs: list[float]) -> float:
+    m = _mean(xs)
+    return math.sqrt(sum((x - m) ** 2 for x in xs) / len(xs))
+
+
+# --------------------------------------------------------------------------- #
+# Per-meeting scoring
+# --------------------------------------------------------------------------- #
+def score_meetings(events: list[dict], series: HrSeries,
+                   max_attendees: int = DEFAULT_MAX_ATTENDEES) -> list[dict]:
+    """Score each usable meeting vs its local baseline. Returns rows with dbpm/z/elev."""
+    intervals = [(parse_ts(e["start"]), parse_ts(e["end"])) for e in events]
+    win = BASELINE_MIN * 60
+    rows: list[dict] = []
+
+    for idx, ev in enumerate(events):
+        attendees = [a for a in ev.get("attendees", []) if a]
+        if not attendees or len(attendees) > max_attendees:
+            continue  # solo or town-hall: skip
+        s, e = intervals[idx]
+        if e - s >= 6 * 3600:
+            continue  # all-day / multi-hour block: skip
+
+        meeting = _bpm_between(series, s, e)
+        # baseline = surrounding window minus *every* meeting (incl. this one)
+        base = _bpm_baseline(series, s - win, e + win, intervals)
+        if not meeting or len(base) < MIN_BASELINE_SAMPLES:
+            continue  # not enough signal
+
+        mean_m, mean_b = _mean(meeting), _mean(base)
+        std_b = max(_pstdev(base), 1.0)  # floor: avoid div-by-zero / z blow-up
+        dbpm = mean_m - mean_b
+        rows.append({
+            "title": ev.get("title", "(untitled)"),
+            "attendees": attendees,
+            "dbpm": dbpm,
+            "z": dbpm / std_b,
+            "elev": sum(1 for b in meeting if b > mean_b) / len(meeting),
+        })
+
+    rows.sort(key=lambda r: r["dbpm"], reverse=True)
+    return rows
+
+
+# --------------------------------------------------------------------------- #
+# Ridge regression (hand-rolled normal equations, intercept unpenalised)
+# --------------------------------------------------------------------------- #
+def _solve(a: list[list[float]], b: list[float]) -> list[float]:
+    """Solve a x = b via Gauss-Jordan with partial pivoting. n is tiny (#attendees)."""
+    n = len(b)
+    m = [row[:] + [b[i]] for i, row in enumerate(a)]
+    for col in range(n):
+        piv = max(range(col, n), key=lambda r: abs(m[r][col]))
+        if abs(m[piv][col]) < 1e-12:
+            continue  # singular column; ridge penalty normally prevents this
+        m[col], m[piv] = m[piv], m[col]
+        pv = m[col][col]
+        m[col] = [v / pv for v in m[col]]
+        for r in range(n):
+            if r != col and m[r][col]:
+                factor = m[r][col]
+                m[r] = [v - factor * m[col][k] for k, v in enumerate(m[r])]
+    return [m[i][n] for i in range(n)]
+
+
+def ridge_effects(rows: list[dict], lam: float = DEFAULT_LAMBDA) -> dict[str, float]:
+    """Marginal bpm effect per attendee. Column 0 is an unpenalised intercept."""
+    people = sorted({p for r in rows for p in r["attendees"]})
+    if not people:
+        return {}
+    cols = ["__intercept__"] + people
+    x = [[1.0] + [1.0 if p in r["attendees"] else 0.0 for p in people] for r in rows]
+    y = [r["dbpm"] for r in rows]
+
+    k = len(cols)
+    xtx = [[sum(x[t][i] * x[t][j] for t in range(len(x))) for j in range(k)] for i in range(k)]
+    for i in range(1, k):           # penalise attendees, not the intercept
+        xtx[i][i] += lam
+    xty = [sum(x[t][i] * y[t] for t in range(len(x))) for i in range(k)]
+    w = _solve(xtx, xty)
+    return dict(zip(people, w[1:]))
+
+
+def naive_effects(rows: list[dict]) -> dict[str, list[float]]:
+    """Per attendee: list of meeting dbpm values where they were present."""
+    out: dict[str, list[float]] = {}
+    for r in rows:
+        for p in r["attendees"]:
+            out.setdefault(p, []).append(r["dbpm"])
+    return out
+
+
+def _label(ridge: float, n: int) -> str:
+    if n < MIN_RANK_MEETINGS:
+        return "thin data"
+    if ridge >= 5.0:
+        return "prime suspect"
+    if ridge >= 2.0:
+        return "mild stressor"
+    if ridge >= 0.5:
+        return "slightly raises HR"
+    if ridge > -0.5:
+        return "neutral"
+    return "calming"
+
+
+def _reliability(n: int) -> str:
+    return "high" if n >= 5 else "med" if n >= MIN_RANK_MEETINGS else "low"
+
+
+def leaderboard(rows: list[dict], lam: float = DEFAULT_LAMBDA) -> list[dict]:
+    """Combine naive + ridge into a ranked per-person table."""
+    naive = naive_effects(rows)
+    ridge = ridge_effects(rows, lam)
+    people = []
+    for p, deltas in naive.items():
+        n = len(deltas)
+        r = ridge.get(p, 0.0)
+        people.append({
+            "attendee": p,
+            "n": n,
+            "naive": _mean(deltas),
+            "ridge": r,
+            "reliability": _reliability(n),
+            "label": _label(r, n),
+        })
+    people.sort(key=lambda d: d["ridge"], reverse=True)
+    return people
+
+
+# --------------------------------------------------------------------------- #
+# Output
+# --------------------------------------------------------------------------- #
+def _c(text: str, value: float, enable: bool) -> str:
+    if not enable:
+        return text
+    code = "31" if value > 0.5 else "32" if value < -0.5 else "90"
+    return f"\033[{code}m{text}\033[0m"
+
+
+def print_report(meetings: list[dict], people: list[dict], color: bool) -> None:
+    print("\nMEETING STRESS   mean HR over surrounding baseline")
+    print(f"  {'dbpm':>6} {'z':>6} {'elev':>5}  {'meeting':<22} attendees")
+    for r in meetings:
+        line = f"  {r['dbpm']:+6.1f} {r['z']:6.2f} {r['elev']*100:4.0f}%  {r['title'][:22]:<22} {', '.join(r['attendees'])}"
+        print(_c(line, r["dbpm"], color))
+
+    print("\nPER-PERSON   ranked by ridge marginal effect (bpm)")
+    print(f"  {'attendee':<16} {'n':>3} {'naive':>7} {'ridge':>7} {'rel':>5}  label")
+    for p in people:
+        line = (f"  {p['attendee']:<16} {p['n']:>3} {p['naive']:>7.2f} "
+                f"{p['ridge']:>7.2f} {p['reliability']:>5}  {p['label']}")
+        print(_c(line, p["ridge"], color))
+    print()
+
+
+def write_csvs(meetings: list[dict], people: list[dict], outdir: str) -> None:
+    with open(os.path.join(outdir, "meeting_scores.csv"), "w", newline="") as f:
+        w = csv.writer(f)
+        w.writerow(["dbpm", "z", "elev", "title", "attendees"])
+        for r in meetings:
+            w.writerow([f"{r['dbpm']:.2f}", f"{r['z']:.3f}", f"{r['elev']:.3f}",
+                        r["title"], "|".join(r["attendees"])])
+    with open(os.path.join(outdir, "person_scores.csv"), "w", newline="") as f:
+        w = csv.writer(f)
+        w.writerow(["attendee", "n", "naive", "ridge", "reliability", "label"])
+        for p in people:
+            w.writerow([p["attendee"], p["n"], f"{p['naive']:.3f}",
+                        f"{p['ridge']:.3f}", p["reliability"], p["label"]])
+    print(f"wrote meeting_scores.csv, person_scores.csv -> {outdir}")
+
+
+# --------------------------------------------------------------------------- #
+# HR sources
+# --------------------------------------------------------------------------- #
+def load_hr_cache(cache_dir: str) -> HrSeries:
+    """Load every cache/hr_*.json ([[epoch_s, bpm], ...]) into one sorted series."""
+    series: HrSeries = []
+    for name in sorted(os.listdir(cache_dir)):
+        if name.startswith("hr_") and name.endswith(".json"):
+            with open(os.path.join(cache_dir, name)) as f:
+                series.extend((int(ts), float(bpm)) for ts, bpm in json.load(f) if bpm is not None)
+    series.sort()
+    return series
+
+
+def fetch_hr_garmin(dates: list[str], cache_dir: str) -> HrSeries:
+    """Real path: pull ~2-min HR per date via garminconnect, cache, return series.
+
+    ponytail: untested here (needs saved tokens). Reuses GARMIN_TOKEN_DIR like the addon.
+    """
+    from garminconnect import Garmin  # type: ignore
+
+    token_dir = os.environ.get("GARMIN_TOKEN_DIR", "/data/garmin-tokens")
+    client = Garmin(os.environ.get("GARMIN_EMAIL", "token-user"),
+                    os.environ.get("GARMIN_PASSWORD", ""))
+    client.login(tokenstore=token_dir)
+
+    os.makedirs(cache_dir, exist_ok=True)
+    series: HrSeries = []
+    for date_str in dates:
+        path = os.path.join(cache_dir, f"hr_{date_str}.json")
+        if os.path.exists(path):
+            with open(path) as f:
+                pairs = json.load(f)
+        else:
+            data = client.get_heart_rates(date_str) or {}
+            pairs = [[int(ms // 1000), bpm] for ms, bpm in data.get("heartRateValues") or []
+                     if bpm is not None]
+            with open(path, "w") as f:
+                json.dump(pairs, f)
+        series.extend((int(ts), float(bpm)) for ts, bpm in pairs)
+    series.sort()
+    return series
+
+
+# --------------------------------------------------------------------------- #
+# Synthetic demo data
+# --------------------------------------------------------------------------- #
+def make_demo(seed: int = 7) -> tuple[list[dict], HrSeries]:
+    """Post-like dataset: 8 attendees, ~18 meetings, synthetic 2-min HR.
+
+    `manager` attends almost everything (the confounder); the leaderboard should
+    still clear them via ridge while flagging the real stressor `pm_growth`.
+    """
+    rng = random.Random(seed)
+    effects = {  # true marginal bpm each attendee adds to a meeting
+        "pm_growth": 8.0, "team_1_person": 4.0, "engg_1": 1.3, "ios_engg": 1.0,
+        "team_2_person": 0.8, "manager": 0.2, "engg_2": -1.0, "senior_dev": -3.5,
+    }
+    people = list(effects)
+
+    # Build meetings on weekdays, business hours, 2026-06-01 (Mon) onward.
+    base_day = datetime(2026, 6, 1, tzinfo=timezone.utc)
+    events: list[dict] = []
+    workdays = [base_day + timedelta(days=d) for d in range(14) if (base_day + timedelta(days=d)).weekday() < 5]
+    titles = ["standup", "1:1", "planning", "review", "sync", "all-hands prep",
+              "retro", "design", "roadmap", "incident review"]
+    for day in workdays:
+        for _ in range(rng.randint(1, 3)):
+            hour = rng.choice([9, 10, 11, 13, 14, 15, 16])
+            start = day.replace(hour=hour, minute=0)
+            dur = rng.choice([30, 45, 60])
+            others = rng.sample([p for p in people if p != "manager"], rng.randint(1, 4))
+            attendees = (["manager"] + others) if rng.random() < 0.75 else others
+            events.append({
+                "start": start.isoformat(),
+                "end": (start + timedelta(minutes=dur)).isoformat(),
+                "title": rng.choice(titles),
+                "attendees": attendees,
+            })
+    events = events[:18]
+
+    # Mark each meeting's true elevation = sum of attendee effects.
+    meeting_lift: list[tuple[int, int, float]] = []
+    for ev in events:
+        s, e = parse_ts(ev["start"]), parse_ts(ev["end"])
+        meeting_lift.append((s, e, sum(effects[a] for a in ev["attendees"])))
+
+    # Generate 2-min HR across each workday: circadian-ish drift + noise + meeting lift.
+    series: HrSeries = []
+    for day in workdays:
+        day_start = int(day.replace(hour=7).timestamp())
+        for k in range(0, 11 * 60, 2):  # 07:00..18:00, every 2 min
+            ts = day_start + k * 60
+            circadian = 6.0 * math.sin(k / (11 * 60) * math.pi)  # gentle daytime hump
+            lift = sum(l for s, e, l in meeting_lift if s <= ts < e)
+            bpm = 62 + circadian + lift + rng.gauss(0, 2.0)
+            series.append((ts, round(bpm, 1)))
+    series.sort()
+    return events, series
+
+
+# --------------------------------------------------------------------------- #
+# CLI
+# --------------------------------------------------------------------------- #
+def main(argv: list[str] | None = None) -> int:
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument("--events", help="calendar_events.json")
+    ap.add_argument("--hr-cache", default="cache", help="dir of hr_YYYY-MM-DD.json files")
+    ap.add_argument("--fetch", action="store_true", help="pull HR live from Garmin (needs tokens)")
+    ap.add_argument("--demo", action="store_true", help="run on synthetic post-like data")
+    ap.add_argument("--lambda", dest="lam", type=float, default=DEFAULT_LAMBDA)
+    ap.add_argument("--max-attendees", type=int, default=DEFAULT_MAX_ATTENDEES)
+    ap.add_argument("--outdir", default=".")
+    ap.add_argument("--no-color", action="store_true")
+    args = ap.parse_args(argv)
+
+    if args.demo:
+        events, series = make_demo()
+    else:
+        if not args.events:
+            ap.error("--events is required (or use --demo)")
+        with open(args.events) as f:
+            events = json.load(f)
+        if args.fetch:
+            dates = sorted({parse_ts(e["start"]) for e in events})
+            dates = sorted({datetime.fromtimestamp(d, timezone.utc).strftime("%Y-%m-%d") for d in dates})
+            series = fetch_hr_garmin(dates, args.hr_cache)
+        else:
+            series = load_hr_cache(args.hr_cache)
+
+    if not series:
+        print("No heart-rate samples found. Use --demo, --fetch, or populate --hr-cache.",
+              file=sys.stderr)
+        return 1
+
+    meetings = score_meetings(events, series, args.max_attendees)
+    if not meetings:
+        print("No scorable meetings (all solo / too big / outside HR coverage).", file=sys.stderr)
+        return 1
+    people = leaderboard(meetings, args.lam)
+
+    color = sys.stdout.isatty() and not args.no_color
+    print_report(meetings, people, color)
+    write_csvs(meetings, people, args.outdir)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/meeting_stress.py
+++ b/scripts/meeting_stress.py
@@ -259,14 +259,43 @@ def load_hr_cache(cache_dir: str) -> HrSeries:
     return series
 
 
-def fetch_hr_garmin(dates: list[str], cache_dir: str) -> HrSeries:
-    """Real path: pull ~2-min HR per date via garminconnect, cache, return series.
+def _migrate_garth_tokens(token_dir: str) -> None:
+    """Convert legacy garth oauth2_token.json to garminconnect 0.3.x native format.
 
-    ponytail: untested here (needs saved tokens). Reuses GARMIN_TOKEN_DIR like the addon.
+    Same migration as pulsecoach garmin-sync.py — generate-garmin-tokens.py emits
+    garth-format files, which newer garminconnect can't load directly.
     """
+    import base64
+
+    native = os.path.join(token_dir, "garmin_tokens.json")
+    legacy = os.path.join(token_dir, "oauth2_token.json")
+    if os.path.exists(native) or not os.path.exists(legacy):
+        return
+    with open(legacy) as f:
+        oauth2 = json.load(f)
+    access_token = oauth2.get("access_token", "")
+    if not access_token:
+        return
+    client_id = ""
+    try:
+        part = access_token.split(".")[1]
+        jwt = json.loads(base64.b64decode(part + "=" * (4 - len(part) % 4)))
+        client_id = jwt.get("client_id", "")
+    except Exception:
+        pass
+    fd = os.open(native, os.O_WRONLY | os.O_CREAT | os.O_TRUNC | os.O_NOFOLLOW, 0o600)
+    with os.fdopen(fd, "w") as f:
+        json.dump({"di_token": access_token,
+                   "di_refresh_token": oauth2.get("refresh_token", ""),
+                   "di_client_id": client_id}, f, indent=2)
+
+
+def fetch_hr_garmin(dates: list[str], cache_dir: str) -> HrSeries:
+    """Real path: pull ~2-min HR per date via garminconnect, cache, return series."""
     from garminconnect import Garmin  # type: ignore
 
     token_dir = os.environ.get("GARMIN_TOKEN_DIR", "/data/garmin-tokens")
+    _migrate_garth_tokens(token_dir)
     client = Garmin(os.environ.get("GARMIN_EMAIL", "token-user"),
                     os.environ.get("GARMIN_PASSWORD", ""))
     client.login(tokenstore=token_dir)

--- a/tests/test_meeting_stress.py
+++ b/tests/test_meeting_stress.py
@@ -5,12 +5,15 @@
 
 Run: python -m pytest tests/test_meeting_stress.py   (or: python tests/test_meeting_stress.py)
 """
-import os
-import sys
+import importlib.util
 from datetime import datetime, timedelta, timezone
+from pathlib import Path
 
-sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "scripts"))
-import meeting_stress as ms  # noqa: E402
+_SCRIPT = (Path(__file__).resolve().parents[1] / "pulsecoach" / "rootfs"
+           / "app" / "scripts" / "meeting-stress.py")
+_spec = importlib.util.spec_from_file_location("meeting_stress", _SCRIPT)
+ms = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(ms)
 
 DAY = datetime(2026, 6, 1, tzinfo=timezone.utc)
 

--- a/tests/test_meeting_stress.py
+++ b/tests/test_meeting_stress.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 # SPDX-License-Identifier: Apache-2.0
-# SPDX-FileCopyrightText: 2026 The Linux Foundation
+# SPDX-FileCopyrightText: 2026 Anil Belur <askb23@gmail.com>
 """Self-check for meeting_stress: baseline math + ridge de-confounding.
 
 Run: python -m pytest tests/test_meeting_stress.py   (or: python tests/test_meeting_stress.py)

--- a/tests/test_meeting_stress.py
+++ b/tests/test_meeting_stress.py
@@ -1,0 +1,92 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: 2026 The Linux Foundation
+"""Self-check for meeting_stress: baseline math + ridge de-confounding.
+
+Run: python -m pytest tests/test_meeting_stress.py   (or: python tests/test_meeting_stress.py)
+"""
+import os
+import sys
+from datetime import datetime, timedelta, timezone
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "scripts"))
+import meeting_stress as ms  # noqa: E402
+
+DAY = datetime(2026, 6, 1, tzinfo=timezone.utc)
+
+
+def _build():
+    """alice = true +10 stressor; bob = 0 bystander who co-attends alice; carol = -6 calming.
+
+    bob also gets solo-ish neutral meetings so ridge can separate him from alice.
+    """
+    lift = {"alice": 10.0, "bob": 0.0, "carol": -6.0, "dave": 0.0}
+    # (day_offset, hour, [attendees])
+    specs = [
+        (0, 9, ["alice", "bob", "dave"]),
+        (0, 14, ["alice", "dave"]),
+        (1, 9, ["alice", "bob"]),
+        (1, 14, ["bob", "dave"]),       # bob without alice -> neutral
+        (2, 9, ["alice", "bob", "carol"]),
+        (2, 14, ["bob", "dave"]),       # bob without alice -> neutral
+        (3, 9, ["alice", "carol"]),
+        (3, 14, ["carol", "dave"]),     # carol calming, no alice
+        (4, 9, ["alice", "bob", "dave"]),
+        (4, 14, ["carol", "bob"]),
+    ]
+    events, windows = [], []
+    for d, h, att in specs:
+        start = DAY.replace(hour=h) + timedelta(days=d)
+        end = start + timedelta(minutes=40)
+        events.append({"start": start.isoformat(), "end": end.isoformat(),
+                       "title": "m", "attendees": att})
+        windows.append((int(start.timestamp()), int(end.timestamp()),
+                        sum(lift[a] for a in att)))
+
+    # 2-min HR backbone at 62 bpm across each meeting day, with meeting lifts applied.
+    series = []
+    for d in range(5):
+        day_start = int((DAY.replace(hour=7) + timedelta(days=d)).timestamp())
+        for k in range(0, 11 * 60, 2):
+            ts = day_start + k * 60
+            bpm = 62.0 + sum(l for s, e, l in windows if s <= ts < e)
+            series.append((ts, bpm))
+    series.sort()
+    return events, series
+
+
+def test_ridge_deconfounds_bystander():
+    events, series = _build()
+    rows = ms.score_meetings(events, series)
+    people = {p["attendee"]: p for p in ms.leaderboard(rows, lam=1.0)}
+
+    # 1. alice is the clear top stressor.
+    assert people["alice"]["ridge"] > 4.0, people["alice"]
+    top = max(people.values(), key=lambda p: p["ridge"])["attendee"]
+    assert top == "alice", top
+
+    # 2. bob's NAIVE average is inflated by co-attending alice, but ridge clears him.
+    assert people["bob"]["naive"] > 2.0, people["bob"]      # confounded
+    assert abs(people["bob"]["ridge"]) < 2.5, people["bob"]  # de-confounded ~0
+    assert people["bob"]["naive"] - people["bob"]["ridge"] > 1.5, people["bob"]
+
+    # 3. carol reads as calming (negative effect).
+    assert people["carol"]["ridge"] < -1.0, people["carol"]
+
+
+def test_solo_and_oversize_meetings_skipped():
+    events = [
+        {"start": DAY.replace(hour=9).isoformat(),
+         "end": DAY.replace(hour=9, minute=30).isoformat(), "title": "solo", "attendees": []},
+        {"start": DAY.replace(hour=10).isoformat(),
+         "end": DAY.replace(hour=10, minute=30).isoformat(), "title": "townhall",
+         "attendees": [f"p{i}" for i in range(20)]},
+    ]
+    series = [(int(DAY.replace(hour=7).timestamp()) + k * 60, 62.0) for k in range(0, 600, 2)]
+    assert ms.score_meetings(events, series) == []
+
+
+if __name__ == "__main__":
+    test_ridge_deconfounds_bystander()
+    test_solo_and_oversize_meetings_skipped()
+    print("ok")


### PR DESCRIPTION
## What

Replicates the viral Whoop×calendar hack with PulseCoach: score each meeting's heart-rate elevation against a ±90-min local baseline (dbpm/z/elev), then fit a ridge regression over attendee presence to de-confound co-attendance and rank coworkers by marginal bpm effect.

## How

- `pulsecoach/rootfs/app/scripts/meeting-stress.py` — stdlib-only scorer. Inputs: `/share/pulsecoach/calendar_events.json` + Garmin ~2-min HR via `get_heart_rates` (tokens from `/data/garmin-tokens`, cached in `/data/hr-cache`). Outputs: leaderboard to stdout, `meeting_stress.json` + 2 CSVs to `/share/pulsecoach/`. Includes `--demo` synthetic mode and garth→native token migration (same as garmin-sync.py).
- `garmin-auth-server.py` — new endpoints `POST /auth/meeting-stress` and `GET /auth/meeting-stress-status`, cloned from the existing recompute Popen + status-file pattern.
- `scripts/ics_to_events.py` — laptop-side Google Calendar ICS → events JSON converter (expands RRULEs, drops declined attendees/self/rooms). Not shipped in the image; needs `icalendar` + `recurring-ical-events` locally.
- `tests/test_meeting_stress.py` — self-check proving ridge ranks the true stressor top and clears a co-attending bystander.

## Verified

- Test green; `--demo` reproduces the reference post's signature (heavy-attender cleared by ridge, true stressor ranked top).
- End-to-end on real data: 30-day calendar export (17 meetings / 10 attendees) + live Garmin HR fetch.
- No new image dependencies (stdlib only). pre-commit clean.

## Usage

1. `python3 scripts/ics_to_events.py export.ics --self you@example.org`
2. Copy `calendar_events.json` to `/share/pulsecoach/`
3. `curl -X POST http://<addon>:8099/auth/meeting-stress`
4. `GET /auth/meeting-stress-status` → leaderboard JSON