### PR TITLE
chore: bundle app v0.22.0 in the addon image

### DIFF
--- a/pulsecoach/Dockerfile
+++ b/pulsecoach/Dockerfile
@@ -15,7 +15,7 @@ WORKDIR /build
 # Clone the app source from GitHub
 # Use build arg timestamp for cache busting instead of GitHub API (avoids 403 rate limits)
 ARG APP_REPO=askb/ha-garmin-fitness-coach-app
-ARG APP_REF=v0.21.0
+ARG APP_REF=v0.22.0
 ARG CACHEBUST=1
 RUN echo "Cache bust: ${CACHEBUST}" && \
     git clone --depth=1 --branch="${APP_REF}" \


### PR DESCRIPTION
Bumps the addon image's `APP_REF` from `v0.21.0` to `v0.22.0` so the built addon bundles the new Stress Board UI (in-UI Google Calendar linking + multi-calendar selection) shipped in app #334.

Addon backend for these features already merged in #263; this points the image build at the matching app release tag.