### PR TITLE
chore: release 0.20.1 with app v0.20.1

### DIFF
--- a/pulsecoach/CHANGELOG.md
+++ b/pulsecoach/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.20.1] - 2026-07-06
+
+### Fixed
+
+- **Stress Board unreachable under HA ingress.** Bundled app updated to
+  v0.20.1: the board's API calls now use the ingress-prefixed base path
+  instead of absolute `/api/*` (which resolved to HA core).
+
 ## [0.20.0] - 2026-07-06
 
 ### Added

--- a/pulsecoach/Dockerfile
+++ b/pulsecoach/Dockerfile
@@ -15,7 +15,7 @@ WORKDIR /build
 # Clone the app source from GitHub
 # Use build arg timestamp for cache busting instead of GitHub API (avoids 403 rate limits)
 ARG APP_REPO=askb/ha-garmin-fitness-coach-app
-ARG APP_REF=v0.20.0
+ARG APP_REF=v0.20.1
 ARG CACHEBUST=1
 RUN echo "Cache bust: ${CACHEBUST}" && \
     git clone --depth=1 --branch="${APP_REF}" \
@@ -91,4 +91,4 @@ LABEL \
     io.hass.description="AI-powered sport scientist for Garmin athletes" \
     io.hass.arch="${BUILD_ARCH}" \
     io.hass.type="addon" \
-    io.hass.version="0.20.0"
+    io.hass.version="0.20.1"

--- a/pulsecoach/config.json
+++ b/pulsecoach/config.json
@@ -1,6 +1,6 @@
 {
   "name": "PulseCoach",
-  "version": "0.20.0",
+  "version": "0.20.1",
   "slug": "pulsecoach",
   "image": "ghcr.io/askb/pulsecoach-addon-{arch}",
   "description": "AI-powered sport scientist — training analysis, coaching, and recovery optimization from your Garmin data",


### PR DESCRIPTION
Patch release: bundled app v0.20.1 fixes the Stress Board being unreachable under HA ingress (absolute /api/* paths resolved against HA core). APP_REF, config version, and io.hass.version label all bumped.