### PR TITLE
chore: release v0.24.0

### DIFF
--- a/pulsecoach/CHANGELOG.md
+++ b/pulsecoach/CHANGELOG.md
@@ -7,6 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.24.0] - 2026-07-10
+
+### Changed
+
+- **Development harness hardening (no image/behavior change).** Applied the
+  deterministic harness audit remediations and AgentShield findings:
+  deny-only Claude Code permissions, fail-secure secret-guard hooks
+  (PreToolUse + Stop), durable project memory, standalone behavioral evals,
+  and PR/issue templates plus CODEOWNERS. Nothing bundled into the addon
+  image changed.
+
 ## [0.23.0] - 2026-07-10
 
 ### Added

--- a/pulsecoach/config.json
+++ b/pulsecoach/config.json
@@ -1,6 +1,6 @@
 {
   "name": "PulseCoach",
-  "version": "0.23.0",
+  "version": "0.24.0",
   "slug": "pulsecoach",
   "image": "ghcr.io/askb/pulsecoach-addon-{arch}",
   "description": "AI-powered sport scientist — training analysis, coaching, and recovery optimization from your Garmin data",


### PR DESCRIPTION
Bumps addon to **v0.24.0** for the harness/AgentShield hardening merged in #268. Tooling-only — no image behavior change.