### PR TITLE
chore: release 0.20.0 with app v0.20.0

### DIFF
--- a/pulsecoach/CHANGELOG.md
+++ b/pulsecoach/CHANGELOG.md
@@ -7,6 +7,24 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.20.0] - 2026-07-06
+
+### Added
+
+- **Meeting stress leaderboard.** Scores each calendar meeting's heart-rate
+  elevation against a ±90-min local baseline (dbpm/z/elev) and ranks
+  attendees by ridge marginal effect to de-confound co-attendance. New
+  auth-server endpoints `POST /auth/meeting-stress` and
+  `GET /auth/meeting-stress-status`; results land in
+  `/share/pulsecoach/` (JSON + CSVs) and power the app's Stress Board
+  screen.
+- **Google Calendar linking.** Drop a `gcal-token.json` (generated once by
+  `scripts/generate-gcal-token.py`, read-only calendar scope) into
+  `/share/pulsecoach/` — the addon adopts it into `/data` (0600) and pulls
+  meetings with attendees live from the Calendar API. Falls back to a
+  `calendar_events.json` file (see `scripts/ics_to_events.py`).
+- **Bundled app updated to v0.20.0** with the Stress Board screen.
+
 ### Security
 
 - **Removed optional direct port mapping (`3000/tcp`).** The web UI relies

--- a/pulsecoach/Dockerfile
+++ b/pulsecoach/Dockerfile
@@ -15,7 +15,7 @@ WORKDIR /build
 # Clone the app source from GitHub
 # Use build arg timestamp for cache busting instead of GitHub API (avoids 403 rate limits)
 ARG APP_REPO=askb/ha-garmin-fitness-coach-app
-ARG APP_REF=v0.19.0
+ARG APP_REF=v0.20.0
 ARG CACHEBUST=1
 RUN echo "Cache bust: ${CACHEBUST}" && \
     git clone --depth=1 --branch="${APP_REF}" \

--- a/pulsecoach/Dockerfile
+++ b/pulsecoach/Dockerfile
@@ -91,4 +91,4 @@ LABEL \
     io.hass.description="AI-powered sport scientist for Garmin athletes" \
     io.hass.arch="${BUILD_ARCH}" \
     io.hass.type="addon" \
-    io.hass.version="0.19.0"
+    io.hass.version="0.20.0"

--- a/pulsecoach/config.json
+++ b/pulsecoach/config.json
@@ -1,6 +1,6 @@
 {
   "name": "PulseCoach",
-  "version": "0.19.0",
+  "version": "0.20.0",
   "slug": "pulsecoach",
   "image": "ghcr.io/askb/pulsecoach-addon-{arch}",
   "description": "AI-powered sport scientist — training analysis, coaching, and recovery optimization from your Garmin data",


### PR DESCRIPTION
Bump addon to 0.20.0: APP_REF → v0.20.0 (Stress Board screen, askb/ha-garmin-fitness-coach-app#320), meeting stress leaderboard endpoints (#246) + Google Calendar linking (#247), changelog.