### PR TITLE
feat: auto-rescore Stress Board and refresh recent-day heart-rate cache

### DIFF
--- a/pulsecoach/CHANGELOG.md
+++ b/pulsecoach/CHANGELOG.md
@@ -7,6 +7,27 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.25.0] - 2026-07-11
+
+### Fixed
+
+- **Stress Board now surfaces recent meetings and interactions on its own.**
+  Two gaps kept freshly-logged meetings and interactions stuck behind the
+  "no heart-rate coverage yet — run again" notice:
+  - **Stale heart-rate cache.** Per-day HR was cached on first fetch and never
+    refreshed, so a day first pulled with partial or zero coverage stayed frozen
+    — re-running the board could never rescue it. The scorer now always
+    re-fetches the current and previous UTC day (which are still gaining samples
+    as Garmin syncs) while keeping older, immutable days cached.
+  - **Manual-only scoring.** The board only scored on a manual ▶ run. A new
+    background loop re-triggers a run every `meeting_rescore_interval_minutes`
+    (new add-on option, default 360; set to 0 to disable), so meetings and
+    interactions logged before Garmin uploaded their heart rate appear
+    automatically once it syncs. The loop reuses the existing
+    `/auth/meeting-stress` running-guard, so it never double-runs alongside a
+    manual ▶ run and self-skips when no calendar or Garmin tokens are linked.
+
+
 ## [0.24.0] - 2026-07-10
 
 ### Changed

--- a/pulsecoach/DOCS.md
+++ b/pulsecoach/DOCS.md
@@ -176,9 +176,12 @@ data, all fictional):
    > **Interactions only appear after a run *and* once heart rate exists
    > for that time.** A contact you log for *right now* won't score until
    > Garmin syncs that window — the board shows a "⚠ N events had no
-   > heart-rate coverage yet (incl. logged interactions)" notice and picks
-   > them up on the next **▶ run**. Backdate the `end` to a time you've
-   > already synced to see it immediately.
+   > heart-rate coverage yet (incl. logged interactions)" notice. The
+   > addon now re-scores in the background every
+   > `meeting_rescore_interval_minutes` (add-on option, default 360; set to
+   > 0 to disable), so they appear on their own once Garmin syncs — no
+   > manual re-run needed. To see one immediately, backdate the `end` to a
+   > time you've already synced and hit **▶ run**.
 
 ### Running
 

--- a/pulsecoach/config.json
+++ b/pulsecoach/config.json
@@ -1,6 +1,6 @@
 {
   "name": "PulseCoach",
-  "version": "0.24.0",
+  "version": "0.25.0",
   "slug": "pulsecoach",
   "image": "ghcr.io/askb/pulsecoach-addon-{arch}",
   "description": "AI-powered sport scientist — training analysis, coaching, and recovery optimization from your Garmin data",
@@ -34,7 +34,8 @@
     "ha_events_enabled": true,
     "low_readiness_threshold": 50,
     "missed_session_grace_min": 360,
-    "meeting_lookback_days": 30
+    "meeting_lookback_days": 30,
+    "meeting_rescore_interval_minutes": 360
   },
   "schema": {
     "garmin_email": "str?",
@@ -50,7 +51,8 @@
     "ha_events_enabled": "bool",
     "low_readiness_threshold": "int(0,100)",
     "missed_session_grace_min": "int(0,1440)",
-    "meeting_lookback_days": "int(1,365)?"
+    "meeting_lookback_days": "int(1,365)?",
+    "meeting_rescore_interval_minutes": "int(0,1440)?"
   },
   "environment": {
     "DATABASE_URL": "postgresql://postgres@127.0.0.1:5432/pulsecoach",

--- a/pulsecoach/rootfs/app/scripts/meeting-stress.py
+++ b/pulsecoach/rootfs/app/scripts/meeting-stress.py
@@ -370,7 +370,15 @@ def _migrate_garth_tokens(token_dir: str) -> None:
 
 
 def fetch_hr_garmin(dates: list[str], cache_dir: str) -> HrSeries:
-    """Real path: pull ~2-min HR per date via garminconnect, cache, return series."""
+    """Real path: pull ~2-min HR per date via garminconnect, cache, return series.
+
+    Recent days (today and yesterday, UTC) are always re-fetched rather than
+    served from cache. Garmin uploads heart rate with a lag, so a day first
+    fetched with partial or zero coverage would otherwise stay frozen in the
+    cache — a meeting or interaction logged today would never gain HR even after
+    Garmin syncs, and re-running the board could never rescue it. Older days are
+    complete and immutable, so their cache is authoritative.
+    """
     from garminconnect import Garmin  # type: ignore
 
     token_dir = os.environ.get("GARMIN_TOKEN_DIR", "/data/garmin-tokens")
@@ -380,10 +388,13 @@ def fetch_hr_garmin(dates: list[str], cache_dir: str) -> HrSeries:
     client.login(tokenstore=token_dir)
 
     os.makedirs(cache_dir, exist_ok=True)
+    # UTC days that may still be gaining samples — never trust their cache.
+    today = datetime.now(timezone.utc).date()
+    volatile = {(today - timedelta(days=n)).strftime("%Y-%m-%d") for n in (0, 1)}
     series: HrSeries = []
     for date_str in dates:
         path = os.path.join(cache_dir, f"hr_{date_str}.json")
-        if os.path.exists(path):
+        if os.path.exists(path) and date_str not in volatile:
             with open(path) as f:
                 pairs = json.load(f)
         else:

--- a/pulsecoach/rootfs/etc/s6-overlay/s6-rc.d/pulsecoach/run
+++ b/pulsecoach/rootfs/etc/s6-overlay/s6-rc.d/pulsecoach/run
@@ -94,6 +94,7 @@ SYNC_PID=""
 COMPUTE_PID=""
 NOTIFY_PID=""
 MEMORY_PID=""
+RESCORE_PID=""
 NEXTJS_PID=""
 INGRESS_PID=""
 SHUTTING_DOWN=false
@@ -103,7 +104,7 @@ cleanup() {
     bashio::log.info "Shutting down PulseCoach services..."
     # Backup before shutdown
     backup_to_share
-    for pid in $SYNC_PID $COMPUTE_PID $NOTIFY_PID $MEMORY_PID $NEXTJS_PID $INGRESS_PID; do
+    for pid in $SYNC_PID $COMPUTE_PID $NOTIFY_PID $MEMORY_PID $RESCORE_PID $NEXTJS_PID $INGRESS_PID; do
         if kill -0 "$pid" 2>/dev/null; then
             kill "$pid" 2>/dev/null
         fi
@@ -441,6 +442,43 @@ else
     bashio::log.info "No Ollama URL — skipping coach memory rebuild (embeddings need Ollama)"
 fi
 
+# ─── Start Stress Board auto-rescore in background ──────────────────────────
+# The Stress Board only scores on demand (manual ▶ run / POST /auth/meeting-stress).
+# Meetings and logged interactions from the last hours usually have no Garmin
+# heart rate yet (HR uploads lag), so they sit unscored until the user re-runs
+# by hand. Periodically re-trigger the run so they appear on their own once HR
+# syncs. The endpoint self-skips (HTTP 400 without a calendar/tokens) and
+# de-dupes via its own running-guard (HTTP 409), so this is safe beside manual
+# runs. Set the meeting_rescore_interval_minutes option to 0 to disable.
+MEETING_RESCORE_INTERVAL_MINUTES="$(bashio::config 'meeting_rescore_interval_minutes' || echo "${MEETING_RESCORE_INTERVAL_MINUTES:-360}")"
+# Sanitize: a non-integer would kill the loop in the $((...)) below and the
+# monitor would restart it forever. Fall back to the default if it isn't a
+# plain non-negative integer.
+case "${MEETING_RESCORE_INTERVAL_MINUTES}" in
+    ''|*[!0-9]*) MEETING_RESCORE_INTERVAL_MINUTES=360 ;;
+esac
+meeting_rescore_loop() {
+    sleep 600  # let the auth server and first Garmin sync settle
+    while true; do
+        bashio::log.info "Auto-rescoring Stress Board..."
+        code="$(curl -s -o /dev/null -w '%{http_code}' -m 900 -X POST \
+            http://127.0.0.1:8099/auth/meeting-stress 2>/dev/null || echo "000")"
+        case "${code}" in
+            2*) : ;;  # run started
+            400|409) bashio::log.info "Stress Board auto-rescore skipped (no calendar/tokens or already running)" ;;
+            *) bashio::log.warning "Stress Board auto-rescore request failed (HTTP ${code})" ;;
+        esac
+        sleep "$((MEETING_RESCORE_INTERVAL_MINUTES * 60))"
+    done
+}
+if [ "${MEETING_RESCORE_INTERVAL_MINUTES}" -gt 0 ] 2>/dev/null; then
+    bashio::log.info "Starting Stress Board auto-rescore (every ${MEETING_RESCORE_INTERVAL_MINUTES} minutes)..."
+    meeting_rescore_loop &
+    RESCORE_PID=$!
+else
+    bashio::log.info "Stress Board auto-rescore disabled (interval <= 0)"
+fi
+
 # ─── Configure AI backend ─────────────────────────────────────────────────────
 case "${AI_BACKEND}" in
     ha_conversation)
@@ -575,6 +613,12 @@ while true; do
             done
         ) &
         MEMORY_PID=$!
+    fi
+
+    if [ -n "$RESCORE_PID" ] && ! kill -0 "$RESCORE_PID" 2>/dev/null; then
+        bashio::log.warning "Stress Board auto-rescore died, restarting..."
+        meeting_rescore_loop &
+        RESCORE_PID=$!
     fi
 
     if ! kill -0 "$NEXTJS_PID" 2>/dev/null; then

--- a/pulsecoach/translations/en.yaml
+++ b/pulsecoach/translations/en.yaml
@@ -43,6 +43,10 @@
     "meeting_lookback_days": {
       "name": "Stress Board Lookback (days)",
       "description": "How far back the Stress Board pulls linked-calendar events (1–365). Raise it (e.g. 90) to backfill more history for better per-person stress stats."
+    },
+    "meeting_rescore_interval_minutes": {
+      "name": "Stress Board Auto-Rescore (minutes)",
+      "description": "How often (minutes) the Stress Board re-scores in the background so meetings and interactions show once Garmin syncs their heart rate (0-1440, default 360). 0 disables it."
     }
   }
 }

--- a/tests/test_meeting_stress.py
+++ b/tests/test_meeting_stress.py
@@ -241,6 +241,60 @@ def test_score_meetings_without_skipped_is_backward_compatible():
     assert ms.score_meetings(events, series) == []
 
 
+def test_fetch_hr_refreshes_volatile_days(tmp_path, monkeypatch):
+    """fetch_hr_garmin re-fetches today/yesterday (still gaining samples) but
+    serves older, immutable days straight from the on-disk cache."""
+    import sys
+    import types
+
+    calls: list[str] = []
+
+    class _FakeGarmin:
+        def __init__(self, *a, **k):
+            pass
+
+        def login(self, *a, **k):
+            pass
+
+        def get_heart_rates(self, date_str):
+            calls.append(date_str)
+            ts = int(datetime.fromisoformat(date_str + "T12:00:00+00:00").timestamp())
+            return {"heartRateValues": [[ts * 1000, 70]]}
+
+    fake = types.ModuleType("garminconnect")
+    fake.Garmin = _FakeGarmin
+    monkeypatch.setitem(sys.modules, "garminconnect", fake)
+    monkeypatch.setenv("GARMIN_TOKEN_DIR", str(tmp_path / "tokens"))
+
+    # Pin the clock so the module's notion of "today" can't drift from the
+    # test's across a UTC-midnight boundary (which would make this flaky).
+    class _FixedDateTime(datetime):
+        @classmethod
+        def now(cls, tz=None):
+            return datetime(2026, 7, 15, 12, 0, tzinfo=tz or timezone.utc)
+
+    monkeypatch.setattr(ms, "datetime", _FixedDateTime)
+    today = _FixedDateTime.now(timezone.utc).date()
+
+    cache = tmp_path / "hr-cache"
+    cache.mkdir()
+    old_day = (today - timedelta(days=10)).strftime("%Y-%m-%d")
+    today_str = today.strftime("%Y-%m-%d")
+    # Seed BOTH days with a stale (empty-coverage) cache file.
+    for d in (old_day, today_str):
+        (cache / f"hr_{d}.json").write_text("[]")
+
+    ms.fetch_hr_garmin([old_day, today_str], str(cache))
+
+    # Old day: served from stale cache, never re-fetched.
+    assert old_day not in calls, calls
+    # Today: re-fetched despite the cache existing (it may still gain samples).
+    assert today_str in calls, calls
+    # And its cache is refreshed with the new sample, not left empty.
+    import json as _json
+    assert _json.loads((cache / f"hr_{today_str}.json").read_text()), "today cache refreshed"
+
+
 if __name__ == "__main__":
     test_ridge_deconfounds_bystander()
     test_solo_and_oversize_meetings_skipped()


### PR DESCRIPTION
## What

Two fixes so freshly-logged meetings and interactions appear on the Stress Board on their own, instead of staying stuck behind the "⚠ N events had no heart-rate coverage yet — run again" notice.

### 1. Refresh recent-day HR cache (root cause)
`fetch_hr_garmin` cached per-day HR on first fetch and **never refreshed it**. A day first pulled with partial/zero coverage stayed frozen — so re-running the board could *never* rescue a meeting logged today, even after Garmin synced. It now always re-fetches the current and previous UTC day (still gaining samples) while keeping older, immutable days cached.

### 2. Background auto-rescore loop
The board only scored on a manual ▶ run. A new loop re-triggers a run every `MEETING_RESCORE_INTERVAL_MINUTES` (default 360; `0` disables), reusing the existing `/auth/meeting-stress` running-guard so it never double-runs alongside a manual run and self-skips (HTTP 400) when no calendar/Garmin tokens are linked.

## Testing
- `pytest tests/test_meeting_stress.py` → 8/8 pass
- `bash -n` + shellcheck on the run script: no new findings
- `py_compile` clean

## Release
Addon 0.24.0 → **0.25.0**; CHANGELOG + DOCS updated. Backend/HA only — no app rebundle needed.