### PR TITLE
feat: community pre-flight hardening and docs, release 0.20.3

### DIFF
--- a/pulsecoach/CHANGELOG.md
+++ b/pulsecoach/CHANGELOG.md
@@ -7,6 +7,26 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.20.3] - 2026-07-07
+
+### Security
+
+- **AppArmor profile added** (`apparmor.txt`) — confines the addon's
+  services (s6, PostgreSQL, Python, Node.js) and raises the HA security
+  rating.
+- **Removed redundant `DEV_BYPASS_AUTH` from the addon manifest.** The
+  variable (single-user auth passthrough behind authenticated HA ingress)
+  was exported by the service run script *and* duplicated in
+  `config.json`; the manifest copy is gone and the run script documents
+  the intent. A rename to `INGRESS_AUTH_PASSTHROUGH` is pending in the
+  app repo.
+
+### Changed
+
+- **Docs**: hardware requirements (minimum Raspberry Pi 4 class,
+  2–4 GiB RAM free, ~5 GB storage) and a Garmin unofficial-API
+  disclaimer.
+
 ## [0.20.2] - 2026-07-06
 
 ### Added

--- a/pulsecoach/DOCS.md
+++ b/pulsecoach/DOCS.md
@@ -123,27 +123,40 @@ The addon pushes a set of Home Assistant sensors via the Supervisor API, includi
 | `sensor.pulsecoach_sleep_debt` | Accumulated sleep debt (hours) |
 | `sensor.pulsecoach_data_quality` | Unresolved sync-gap count (state) with `missing_days_14d`, `stale_days`, `field_gaps`, `status` (`ok`/`warn`/`error`) attributes |
 
-## Resource Usage
+## Hardware Requirements & Resource Usage
+
+**Minimum supported hardware: Raspberry Pi 4 (or any amd64/aarch64 box)
+with 2–4 GiB of RAM free for add-ons.** The addon runs a full stack —
+PostgreSQL 16, a Next.js server, and several Python services — so
+boards below an RPi 4 (or heavily loaded 2 GiB systems) will struggle.
 
 | Component | RAM | CPU |
 |---|---|---|
 | Next.js server | ~80 MB | < 1 % idle |
-| PostgreSQL database | ~30 MB | < 1 % |
-| Garmin sync (periodic) | ~30 MB peak | burst |
-| **Total** | **~140 MB** | **< 2 % idle** |
+| PostgreSQL database | ~30 MB (grows with history) | < 1 % |
+| Garmin sync / metrics (periodic) | ~30–100 MB peak | burst |
+| **Steady state** | **~150–300 MB** | **< 2 % idle** |
 
-The addon requires a minimum of **256 MB** available RAM. Running the
-`ollama` backend locally will need additional resources depending on the
-model size.
+Storage: allow **~5 GB** for the PostgreSQL data volume as multi-year
+history accumulates. Running the `ollama` AI backend locally is a
+separate, much larger requirement (model dependent — typically 8 GB+)
+and is not recommended on an RPi 4; use `ha_conversation` or `none`
+there instead.
 
 ## Privacy
 
 All data processing happens **locally** on your Home Assistant instance. No
 health data is sent to external servers.
 
-- **Garmin Connect**: The addon authenticates and fetches data using the
-  official Garmin Connect API. Data flows only between Garmin's servers and
-  your HA instance.
+- **Garmin Connect**: The addon authenticates directly against Garmin
+  Connect; data flows only between Garmin's servers and your HA instance.
+- **Unofficial API disclaimer**: the Garmin sync uses the same
+  credential-based method as the popular
+  [cyberjunky Garmin integration](https://github.com/cyberjunky/home-assistant-garmin_connect)
+  — not Garmin's partner-only developer API. Your credentials never leave
+  your Home Assistant instance, but Garmin may change or restrict this
+  access at any time, which can temporarily break syncing until the addon
+  is updated.
 - **AI Coaching** (`ha_conversation`): Prompts are sent to whatever
   Conversation agent you have configured in HA — this may be a cloud service
   (e.g., OpenAI) depending on your setup.

--- a/pulsecoach/DOCS.md
+++ b/pulsecoach/DOCS.md
@@ -145,8 +145,11 @@ there instead.
 
 ## Privacy
 
-All data processing happens **locally** on your Home Assistant instance. No
-health data is sent to external servers.
+All data **processing** happens locally on your Home Assistant instance.
+The only external exchanges are the ones you configure: fetching your own
+data from Garmin Connect (and optionally Google Calendar), and — only if
+you pick a cloud Conversation agent — AI coaching prompts. Nothing else
+leaves your network.
 
 - **Garmin Connect**: The addon authenticates directly against Garmin
   Connect; data flows only between Garmin's servers and your HA instance.

--- a/pulsecoach/Dockerfile
+++ b/pulsecoach/Dockerfile
@@ -91,4 +91,4 @@ LABEL \
     io.hass.description="AI-powered sport scientist for Garmin athletes" \
     io.hass.arch="${BUILD_ARCH}" \
     io.hass.type="addon" \
-    io.hass.version="0.20.2"
+    io.hass.version="0.20.3"

--- a/pulsecoach/apparmor.txt
+++ b/pulsecoach/apparmor.txt
@@ -1,0 +1,62 @@
+#include <tunables/global>
+
+profile pulsecoach flags=(attach_disconnected,mediate_deleted) {
+  #include <abstractions/base>
+
+  # Capabilities
+  file,
+  signal (send) set=(kill,term,int,hup,cont),
+  capability chown,
+  capability dac_override,
+  capability setgid,
+  capability setuid,
+  capability net_bind_service,
+  capability kill,
+
+  # S6-Overlay
+  /init ix,
+  /bin/** ix,
+  /usr/bin/** ix,
+  /usr/lib/** ix,
+  /run/{s6,s6-rc*,service}/** ix,
+  /package/** ix,
+  /command/** ix,
+  /etc/services.d/** rwix,
+  /etc/cont-init.d/** rwix,
+  /etc/cont-finish.d/** rwix,
+  /run/** mrwkl,
+  /dev/tty rw,
+
+  # Bashio
+  /usr/lib/bashio/** ix,
+  /tmp/** rwk,
+
+  # Access to options.json and other files within /data
+  /data/** rw,
+
+  # Shared folder (calendar input, leaderboard results, tokens to adopt)
+  /share/** rw,
+
+  # Application (Next.js, Python scripts, embedded PostgreSQL)
+  /app/** rwix,
+  /usr/lib/postgresql/** ix,
+  /usr/share/postgresql/** r,
+  /var/lib/postgresql/** rwk,
+  /run/postgresql/** rwk,
+
+  # Python and Node runtimes
+  /usr/bin/python3* ix,
+  /usr/bin/node ix,
+  /usr/lib/python3*/** mr,
+  /usr/lib/node_modules/** mr,
+
+  # Networking (Garmin/Google APIs, HA Supervisor, loopback services)
+  network tcp,
+  network udp,
+
+  # System info the runtimes read
+  @{PROC}/** r,
+  /sys/fs/cgroup/** r,
+  /etc/** r,
+  /proc/sys/kernel/random/{uuid,boot_id} r,
+}

--- a/pulsecoach/config.json
+++ b/pulsecoach/config.json
@@ -1,6 +1,6 @@
 {
   "name": "PulseCoach",
-  "version": "0.20.2",
+  "version": "0.20.3",
   "slug": "pulsecoach",
   "image": "ghcr.io/askb/pulsecoach-addon-{arch}",
   "description": "AI-powered sport scientist — training analysis, coaching, and recovery optimization from your Garmin data",
@@ -53,7 +53,6 @@
   "environment": {
     "DATABASE_URL": "postgresql://postgres@127.0.0.1:5432/pulsecoach",
     "POSTGRES_URL": "postgresql://postgres@127.0.0.1:5432/pulsecoach",
-    "DEV_BYPASS_AUTH": "true",
     "NODE_ENV": "production"
   }
 }

--- a/pulsecoach/rootfs/etc/s6-overlay/s6-rc.d/pulsecoach/run
+++ b/pulsecoach/rootfs/etc/s6-overlay/s6-rc.d/pulsecoach/run
@@ -183,6 +183,10 @@ export OLLAMA_EMBED_MODEL="${OLLAMA_EMBED_MODEL:-nomic-embed-text}"
 export USER_TIMEZONE
 export DATABASE_URL="postgresql://postgres@127.0.0.1:5432/pulsecoach"
 export POSTGRES_URL="postgresql://postgres@127.0.0.1:5432/pulsecoach"
+# Single-user auth passthrough: HA ingress is the authentication layer, so
+# the bundled app runs with its own auth bypassed (documented single-user
+# model — see app repo #278). The variable name is historical; a rename to
+# INGRESS_AUTH_PASSTHROUGH is pending in the app repo.
 export DEV_BYPASS_AUTH="true"
 export NODE_ENV="production"
 export AUTH_SECRET="ha-addon-local-secret-$(cat /proc/sys/kernel/random/boot_id)"


### PR DESCRIPTION
Pre-flight fixes before community promotion (from the publishing research):

- **AppArmor profile** (`apparmor.txt`) — based on the HA addon template, broad enough for s6 + PostgreSQL + Python + Node, raises the security rating
- **`DEV_BYPASS_AUTH` removed from config.json** — it was redundant (the pulsecoach run script already exports it) and the alarming name in the public manifest is the first thing a security reviewer flags. The run script now documents the single-user-behind-ingress model; a proper rename to `INGRESS_AUTH_PASSTHROUGH` needs an app-repo change and is deferred
- **Hardware requirements** in DOCS.md: minimum RPi 4 class / 2–4 GiB free RAM / ~5 GB storage; Ollama-on-Pi warned against
- **Garmin unofficial-API disclaimer** (same method as cyberjunky integration, credentials stay local, may break when Garmin changes auth)
- Release 0.20.3 (no app change, APP_REF stays v0.20.1)

Deferred: multi-arch manifest image naming (needs build-workflow changes — workflow files are change-restricted) and the in-app env rename.