### PR TITLE
chore: release 0.21.0 with app v0.21.0

### DIFF
--- a/pulsecoach/CHANGELOG.md
+++ b/pulsecoach/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.21.0] - 2026-07-07
+
+### Added
+
+- **Stress Board mask toggle** (bundled app v0.21.0) — one-tap privacy
+  mode for screenshots: attendees render as stable initials and meeting
+  titles as generic labels. Real names remain the default.
+
 ## [0.20.3] - 2026-07-07
 
 ### Security

--- a/pulsecoach/Dockerfile
+++ b/pulsecoach/Dockerfile
@@ -15,7 +15,7 @@ WORKDIR /build
 # Clone the app source from GitHub
 # Use build arg timestamp for cache busting instead of GitHub API (avoids 403 rate limits)
 ARG APP_REPO=askb/ha-garmin-fitness-coach-app
-ARG APP_REF=v0.20.1
+ARG APP_REF=v0.21.0
 ARG CACHEBUST=1
 RUN echo "Cache bust: ${CACHEBUST}" && \
     git clone --depth=1 --branch="${APP_REF}" \
@@ -91,4 +91,4 @@ LABEL \
     io.hass.description="AI-powered sport scientist for Garmin athletes" \
     io.hass.arch="${BUILD_ARCH}" \
     io.hass.type="addon" \
-    io.hass.version="0.20.3"
+    io.hass.version="0.21.0"

--- a/pulsecoach/config.json
+++ b/pulsecoach/config.json
@@ -1,6 +1,6 @@
 {
   "name": "PulseCoach",
-  "version": "0.20.3",
+  "version": "0.21.0",
   "slug": "pulsecoach",
   "image": "ghcr.io/askb/pulsecoach-addon-{arch}",
   "description": "AI-powered sport scientist — training analysis, coaching, and recovery optimization from your Garmin data",


### PR DESCRIPTION
Bundled app v0.21.0: Stress Board 🙈 mask toggle (stable initials for attendees, generic meeting titles) — the community-launch screenshot prerequisite (askb/ha-garmin-fitness-coach-app#327). APP_REF, config version, io.hass.version label aligned at 0.21.0.