### PR TITLE
ci: pin docker action version comments to exact tags

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -53,14 +53,14 @@ jobs:
 
       - name: Set up QEMU (for cross-compilation)
         if: matrix.arch == 'aarch64'
-        uses: docker/setup-qemu-action@06116385d9baf250c9f4dcb4858b16962ea869c3  # v4
+        uses: docker/setup-qemu-action@06116385d9baf250c9f4dcb4858b16962ea869c3  # v4.1.0
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5  # v4
+        uses: docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5  # v4.1.0
 
       - name: Log in to GHCR
         if: github.event_name != 'pull_request'
-        uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee  # v4
+        uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee  # v4.2.0
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
@@ -75,7 +75,7 @@ jobs:
           echo "version=${VERSION}" >> "$GITHUB_OUTPUT"
 
       - name: Build image
-        uses: docker/build-push-action@f9f3042f7e2789586610d6e8b85c8f03e5195baf  # v7
+        uses: docker/build-push-action@f9f3042f7e2789586610d6e8b85c8f03e5195baf  # v7.2.0
         with:
           context: pulsecoach
           file: pulsecoach/Dockerfile

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -82,13 +82,13 @@ jobs:
           persist-credentials: false
 
       - name: 'Set up QEMU'
-        uses: docker/setup-qemu-action@06116385d9baf250c9f4dcb4858b16962ea869c3  # v4
+        uses: docker/setup-qemu-action@06116385d9baf250c9f4dcb4858b16962ea869c3  # v4.1.0
 
       - name: 'Set up Docker Buildx'
-        uses: docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5  # v4
+        uses: docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5  # v4.1.0
 
       - name: 'Login to GHCR'
-        uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee  # v4
+        uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee  # v4.2.0
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
@@ -99,7 +99,7 @@ jobs:
         run: echo "version=${GITHUB_REF#refs/tags/v}" >> "$GITHUB_OUTPUT"
 
       - name: 'Build and push arch image'
-        uses: docker/build-push-action@f9f3042f7e2789586610d6e8b85c8f03e5195baf  # v7
+        uses: docker/build-push-action@f9f3042f7e2789586610d6e8b85c8f03e5195baf  # v7.2.0
         with:
           context: pulsecoach
           push: true
@@ -136,7 +136,7 @@ jobs:
           persist-credentials: false
 
       - name: 'Login to GHCR'
-        uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee  # v4
+        uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee  # v4.2.0
         with:
           registry: ghcr.io
           username: ${{ github.actor }}


### PR DESCRIPTION
## What

zizmor code-scanning flagged `ref-version-mismatch` on the `docker/*` actions in `build.yml` and `release.yaml`: their SHA pins carried floating-major version comments (`# v4`, `# v7`), but the pinned commits resolve to exact releases and the major tags have since moved past them.

## Fix

Align each version comment with the exact tag the pinned SHA resolves to (SHAs unchanged):

| action | SHA | was | now |
|---|---|---|---|
| docker/setup-qemu-action | `06116385` | # v4 | # v4.1.0 |
| docker/setup-buildx-action | `d7f5e7f5` | # v4 | # v4.1.0 |
| docker/login-action | `650006c6` | # v4 | # v4.2.0 |
| docker/build-push-action | `f9f3042f` | # v7 | # v7.2.0 |

Clears 9 open code-scanning alerts (#13–#21). Other floating-major pins in this repo were checked and are valid (their major tag still co-points to the pinned SHA), so they're left untouched.

## Test

No behavior change — SHA pins are identical; only comments updated. Verified each SHA→tag mapping via the GitHub tags API.