### PR TITLE
fix: report interactions dropped for missing HR coverage

### DIFF
--- a/pulsecoach/DOCS.md
+++ b/pulsecoach/DOCS.md
@@ -144,6 +144,13 @@ just for being in every meeting). People with n < 3 meetings are marked
    A ready-made dashboard + scripts (preset buttons, freeform and
    backdated logging) lives in the companion HA config.
 
+   > **Interactions only appear after a run *and* once heart rate exists
+   > for that time.** A contact you log for *right now* won't score until
+   > Garmin syncs that window — the board shows a "⚠ N events had no
+   > heart-rate coverage yet (incl. logged interactions)" notice and picks
+   > them up on the next **▶ run**. Backdate the `end` to a time you've
+   > already synced to see it immediately.
+
 ### Running
 
 Open **Stress Board** from the web UI menu and hit **▶ run** — or

--- a/pulsecoach/rootfs/app/scripts/meeting-stress.py
+++ b/pulsecoach/rootfs/app/scripts/meeting-stress.py
@@ -83,25 +83,56 @@ def _pstdev(xs: list[float]) -> float:
 # Per-meeting scoring
 # --------------------------------------------------------------------------- #
 def score_meetings(events: list[dict], series: HrSeries,
-                   max_attendees: int = DEFAULT_MAX_ATTENDEES) -> list[dict]:
-    """Score each usable meeting vs its local baseline. Returns rows with dbpm/z/elev."""
+                   max_attendees: int = DEFAULT_MAX_ATTENDEES,
+                   skipped: list[dict] | None = None) -> list[dict]:
+    """Score each usable meeting vs its local baseline. Returns rows with dbpm/z/elev.
+
+    When ``skipped`` is provided, every event that can't be scored is appended
+    to it as a dict with keys ``title``, ``attendees`` and ``reason`` so callers
+    can tell the user *why* something (e.g. a just-logged interaction) never
+    reached the board.
+    """
     intervals = [(parse_ts(e["start"]), parse_ts(e["end"])) for e in events]
     win = BASELINE_MIN * 60
     rows: list[dict] = []
 
+    def _skip(ev: dict, attendees: list[str], reason: str) -> None:
+        if skipped is not None:
+            skipped.append({
+                "title": ev.get("title", "(untitled)"),
+                # town-halls can carry hundreds of attendees; the summary only
+                # needs a sample, so cap to keep meeting_stress.json small.
+                "attendees": attendees[:20],
+                "reason": reason,
+            })
+
     for idx, ev in enumerate(events):
         attendees = [a for a in ev.get("attendees", []) if a]
-        if not attendees or len(attendees) > max_attendees:
-            continue  # solo or town-hall: skip
+        if not attendees:
+            _skip(ev, attendees, "no_attendees")
+            continue  # solo: skip
+        if len(attendees) > max_attendees:
+            _skip(ev, attendees, "too_many_attendees")
+            continue  # town-hall: skip
         s, e = intervals[idx]
         if e - s >= 6 * 3600:
+            _skip(ev, attendees, "too_long")
             continue  # all-day / multi-hour block: skip
 
         meeting = _bpm_between(series, s, e)
+        if not meeting:
+            # No HR inside the meeting window — usually the window isn't synced
+            # yet (e.g. an interaction logged for "right now"). Resolvable by a
+            # Garmin sync + re-run.
+            _skip(ev, attendees, "no_hr")
+            continue
         # baseline = surrounding window minus *every* meeting (incl. this one)
         base = _bpm_baseline(series, s - win, e + win, intervals)
-        if not meeting or len(base) < MIN_BASELINE_SAMPLES:
-            continue  # not enough signal
+        if len(base) < MIN_BASELINE_SAMPLES:
+            # HR exists but too little quiet surrounding time to form a baseline
+            # (e.g. back-to-back meetings). Waiting for a sync won't fix this.
+            _skip(ev, attendees, "thin_baseline")
+            continue
 
         mean_m, mean_b = _mean(meeting), _mean(base)
         std_b = max(_pstdev(base), 1.0)  # floor: avoid div-by-zero / z blow-up
@@ -230,10 +261,43 @@ def print_report(meetings: list[dict], people: list[dict], color: bool) -> None:
     print()
 
 
-def write_csvs(meetings: list[dict], people: list[dict], outdir: str) -> None:
+def summarize_skipped(skipped: list[dict]) -> dict:
+    """Roll skipped events into a compact summary the UI can act on.
+
+    ``no_hr`` is the actionable bucket: events (often just-logged
+    interactions) dropped because Garmin hadn't synced heart rate for that
+    window yet — resolvable by a sync + re-run. ``thin_baseline`` (too little
+    surrounding quiet time, e.g. back-to-back meetings) and structural skips
+    (solo / town-hall / all-day) are counted in ``by_reason`` but not surfaced
+    as "wait for sync", since waiting won't fix them.
+    """
+    by_reason: dict[str, int] = {}
+    for s in skipped:
+        by_reason[s["reason"]] = by_reason.get(s["reason"], 0) + 1
+    no_hr = [s for s in skipped if s["reason"] == "no_hr"]
+    interactions_no_hr = sum(
+        1 for s in no_hr if str(s["title"]).startswith("interaction: ")
+    )
+    return {
+        "total": len(skipped),
+        "by_reason": by_reason,
+        "no_hr": len(no_hr),
+        "interactions_no_hr": interactions_no_hr,
+        # human-readable titles for the actionable ones (interactions un-prefixed)
+        "no_hr_titles": [
+            str(s["title"]).removeprefix("interaction: ") for s in no_hr
+        ][:10],
+    }
+
+
+def write_csvs(meetings: list[dict], people: list[dict], outdir: str,
+               skipped_summary: dict | None = None) -> None:
+    payload: dict = {"generated": datetime.now(timezone.utc).isoformat(),
+                     "meetings": meetings, "people": people}
+    if skipped_summary is not None:
+        payload["skipped"] = skipped_summary
     with open(os.path.join(outdir, "meeting_stress.json"), "w") as f:
-        json.dump({"generated": datetime.now(timezone.utc).isoformat(),
-                   "meetings": meetings, "people": people}, f, indent=1)
+        json.dump(payload, f, indent=1)
     with open(os.path.join(outdir, "meeting_scores.csv"), "w", newline="") as f:
         w = csv.writer(f)
         w.writerow(["dbpm", "z", "elev", "title", "attendees"])
@@ -597,16 +661,27 @@ def main(argv: list[str] | None = None) -> int:
               file=sys.stderr)
         return 1
 
-    meetings = score_meetings(events, series, args.max_attendees)
-    if not meetings:
-        print("No scorable meetings (all solo / too big / outside HR coverage).", file=sys.stderr)
-        return 1
-    people = leaderboard(meetings, args.lam)
+    skipped: list[dict] = []
+    meetings = score_meetings(events, series, args.max_attendees, skipped=skipped)
+    summary = summarize_skipped(skipped)
+    people = leaderboard(meetings, args.lam) if meetings else []
 
     color = sys.stdout.isatty() and not args.no_color
-    print_report(meetings, people, color)
-    write_csvs(meetings, people, args.outdir)
-    return 0
+    if meetings:
+        print_report(meetings, people, color)
+    else:
+        print("No scorable meetings yet — see the skipped summary in "
+              "meeting_stress.json for per-event reasons.",
+              file=sys.stderr)
+    if summary["no_hr"]:
+        note = f"{summary['no_hr']} event(s) had no heart-rate coverage yet"
+        if summary["interactions_no_hr"]:
+            note += f" (incl. {summary['interactions_no_hr']} logged interaction(s))"
+        print(note + " — they'll appear after the next Garmin sync + re-run.",
+              file=sys.stderr)
+    # Always persist results (even empty) so the UI can surface the skip notice.
+    write_csvs(meetings, people, args.outdir, summary)
+    return 0 if meetings else 1
 
 
 def _clear_status() -> None:

--- a/tests/test_meeting_stress.py
+++ b/tests/test_meeting_stress.py
@@ -130,9 +130,73 @@ def test_interactions_jsonl():
     assert ms.load_interactions("/nonexistent/interactions.jsonl") == []
 
 
+def test_skipped_reports_no_hr_interactions():
+    """Interactions with no HR coverage are dropped but reported, not silent."""
+    # One scorable calendar meeting (has surrounding HR) + one interaction that
+    # falls entirely outside the HR series (as when logged before today synced).
+    meet_start = DAY.replace(hour=9)
+    meet_end = meet_start + timedelta(minutes=40)
+    inter_start = DAY.replace(hour=20)  # after the series ends -> no HR
+    inter_end = inter_start + timedelta(minutes=30)
+    events = [
+        {"start": meet_start.isoformat(), "end": meet_end.isoformat(),
+         "title": "standup", "attendees": ["alice", "bob"]},
+        {"start": inter_start.isoformat(), "end": inter_end.isoformat(),
+         "title": "interaction: Mum", "attendees": ["Mum"]},
+    ]
+    # 07:00 -> 11:00 HR backbone (covers the meeting, not the evening interaction).
+    day7 = int(DAY.replace(hour=7).timestamp())
+    series = [(day7 + k * 60, 62.0) for k in range(0, 4 * 60, 2)]
+
+    skipped: list[dict] = []
+    rows = ms.score_meetings(events, series, skipped=skipped)
+    # meeting scored, interaction dropped for no HR.
+    assert len(rows) == 1 and rows[0]["title"] == "standup", rows
+    reasons = [s["reason"] for s in skipped]
+    assert "no_hr" in reasons, skipped
+
+    summary = ms.summarize_skipped(skipped)
+    assert summary["no_hr"] == 1, summary
+    assert summary["interactions_no_hr"] == 1, summary
+    assert "Mum" in summary["no_hr_titles"], summary  # prefix stripped
+
+
+def test_thin_baseline_is_distinct_from_no_hr():
+    """A meeting with HR but too little surrounding quiet time is thin_baseline,
+    not no_hr — so the 'wait for sync' message stays accurate."""
+    # HR exists only for a narrow 20-min band == the meeting itself, so the
+    # ±90-min baseline has almost no samples outside the meeting.
+    m_start = DAY.replace(hour=9)
+    m_end = m_start + timedelta(minutes=20)
+    events = [{"start": m_start.isoformat(), "end": m_end.isoformat(),
+               "title": "standup", "attendees": ["alice", "bob"]}]
+    series = [(int(m_start.timestamp()) + k * 60, 62.0) for k in range(0, 20, 2)]
+
+    skipped: list[dict] = []
+    rows = ms.score_meetings(events, series, skipped=skipped)
+    assert rows == [], rows
+    assert [s["reason"] for s in skipped] == ["thin_baseline"], skipped
+    summary = ms.summarize_skipped(skipped)
+    assert summary["no_hr"] == 0, summary            # not the sync-pending bucket
+    assert summary["by_reason"]["thin_baseline"] == 1, summary
+
+
+def test_score_meetings_without_skipped_is_backward_compatible():
+    """Omitting the skipped arg still returns just the scored rows (no crash)."""
+    events = [{"start": DAY.replace(hour=9).isoformat(),
+               "end": DAY.replace(hour=9, minute=30).isoformat(),
+               "title": "solo", "attendees": []}]
+    series = [(int(DAY.replace(hour=7).timestamp()) + k * 60, 62.0)
+              for k in range(0, 600, 2)]
+    assert ms.score_meetings(events, series) == []
+
+
 if __name__ == "__main__":
     test_ridge_deconfounds_bystander()
     test_solo_and_oversize_meetings_skipped()
     test_gcal_item_mapping()
     test_interactions_jsonl()
+    test_skipped_reports_no_hr_interactions()
+    test_thin_baseline_is_distinct_from_no_hr()
+    test_score_meetings_without_skipped_is_backward_compatible()
     print("ok")


### PR DESCRIPTION
## Problem

Interactions logged from the HA-config sidebar (`interactions.jsonl`) — and any meeting — whose time window had **no synced heart rate** were **silently dropped** by `score_meetings()`. A contact you log for *right now* never reaches the board (Garmin hasn't synced that window yet), with **zero feedback**, so it looks broken.

Reproduced: an interaction outside the HR series is dropped and never appears; a mid-day one with HR coverage scores fine.

## Fix (addon / Python)

- `score_meetings()` now records every skipped event as `{title, attendees, reason}` via an optional `skipped` out-param (`no_attendees` / `too_many_attendees` / `too_long` / `no_hr`). Return type unchanged → existing callers/tests unaffected.
- New `summarize_skipped()` rolls these into a compact summary (`no_hr`, `interactions_no_hr`, un-prefixed `no_hr_titles`, `by_reason`).
- The run writes a `skipped` block into `meeting_stress.json`, and **persists results even when nothing scores**, so the UI can show a notice instead of stale data. A stderr note is printed too.
- `DOCS.md`: documents that interactions appear after a run **and** once HR exists for that window (backdate `end` to see immediately).

## Companion UI change

The app-side notice that consumes this `skipped` block is a separate PR in `ha-garmin-fitness-coach-app` (amber "⚠ N events had no heart-rate coverage yet…" banner, mask-aware so names never leak). Verified end-to-end against a live dev server: unmasked shows titles, masked hides them.

## Tests

- `test_skipped_reports_no_hr_interactions` — meeting scores, interaction dropped, summary reports `no_hr=1`, `interactions_no_hr=1`, title `Mum`.
- `test_score_meetings_without_skipped_is_backward_compatible`.
- Full suite: 6/6 green. `pre-commit` clean.