### PR TITLE
feat: interaction logging + release 0.20.2

### DIFF
--- a/pulsecoach/CHANGELOG.md
+++ b/pulsecoach/CHANGELOG.md
@@ -7,6 +7,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.20.2] - 2026-07-06
+
+### Added
+
+- **Out-of-calendar interaction logging.** meeting-stress now merges
+  `/share/pulsecoach/interactions.jsonl` (one JSON object per line:
+  `{"person", "minutes", "end"}`) as one-person events — log coffee
+  chats, family visits, or gym sessions from Home Assistant via a
+  `shell_command` (dashboard buttons, voice, NFC, zone automations) and
+  they rank in the same leaderboard as work meetings. Malformed lines
+  are skipped.
+
 ## [0.20.1] - 2026-07-06
 
 ### Fixed

--- a/pulsecoach/Dockerfile
+++ b/pulsecoach/Dockerfile
@@ -91,4 +91,4 @@ LABEL \
     io.hass.description="AI-powered sport scientist for Garmin athletes" \
     io.hass.arch="${BUILD_ARCH}" \
     io.hass.type="addon" \
-    io.hass.version="0.20.1"
+    io.hass.version="0.20.2"

--- a/pulsecoach/config.json
+++ b/pulsecoach/config.json
@@ -1,6 +1,6 @@
 {
   "name": "PulseCoach",
-  "version": "0.20.1",
+  "version": "0.20.2",
   "slug": "pulsecoach",
   "image": "ghcr.io/askb/pulsecoach-addon-{arch}",
   "description": "AI-powered sport scientist — training analysis, coaching, and recovery optimization from your Garmin data",

--- a/pulsecoach/rootfs/app/scripts/meeting-stress.py
+++ b/pulsecoach/rootfs/app/scripts/meeting-stress.py
@@ -505,6 +505,48 @@ def fetch_events_gcal(days: int) -> list[dict]:
 
 
 # --------------------------------------------------------------------------- #
+# HA-logged interactions (out-of-calendar contacts)
+# --------------------------------------------------------------------------- #
+INTERACTIONS_PATH = "/share/pulsecoach/interactions.jsonl"
+
+
+def load_interactions(path: str = INTERACTIONS_PATH) -> list[dict]:
+    """Read interactions logged from Home Assistant as one-person events.
+
+    One JSON object per line: {"person": str, "minutes": num, "end": ISO8601}.
+    The window is [end - minutes, end]. Malformed lines are skipped so an
+    append-only log written by HA shell_command stays forgiving.
+    """
+    events: list[dict] = []
+    if not os.path.exists(path):
+        return events
+    with open(path) as f:
+        for line in f:
+            line = line.strip()
+            if not line:
+                continue
+            try:
+                rec = json.loads(line)
+                person = str(rec["person"]).strip()
+                minutes = float(rec.get("minutes", 30))
+                end_s = parse_ts(str(rec["end"]))
+            except (KeyError, ValueError, TypeError):
+                continue
+            if not person or minutes <= 0:
+                continue
+            end_dt = datetime.fromtimestamp(end_s, timezone.utc)
+            events.append({
+                "start": (end_dt - timedelta(minutes=minutes)).isoformat(),
+                "end": end_dt.isoformat(),
+                "title": f"interaction: {person}",
+                "attendees": [person],
+            })
+    if events:
+        print(f"Merged {len(events)} logged interactions")
+    return events
+
+
+# --------------------------------------------------------------------------- #
 # CLI
 # --------------------------------------------------------------------------- #
 def main(argv: list[str] | None = None) -> int:
@@ -540,6 +582,7 @@ def main(argv: list[str] | None = None) -> int:
                 events = json.load(f)
         else:
             ap.error("--events is required (or link Google Calendar / use --demo)")
+        events += load_interactions()
         if args.fetch:
             dates = sorted({parse_ts(e["start"]) for e in events})
             dates = sorted({datetime.fromtimestamp(d, timezone.utc).strftime("%Y-%m-%d") for d in dates})

--- a/pulsecoach/rootfs/app/scripts/meeting-stress.py
+++ b/pulsecoach/rootfs/app/scripts/meeting-stress.py
@@ -518,29 +518,31 @@ def load_interactions(path: str = INTERACTIONS_PATH) -> list[dict]:
     append-only log written by HA shell_command stays forgiving.
     """
     events: list[dict] = []
-    if not os.path.exists(path):
-        return events
-    with open(path) as f:
-        for line in f:
-            line = line.strip()
-            if not line:
-                continue
-            try:
-                rec = json.loads(line)
-                person = str(rec["person"]).strip()
-                minutes = float(rec.get("minutes", 30))
-                end_s = parse_ts(str(rec["end"]))
-            except (KeyError, ValueError, TypeError):
-                continue
-            if not person or minutes <= 0:
-                continue
-            end_dt = datetime.fromtimestamp(end_s, timezone.utc)
-            events.append({
-                "start": (end_dt - timedelta(minutes=minutes)).isoformat(),
-                "end": end_dt.isoformat(),
-                "title": f"interaction: {person}",
-                "attendees": [person],
-            })
+    try:
+        with open(path) as f:
+            lines = f.readlines()
+    except OSError:
+        return events  # forgiving log: missing/unreadable == empty
+    for line in lines:
+        line = line.strip()
+        if not line:
+            continue
+        try:
+            rec = json.loads(line)
+            person = str(rec["person"]).strip()
+            minutes = float(rec.get("minutes", 30))
+            end_s = parse_ts(str(rec["end"]))
+        except (KeyError, ValueError, TypeError):
+            continue
+        if not person or minutes <= 0:
+            continue
+        end_dt = datetime.fromtimestamp(end_s, timezone.utc)
+        events.append({
+            "start": (end_dt - timedelta(minutes=minutes)).isoformat(),
+            "end": end_dt.isoformat(),
+            "title": f"interaction: {person}",
+            "attendees": [person],
+        })
     if events:
         print(f"Merged {len(events)} logged interactions")
     return events

--- a/tests/test_meeting_stress.py
+++ b/tests/test_meeting_stress.py
@@ -109,16 +109,19 @@ def test_gcal_item_mapping():
                                    "end": {"date": "2026-07-02"}}) is None
 
 
-def test_interactions_jsonl(tmp_path=None):
+def test_interactions_jsonl():
     import tempfile
+    from pathlib import Path
 
-    with tempfile.NamedTemporaryFile("w", suffix=".jsonl", delete=False) as f:
-        f.write('{"person": "Mum", "minutes": 45, "end": "2026-07-01T18:00:00+10:00"}\n')
-        f.write("not json at all\n")
-        f.write('{"person": "", "minutes": 30, "end": "2026-07-01T19:00:00+10:00"}\n')
-        f.write('{"person": "Dave", "minutes": 0, "end": "2026-07-01T20:00:00+10:00"}\n')
-        path = f.name
-    evs = ms.load_interactions(path)
+    with tempfile.TemporaryDirectory() as td:
+        path = Path(td) / "interactions.jsonl"
+        path.write_text(
+            '{"person": "Mum", "minutes": 45, "end": "2026-07-01T18:00:00+10:00"}\n'
+            "not json at all\n"
+            '{"person": "", "minutes": 30, "end": "2026-07-01T19:00:00+10:00"}\n'
+            '{"person": "Dave", "minutes": 0, "end": "2026-07-01T20:00:00+10:00"}\n'
+        )
+        evs = ms.load_interactions(str(path))
     assert len(evs) == 1, evs
     ev = evs[0]
     assert ev["attendees"] == ["Mum"]

--- a/tests/test_meeting_stress.py
+++ b/tests/test_meeting_stress.py
@@ -109,8 +109,27 @@ def test_gcal_item_mapping():
                                    "end": {"date": "2026-07-02"}}) is None
 
 
+def test_interactions_jsonl(tmp_path=None):
+    import tempfile
+
+    with tempfile.NamedTemporaryFile("w", suffix=".jsonl", delete=False) as f:
+        f.write('{"person": "Mum", "minutes": 45, "end": "2026-07-01T18:00:00+10:00"}\n')
+        f.write("not json at all\n")
+        f.write('{"person": "", "minutes": 30, "end": "2026-07-01T19:00:00+10:00"}\n')
+        f.write('{"person": "Dave", "minutes": 0, "end": "2026-07-01T20:00:00+10:00"}\n')
+        path = f.name
+    evs = ms.load_interactions(path)
+    assert len(evs) == 1, evs
+    ev = evs[0]
+    assert ev["attendees"] == ["Mum"]
+    assert ms.parse_ts(ev["end"]) - ms.parse_ts(ev["start"]) == 45 * 60
+    # missing file -> empty, no crash
+    assert ms.load_interactions("/nonexistent/interactions.jsonl") == []
+
+
 if __name__ == "__main__":
     test_ridge_deconfounds_bystander()
     test_solo_and_oversize_meetings_skipped()
     test_gcal_item_mapping()
+    test_interactions_jsonl()
     print("ok")


### PR DESCRIPTION
## What

Merge Home-Assistant-logged interactions (coffee chats, family visits — anything outside the calendar) into the meeting stress leaderboard.

## How

`meeting-stress.py` reads `/share/pulsecoach/interactions.jsonl` — one JSON object per line, `{"person": str, "minutes": num, "end": ISO8601}` — and merges each as a one-person event with window `[end − minutes, end]`. Malformed lines skipped (append-only HA shell_command log stays forgiving). Logged via HA dashboard buttons / voice / NFC / zone automations (card lands in askb/askb-ha-config).

App unchanged (APP_REF stays v0.20.1); addon version + label → 0.20.2.

## Verified

pytest 4/4 including new interactions parsing test (window math, malformed/empty/zero-minute lines, missing file).