### PR TITLE
feat: configurable Stress Board calendar lookback window

### DIFF
--- a/pulsecoach/CHANGELOG.md
+++ b/pulsecoach/CHANGELOG.md
@@ -7,6 +7,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.23.0] - 2026-07-10
+
+### Added
+
+- **Configurable Stress Board lookback** — a new `meeting_lookback_days`
+  addon option (default 30, 1–365) sets how far back the Stress Board pulls
+  linked-calendar events. Because Garmin heart-rate history goes back years,
+  raising this (e.g. to 90) backfills more meetings per person, trims the
+  *thin data* (n < 3) flags, and gives the ridge de-confounding more signal
+  for steadier scores. Heart rate is still fetched per event-date and cached
+  per day, so a wider window just means a longer first run.
+
 ## [0.22.0] - 2026-07-09
 
 ### Added

--- a/pulsecoach/DOCS.md
+++ b/pulsecoach/DOCS.md
@@ -75,6 +75,7 @@ fetches up to 6 years of historical data.
 | `ollama_url` | url | — | No | Ollama server URL. Required for the `ollama` chat backend, **and** for coach memory/RAG embeddings even when `ai_backend` is `ha_conversation` or `none` (the nightly memory rebuild only runs when this is set) |
 | `ollama_embed_model` | string | `nomic-embed-text` | No | Embedding model for coach memory/RAG over multi-year history. Pull it on your Ollama host; falls back to the chat model if unavailable |
 | `sync_interval_minutes` | integer | `60` | No | Garmin data sync frequency in minutes (5 – 1440) |
+| `meeting_lookback_days` | integer | `30` | No | How far back the Stress Board pulls linked-calendar events (1 – 365). Raise it (e.g. `90`) to backfill more history for better per-person stats — Garmin HR is fetched per event-date and cached, so a wider window just lengthens the first run |
 
 ## Garmin Authentication Troubleshooting
 
@@ -185,6 +186,8 @@ Open **Stress Board** from the web UI menu and hit **▶ run** — or
 `POST /auth/meeting-stress` on the auth server. Results:
 `/share/pulsecoach/meeting_stress.json` plus `meeting_scores.csv` and
 `person_scores.csv`. Heart rate is cached per-day in `/data/hr-cache/`.
+Each run scores the last `meeting_lookback_days` (default 30) of linked
+calendar events; raise that option to backfill months of history at once.
 
 **Caveats:** correlation ≠ causation — treat it as a conversation piece,
 not evidence. Raw HR also rises from *talking* (1:1s where you speak a

--- a/pulsecoach/config.json
+++ b/pulsecoach/config.json
@@ -1,6 +1,6 @@
 {
   "name": "PulseCoach",
-  "version": "0.22.0",
+  "version": "0.23.0",
   "slug": "pulsecoach",
   "image": "ghcr.io/askb/pulsecoach-addon-{arch}",
   "description": "AI-powered sport scientist — training analysis, coaching, and recovery optimization from your Garmin data",
@@ -33,7 +33,8 @@
     "user_timezone": "UTC",
     "ha_events_enabled": true,
     "low_readiness_threshold": 50,
-    "missed_session_grace_min": 360
+    "missed_session_grace_min": 360,
+    "meeting_lookback_days": 30
   },
   "schema": {
     "garmin_email": "str?",
@@ -48,7 +49,8 @@
     "user_timezone": "str?",
     "ha_events_enabled": "bool",
     "low_readiness_threshold": "int(0,100)",
-    "missed_session_grace_min": "int(0,1440)"
+    "missed_session_grace_min": "int(0,1440)",
+    "meeting_lookback_days": "int(1,365)?"
   },
   "environment": {
     "DATABASE_URL": "postgresql://postgres@127.0.0.1:5432/pulsecoach",

--- a/pulsecoach/rootfs/app/scripts/garmin-auth-server.py
+++ b/pulsecoach/rootfs/app/scripts/garmin-auth-server.py
@@ -485,8 +485,21 @@ def trigger_meeting_stress() -> tuple[Response, int] | Response:
         log_fh = open("/data/meeting-stress.log", "w", buffering=1)
         try:
             # Script resolves the source: linked calendar > dropped events file.
+            # Lookback window comes from the addon's meeting_lookback_days
+            # option (default 30); more history = better per-person stats.
+            cmd = ["python3", "/app/scripts/meeting-stress.py",
+                   "--fetch", "--no-color"]
+            raw_days = os.environ.get("MEETING_LOOKBACK_DAYS", "").strip()
+            try:
+                days = int(raw_days)
+            except ValueError:
+                days = 0
+            if days > 0:
+                # Mirror the addon schema's 1–365 bound so a mis-set env can't
+                # trigger an unexpectedly long run.
+                cmd += ["--days", str(min(days, 365))]
             subprocess.Popen(
-                ["python3", "/app/scripts/meeting-stress.py", "--fetch", "--no-color"],
+                cmd,
                 env=os.environ.copy(),
                 stdout=log_fh,
                 stderr=subprocess.STDOUT,

--- a/pulsecoach/rootfs/etc/s6-overlay/s6-rc.d/garmin-auth/run
+++ b/pulsecoach/rootfs/etc/s6-overlay/s6-rc.d/garmin-auth/run
@@ -6,4 +6,6 @@
 # ==============================================================================
 
 bashio::log.info "Starting Garmin auth server on 127.0.0.1:8099..."
+MEETING_LOOKBACK_DAYS=$(bashio::config 'meeting_lookback_days' || echo "30")
+export MEETING_LOOKBACK_DAYS
 exec python3 /app/scripts/garmin-auth-server.py

--- a/pulsecoach/translations/en.yaml
+++ b/pulsecoach/translations/en.yaml
@@ -39,6 +39,10 @@
     "missed_session_grace_min": {
       "name": "Missed Session Grace Period",
       "description": "Minutes to wait before missed planned sessions are considered actionable."
+    },
+    "meeting_lookback_days": {
+      "name": "Stress Board Lookback (days)",
+      "description": "How far back the Stress Board pulls linked-calendar events (1–365). Raise it (e.g. 90) to backfill more history for better per-person stress stats."
     }
   }
 }


### PR DESCRIPTION
Adds a `meeting_lookback_days` addon option (default 30, range 1–365) controlling how far back the Stress Board pulls linked-calendar events.

**Why:** Garmin heart-rate history spans years, but the board only looked back a hardcoded 30 days. Raising the window (e.g. 90) backfills more meetings per person → fewer *thin data* (n<3) flags and more signal for the ridge de-confounding → steadier scores. HR is fetched per event-date and cached per day, so a wider window just lengthens the first run.

**How:** option → exported by the garmin-auth s6 run script as `MEETING_LOOKBACK_DAYS` → `/auth/meeting-stress` passes it to `meeting-stress.py --days`. Default preserves current 30-day behaviour. config→0.23.0; DOCS + CHANGELOG updated.