### PR TITLE
feat: link Google Calendar for meeting stress leaderboard

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,4 @@ garmincoach/ha-garmin-fitness-coach-app/
 # OS files
 .DS_Store
 Thumbs.db
+gcal-token.json

--- a/pulsecoach/rootfs/app/scripts/garmin-auth-server.py
+++ b/pulsecoach/rootfs/app/scripts/garmin-auth-server.py
@@ -444,18 +444,22 @@ def recompute_status() -> Response:
 def trigger_meeting_stress() -> tuple[Response, int] | Response:
     """Score calendar meetings against Garmin HR (background run).
 
-    Reads /share/pulsecoach/calendar_events.json; writes leaderboard JSON+CSVs
+    Calendar source: a linked Google Calendar (/data/gcal-token.json) or a
+    calendar_events.json dropped in /share/pulsecoach/. Results are written
     back to /share/pulsecoach/.
     """
     import subprocess
     import time
 
     events_file = "/share/pulsecoach/calendar_events.json"
-    if not os.path.exists(events_file):
+    gcal_linked = (os.path.exists("/data/gcal-token.json")
+                   or os.path.exists("/share/pulsecoach/gcal-token.json"))
+    if not os.path.exists(events_file) and not gcal_linked:
         return jsonify(
             success=False,
-            message=f"Drop your calendar export at {events_file} first "
-                    "(see scripts/ics_to_events.py in the repo)",
+            message="No calendar source: link Google Calendar "
+                    "(scripts/generate-gcal-token.py) or drop "
+                    f"calendar_events.json at {events_file}",
         ), 400
     has_tokens = any(
         os.path.exists(os.path.join(TOKEN_DIR, name))
@@ -478,9 +482,11 @@ def trigger_meeting_stress() -> tuple[Response, int] | Response:
             json.dump({"running": True, "started": time.time()}, f)
         log_fh = open("/data/meeting-stress.log", "w", buffering=1)
         try:
+            cmd = ["python3", "/app/scripts/meeting-stress.py", "--fetch", "--no-color"]
+            if os.path.exists(events_file):
+                cmd += ["--events", events_file]
             subprocess.Popen(
-                ["python3", "/app/scripts/meeting-stress.py",
-                 "--events", events_file, "--fetch", "--no-color"],
+                cmd,
                 env=os.environ.copy(),
                 stdout=log_fh,
                 stderr=subprocess.STDOUT,
@@ -503,7 +509,12 @@ def trigger_meeting_stress() -> tuple[Response, int] | Response:
 @app.route("/auth/meeting-stress-status", methods=["GET"])
 def meeting_stress_status() -> Response:
     """Running state + latest leaderboard, if any."""
-    out: dict = {"running": False}
+    out: dict = {
+        "running": False,
+        "calendar_linked": os.path.exists("/data/gcal-token.json")
+        or os.path.exists("/share/pulsecoach/gcal-token.json"),
+        "events_file": os.path.exists("/share/pulsecoach/calendar_events.json"),
+    }
     status_file = os.path.join(TOKEN_DIR, ".meeting_stress_status")
     try:
         if os.path.exists(status_file):

--- a/pulsecoach/rootfs/app/scripts/garmin-auth-server.py
+++ b/pulsecoach/rootfs/app/scripts/garmin-auth-server.py
@@ -482,11 +482,9 @@ def trigger_meeting_stress() -> tuple[Response, int] | Response:
             json.dump({"running": True, "started": time.time()}, f)
         log_fh = open("/data/meeting-stress.log", "w", buffering=1)
         try:
-            cmd = ["python3", "/app/scripts/meeting-stress.py", "--fetch", "--no-color"]
-            if os.path.exists(events_file):
-                cmd += ["--events", events_file]
+            # Script resolves the source: linked calendar > dropped events file.
             subprocess.Popen(
-                cmd,
+                ["python3", "/app/scripts/meeting-stress.py", "--fetch", "--no-color"],
                 env=os.environ.copy(),
                 stdout=log_fh,
                 stderr=subprocess.STDOUT,

--- a/pulsecoach/rootfs/app/scripts/meeting-stress.py
+++ b/pulsecoach/rootfs/app/scripts/meeting-stress.py
@@ -390,7 +390,12 @@ GCAL_DROP_PATH = "/share/pulsecoach/gcal-token.json"
 
 
 def _adopt_gcal_token() -> None:
-    """Move a user-dropped token from /share (world-readable) into /data."""
+    """Move a user-dropped token from /share (world-readable) into /data.
+
+    ponytail: overwrite is deliberate — dropping a fresh token in /share IS the
+    refresh mechanism (users have no direct /data access). Anything that can
+    write /share already controls calendar input wholesale.
+    """
     if os.path.exists(GCAL_DROP_PATH) and os.path.isdir("/data"):
         import shutil
 
@@ -507,9 +512,8 @@ def main(argv: list[str] | None = None) -> int:
     default_events = os.path.join(share, "calendar_events.json")
 
     ap = argparse.ArgumentParser(description=__doc__)
-    ap.add_argument("--events",
-                    default=default_events if os.path.exists(default_events) else None,
-                    help="calendar_events.json (default: /share/pulsecoach/ if present)")
+    ap.add_argument("--events", default=None,
+                    help="calendar_events.json (overrides linked calendar)")
     ap.add_argument("--hr-cache", default="/data/hr-cache" if os.path.isdir("/data") else "cache",
                     help="dir of hr_YYYY-MM-DD.json files")
     ap.add_argument("--fetch", action="store_true", help="pull HR live from Garmin (needs tokens)")
@@ -525,11 +529,15 @@ def main(argv: list[str] | None = None) -> int:
     if args.demo:
         events, series = make_demo()
     else:
+        # Priority: explicit --events > linked calendar > dropped events file.
         if args.events:
             with open(args.events) as f:
                 events = json.load(f)
         elif gcal_linked():
             events = fetch_events_gcal(args.days)
+        elif os.path.exists(default_events):
+            with open(default_events) as f:
+                events = json.load(f)
         else:
             ap.error("--events is required (or link Google Calendar / use --demo)")
         if args.fetch:

--- a/pulsecoach/rootfs/app/scripts/meeting-stress.py
+++ b/pulsecoach/rootfs/app/scripts/meeting-stress.py
@@ -382,6 +382,111 @@ def make_demo(seed: int = 7) -> tuple[list[dict], HrSeries]:
 
 
 # --------------------------------------------------------------------------- #
+# Google Calendar (linked-calendar mode)
+# --------------------------------------------------------------------------- #
+GCAL_TOKEN_PATH = "/data/gcal-token.json"
+GCAL_DROP_PATH = "/share/pulsecoach/gcal-token.json"
+
+
+def _adopt_gcal_token() -> None:
+    """Move a user-dropped token from /share (world-readable) into /data."""
+    if os.path.exists(GCAL_DROP_PATH) and os.path.isdir("/data"):
+        import shutil
+
+        shutil.move(GCAL_DROP_PATH, GCAL_TOKEN_PATH)
+        os.chmod(GCAL_TOKEN_PATH, 0o600)
+        print("Adopted gcal-token.json from /share into /data")
+
+
+def gcal_linked() -> bool:
+    """True when a Google Calendar refresh token is available."""
+    _adopt_gcal_token()
+    return os.path.exists(GCAL_TOKEN_PATH)
+
+
+def _gcal_item_to_event(item: dict) -> dict | None:
+    """Map one Calendar API item to our event schema; None if unusable."""
+    start = item.get("start", {}).get("dateTime")
+    end = item.get("end", {}).get("dateTime")
+    if not start or not end:
+        return None  # all-day event
+    attendees = []
+    for att in item.get("attendees", []):
+        if (att.get("responseStatus") == "declined"
+                or att.get("resource") or att.get("self")):
+            continue
+        name = att.get("displayName") or att.get("email", "").split("@")[0]
+        if name:
+            attendees.append(name)
+    if not attendees:
+        return None
+    return {
+        "start": start,
+        "end": end,
+        "title": item.get("summary", "(untitled)"),
+        "attendees": sorted(set(attendees)),
+    }
+
+
+def fetch_events_gcal(days: int) -> list[dict]:
+    """Pull the last `days` of primary-calendar events via the Calendar API.
+
+    Uses the refresh token from generate-gcal-token.py; recurrences arrive
+    pre-expanded (singleEvents). Declined attendees, rooms, and self are
+    dropped — same policy as ics_to_events.py.
+    """
+    import urllib.parse
+    import urllib.request
+
+    with open(GCAL_TOKEN_PATH) as f:
+        tok = json.load(f)
+
+    body = urllib.parse.urlencode({
+        "client_id": tok["client_id"],
+        "client_secret": tok["client_secret"],
+        "refresh_token": tok["refresh_token"],
+        "grant_type": "refresh_token",
+    }).encode()
+    req = urllib.request.Request("https://oauth2.googleapis.com/token", data=body)
+    with urllib.request.urlopen(req, timeout=30) as resp:
+        access = json.load(resp)["access_token"]
+
+    now = datetime.now(timezone.utc)
+    base_params = {
+        "timeMin": (now - timedelta(days=days)).isoformat(),
+        "timeMax": now.isoformat(),
+        "singleEvents": "true",
+        "orderBy": "startTime",
+        "maxResults": "250",
+    }
+    url = "https://www.googleapis.com/calendar/v3/calendars/primary/events"
+    events: list[dict] = []
+    page_token = ""
+    while True:
+        params = dict(base_params)
+        if page_token:
+            params["pageToken"] = page_token
+        req = urllib.request.Request(
+            f"{url}?{urllib.parse.urlencode(params)}",
+            headers={"Authorization": f"Bearer {access}"},
+        )
+        with urllib.request.urlopen(req, timeout=30) as resp:
+            data = json.load(resp)
+
+        for item in data.get("items", []):
+            ev = _gcal_item_to_event(item)
+            if ev:
+                events.append(ev)
+
+        page_token = data.get("nextPageToken", "")
+        if not page_token:
+            break
+
+    print(f"Fetched {len(events)} meetings from Google Calendar (last {days}d)")
+    return events
+
+
+# --------------------------------------------------------------------------- #
 # CLI
 # --------------------------------------------------------------------------- #
 def main(argv: list[str] | None = None) -> int:
@@ -399,16 +504,21 @@ def main(argv: list[str] | None = None) -> int:
     ap.add_argument("--lambda", dest="lam", type=float, default=DEFAULT_LAMBDA)
     ap.add_argument("--max-attendees", type=int, default=DEFAULT_MAX_ATTENDEES)
     ap.add_argument("--outdir", default=share if os.path.isdir(share) else ".")
+    ap.add_argument("--days", type=int, default=30,
+                    help="linked-calendar lookback window (days)")
     ap.add_argument("--no-color", action="store_true")
     args = ap.parse_args(argv)
 
     if args.demo:
         events, series = make_demo()
     else:
-        if not args.events:
-            ap.error("--events is required (or use --demo)")
-        with open(args.events) as f:
-            events = json.load(f)
+        if args.events:
+            with open(args.events) as f:
+                events = json.load(f)
+        elif gcal_linked():
+            events = fetch_events_gcal(args.days)
+        else:
+            ap.error("--events is required (or link Google Calendar / use --demo)")
         if args.fetch:
             dates = sorted({parse_ts(e["start"]) for e in events})
             dates = sorted({datetime.fromtimestamp(d, timezone.utc).strftime("%Y-%m-%d") for d in dates})

--- a/pulsecoach/rootfs/app/scripts/meeting-stress.py
+++ b/pulsecoach/rootfs/app/scripts/meeting-stress.py
@@ -8,8 +8,9 @@
 # scores each meeting vs a local 90-min baseline (dbpm / z / elev), then fits
 # a ridge regression over attendee presence to de-confound who-attends-with-whom.
 #
-# Inputs are files only: a calendar_events.json and an HR series (cache files
-# or --demo synthetic). No audio, no recording, no calendar auth.
+# Calendar input: a linked Google Calendar (read-only OAuth token generated
+# by scripts/generate-gcal-token.py) or a calendar_events.json file. HR comes
+# from Garmin (cache files or --demo synthetic). No audio, no recording.
 #
 # stdlib only (matches repo scripts); ridge is a hand-rolled ~kxk solve.
 ##############################################################################
@@ -449,7 +450,14 @@ def fetch_events_gcal(days: int) -> list[dict]:
     }).encode()
     req = urllib.request.Request("https://oauth2.googleapis.com/token", data=body)
     with urllib.request.urlopen(req, timeout=30) as resp:
-        access = json.load(resp)["access_token"]
+        tok_resp = json.load(resp)
+    access = tok_resp.get("access_token")
+    if not access:
+        # Don't echo the payload — it may carry sensitive fields.
+        err = tok_resp.get("error", "unknown_error")
+        raise RuntimeError(
+            f"Google token refresh failed ({err}) — re-run generate-gcal-token.py"
+        )
 
     now = datetime.now(timezone.utc)
     base_params = {
@@ -472,6 +480,11 @@ def fetch_events_gcal(days: int) -> list[dict]:
         )
         with urllib.request.urlopen(req, timeout=30) as resp:
             data = json.load(resp)
+        if "error" in data:
+            err = data["error"]
+            raise RuntimeError(
+                f"Calendar API error {err.get('code')}: {err.get('message')}"
+            )
 
         for item in data.get("items", []):
             ev = _gcal_item_to_event(item)

--- a/scripts/generate-gcal-token.py
+++ b/scripts/generate-gcal-token.py
@@ -21,6 +21,7 @@ from __future__ import annotations
 import http.server
 import json
 import secrets
+import sys
 import threading
 import urllib.parse
 import urllib.request
@@ -33,9 +34,24 @@ PORT = 8765
 OUT_FILE = "gcal-token.json"
 
 
+def _load_creds() -> tuple[str, str]:
+    """Client id+secret from a downloaded client_secret_*.json arg, or prompts."""
+    if len(sys.argv) > 1:
+        with open(sys.argv[1]) as f:
+            data = json.load(f)
+        blob = data.get("installed") or data.get("web") or {}
+        cid, csec = blob.get("client_id", ""), blob.get("client_secret", "")
+        if cid and csec:
+            if "web" in data:
+                print("NOTE: this is a 'web' OAuth client — make sure "
+                      f"http://127.0.0.1:{PORT} is in its Authorized redirect URIs.")
+            return cid, csec
+        print(f"Could not find client_id/secret in {sys.argv[1]}")
+    return input("OAuth client ID: ").strip(), input("OAuth client secret: ").strip()
+
+
 def main() -> int:
-    client_id = input("OAuth client ID: ").strip()
-    client_secret = input("OAuth client secret: ").strip()
+    client_id, client_secret = _load_creds()
     state = secrets.token_urlsafe(16)
     redirect_uri = f"http://127.0.0.1:{PORT}"
     code_holder: dict = {}

--- a/scripts/generate-gcal-token.py
+++ b/scripts/generate-gcal-token.py
@@ -20,6 +20,7 @@ from __future__ import annotations
 
 import http.server
 import json
+import os
 import secrets
 import sys
 import threading
@@ -106,7 +107,8 @@ def main() -> int:
         "grant_type": "authorization_code",
         "redirect_uri": redirect_uri,
     }).encode()
-    with urllib.request.urlopen(urllib.request.Request(TOKEN_URL, data=body)) as resp:
+    req = urllib.request.Request(TOKEN_URL, data=body)
+    with urllib.request.urlopen(req, timeout=60) as resp:
         tok = json.load(resp)
 
     refresh = tok.get("refresh_token")
@@ -114,7 +116,8 @@ def main() -> int:
         print("Token response had no refresh_token — re-run (prompt=consent should force it).")
         return 1
 
-    with open(OUT_FILE, "w") as f:
+    fd = os.open(OUT_FILE, os.O_WRONLY | os.O_CREAT | os.O_TRUNC, 0o600)
+    with os.fdopen(fd, "w") as f:
         json.dump({"client_id": client_id, "client_secret": client_secret,
                    "refresh_token": refresh}, f, indent=1)
     print(f"\n✓ Wrote {OUT_FILE}")

--- a/scripts/generate-gcal-token.py
+++ b/scripts/generate-gcal-token.py
@@ -55,6 +55,7 @@ def main() -> int:
     state = secrets.token_urlsafe(16)
     redirect_uri = f"http://127.0.0.1:{PORT}"
     code_holder: dict = {}
+    got_callback = threading.Event()
 
     class Handler(http.server.BaseHTTPRequestHandler):
         def do_GET(self):  # noqa: N802
@@ -68,6 +69,7 @@ def main() -> int:
             self.send_header("Content-Type", "text/plain")
             self.end_headers()
             self.wfile.write(msg)
+            got_callback.set()
 
         def log_message(self, *a):  # silence request logging
             pass
@@ -87,7 +89,8 @@ def main() -> int:
     url = f"{AUTH_URL}?{params}"
     print(f"\nOpening browser for consent...\n{url}\n")
     webbrowser.open(url)
-    input("Press Enter after approving in the browser... ")
+    print("Waiting for browser approval (up to 5 minutes)...")
+    got_callback.wait(timeout=300)
 
     code = code_holder.get("code")
     if not code:

--- a/scripts/generate-gcal-token.py
+++ b/scripts/generate-gcal-token.py
@@ -1,0 +1,108 @@
+#!/usr/bin/env python3
+# SPDX-FileCopyrightText: 2026 Anil Belur <askb23@gmail.com>
+# SPDX-License-Identifier: Apache-2.0
+##############################################################################
+# One-time Google Calendar OAuth for the meeting stress leaderboard.
+#
+# Prereq (5 min, once): create a Google Cloud project, enable the Calendar
+# API, create an OAuth client of type "Desktop app", note client id + secret.
+#
+# Runs the browser loopback flow with the read-only calendar scope and writes
+# gcal-token.json (client id/secret + refresh token). Copy that file to
+# /share/pulsecoach/ on HAOS — the addon adopts it into /data on first run.
+#
+# stdlib only: the loopback listener is a plain http.server; token exchange
+# is urllib. No google-auth dependency for a one-shot helper.
+##############################################################################
+"""Generate a Google Calendar refresh token for PulseCoach meeting stress."""
+
+from __future__ import annotations
+
+import http.server
+import json
+import secrets
+import threading
+import urllib.parse
+import urllib.request
+import webbrowser
+
+SCOPE = "https://www.googleapis.com/auth/calendar.readonly"
+AUTH_URL = "https://accounts.google.com/o/oauth2/v2/auth"
+TOKEN_URL = "https://oauth2.googleapis.com/token"
+PORT = 8765
+OUT_FILE = "gcal-token.json"
+
+
+def main() -> int:
+    client_id = input("OAuth client ID: ").strip()
+    client_secret = input("OAuth client secret: ").strip()
+    state = secrets.token_urlsafe(16)
+    redirect_uri = f"http://127.0.0.1:{PORT}"
+    code_holder: dict = {}
+
+    class Handler(http.server.BaseHTTPRequestHandler):
+        def do_GET(self):  # noqa: N802
+            qs = urllib.parse.parse_qs(urllib.parse.urlparse(self.path).query)
+            if qs.get("state", [""])[0] == state and "code" in qs:
+                code_holder["code"] = qs["code"][0]
+                msg = b"Linked! You can close this tab."
+            else:
+                msg = b"Missing/invalid code."
+            self.send_response(200)
+            self.send_header("Content-Type", "text/plain")
+            self.end_headers()
+            self.wfile.write(msg)
+
+        def log_message(self, *a):  # silence request logging
+            pass
+
+    server = http.server.HTTPServer(("127.0.0.1", PORT), Handler)
+    threading.Thread(target=server.handle_request, daemon=True).start()
+
+    params = urllib.parse.urlencode({
+        "client_id": client_id,
+        "redirect_uri": redirect_uri,
+        "response_type": "code",
+        "scope": SCOPE,
+        "access_type": "offline",   # ask for a refresh token
+        "prompt": "consent",        # force refresh token even if previously granted
+        "state": state,
+    })
+    url = f"{AUTH_URL}?{params}"
+    print(f"\nOpening browser for consent...\n{url}\n")
+    webbrowser.open(url)
+    input("Press Enter after approving in the browser... ")
+
+    code = code_holder.get("code")
+    if not code:
+        print("No authorization code received. If your Workspace admin blocks "
+              "unapproved apps you'll have seen an error page — fall back to "
+              "the ICS export flow (scripts/ics_to_events.py).")
+        return 1
+
+    body = urllib.parse.urlencode({
+        "client_id": client_id,
+        "client_secret": client_secret,
+        "code": code,
+        "grant_type": "authorization_code",
+        "redirect_uri": redirect_uri,
+    }).encode()
+    with urllib.request.urlopen(urllib.request.Request(TOKEN_URL, data=body)) as resp:
+        tok = json.load(resp)
+
+    refresh = tok.get("refresh_token")
+    if not refresh:
+        print("Token response had no refresh_token — re-run (prompt=consent should force it).")
+        return 1
+
+    with open(OUT_FILE, "w") as f:
+        json.dump({"client_id": client_id, "client_secret": client_secret,
+                   "refresh_token": refresh}, f, indent=1)
+    print(f"\n✓ Wrote {OUT_FILE}")
+    print("Copy it to HAOS:  scp gcal-token.json <haos>:/share/pulsecoach/")
+    print("The addon moves it into /data (private) on the next meeting-stress run.")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_meeting_stress.py
+++ b/tests/test_meeting_stress.py
@@ -89,7 +89,28 @@ def test_solo_and_oversize_meetings_skipped():
     assert ms.score_meetings(events, series) == []
 
 
+def test_gcal_item_mapping():
+    item = {
+        "summary": "planning",
+        "start": {"dateTime": "2026-07-01T09:00:00+10:00"},
+        "end": {"dateTime": "2026-07-01T09:30:00+10:00"},
+        "attendees": [
+            {"displayName": "Alice", "email": "alice@x.org"},
+            {"email": "bob@x.org", "responseStatus": "declined"},
+            {"email": "room-3@resource.calendar.google.com", "resource": True},
+            {"email": "me@x.org", "self": True},
+            {"email": "carol@x.org"},
+        ],
+    }
+    ev = ms._gcal_item_to_event(item)
+    assert ev["attendees"] == ["Alice", "carol"], ev
+    # all-day events (date, no dateTime) are dropped
+    assert ms._gcal_item_to_event({"start": {"date": "2026-07-01"},
+                                   "end": {"date": "2026-07-02"}}) is None
+
+
 if __name__ == "__main__":
     test_ridge_deconfounds_bystander()
     test_solo_and_oversize_meetings_skipped()
+    test_gcal_item_mapping()
     print("ok")


### PR DESCRIPTION
## What

Lets users link their Google Calendar instead of hand-exporting ICS files: `POST /auth/meeting-stress` now pulls the last N days of meetings (with attendees) live from the Calendar API when a token is linked, falling back to `/share/pulsecoach/calendar_events.json`.

## How

- `meeting-stress.py`: `fetch_events_gcal()` — refresh-token OAuth + paginated `events.list` via stdlib urllib (no new image deps); `singleEvents` handles recurrence expansion; drops declined/self/room attendees (same policy as ics_to_events.py). `--days` lookback flag (default 30).
- Token bootstrap: `scripts/generate-gcal-token.py` (laptop-side, mirrors generate-garmin-tokens.py) — loopback browser flow, `calendar.readonly` scope, accepts a downloaded `client_secret_*.json`. Output dropped in `/share/pulsecoach/` is adopted into `/data/gcal-token.json` (0600) on first run.
- `garmin-auth-server.py`: endpoint accepts linked-calendar OR events-file mode; status reports `calendar_linked`/`events_file` flags for the UI.

## UI

Consumed by the new /stress-board screen: askb/ha-garmin-fitness-coach-app#320

## Verified

- pytest 3/3 (incl. new gcal item-mapping test: declined/self/resource filtering, all-day drop)
- `--demo` end-to-end still green; pre-commit clean