### PR TITLE
feat: interaction quick-add endpoints for the Stress Board

### DIFF
--- a/pulsecoach/CHANGELOG.md
+++ b/pulsecoach/CHANGELOG.md
@@ -7,6 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.26.0] - 2026-07-11
+
+### Added
+
+- **In-app interaction quick-add for the Stress Board.** New
+  `/auth/interactions` endpoints (GET list, POST add, DELETE by id) manage
+  `/share/pulsecoach/interactions.jsonl` from the web UI, so logging an
+  out-of-calendar contact no longer requires hand-writing JSONL through an
+  HA shell_command. Hand-written lines keep working: they are listed with a
+  content-hash id and never rewritten unless explicitly deleted.
+
 ## [0.25.0] - 2026-07-11
 
 ### Fixed

--- a/pulsecoach/config.json
+++ b/pulsecoach/config.json
@@ -1,6 +1,6 @@
 {
   "name": "PulseCoach",
-  "version": "0.25.0",
+  "version": "0.26.0",
   "slug": "pulsecoach",
   "image": "ghcr.io/askb/pulsecoach-addon-{arch}",
   "description": "AI-powered sport scientist — training analysis, coaching, and recovery optimization from your Garmin data",

--- a/pulsecoach/rootfs/app/scripts/garmin-auth-server.py
+++ b/pulsecoach/rootfs/app/scripts/garmin-auth-server.py
@@ -15,6 +15,7 @@ from typing import Optional
 from flask import Flask, Response, jsonify, request
 
 import gcal
+import interactions
 
 try:
     from garminconnect import Garmin
@@ -622,6 +623,42 @@ def gcal_calendars() -> tuple[Response, int] | Response:
         return jsonify(success=True, calendars=gcal.list_calendars())
     except gcal.GcalError as exc:
         return jsonify(success=False, message=str(exc)), 502
+
+
+@app.route("/auth/interactions", methods=["GET", "POST"])
+def interactions_route() -> tuple[Response, int] | Response:
+    """List recent interactions (GET) or quick-add one (POST).
+
+    POST body: {person, minutes, end?} — end defaults to now. Backs the
+    Stress Board's in-app quick-add so out-of-calendar contacts no longer
+    require hand-writing JSONL via an HA shell_command.
+    """
+    if request.method == "POST":
+        data = request.get_json(silent=True) or {}
+        try:
+            rec = interactions.add_interaction(
+                data.get("person", ""),
+                data.get("minutes"),
+                data.get("end") or None,
+            )
+        except interactions.InteractionError as exc:
+            return jsonify(success=False, message=str(exc)), 400
+        except OSError as exc:
+            return jsonify(success=False, message=str(exc)), 500
+        return jsonify(success=True, interaction=rec)
+    return jsonify(success=True,
+                   interactions=interactions.list_interactions())
+
+
+@app.route("/auth/interactions/<iid>", methods=["DELETE"])
+def interactions_delete(iid: str) -> tuple[Response, int] | Response:
+    """Delete one logged interaction by id."""
+    try:
+        if interactions.delete_interaction(iid):
+            return jsonify(success=True, message="Interaction removed")
+    except OSError as exc:
+        return jsonify(success=False, message=str(exc)), 500
+    return jsonify(success=False, message="Interaction not found"), 404
 
 
 if __name__ == "__main__":

--- a/pulsecoach/rootfs/app/scripts/garmin-auth-server.py
+++ b/pulsecoach/rootfs/app/scripts/garmin-auth-server.py
@@ -634,7 +634,9 @@ def interactions_route() -> tuple[Response, int] | Response:
     require hand-writing JSONL via an HA shell_command.
     """
     if request.method == "POST":
-        data = request.get_json(silent=True) or {}
+        data = request.get_json(silent=True)
+        if not isinstance(data, dict):  # a JSON array/scalar has no .get()
+            data = {}
         try:
             rec = interactions.add_interaction(
                 data.get("person", ""),

--- a/pulsecoach/rootfs/app/scripts/interactions.py
+++ b/pulsecoach/rootfs/app/scripts/interactions.py
@@ -94,6 +94,8 @@ def add_interaction(person: str, minutes: object,
     if not person or len(person) > MAX_PERSON_LEN:
         raise InteractionError(
             f"person must be 1-{MAX_PERSON_LEN} characters")
+    if isinstance(minutes, bool):  # bool subclasses int: true would pass as 1
+        raise InteractionError("minutes must be a number")
     try:
         mins = float(minutes)  # type: ignore[arg-type]
     except (TypeError, ValueError):

--- a/pulsecoach/rootfs/app/scripts/interactions.py
+++ b/pulsecoach/rootfs/app/scripts/interactions.py
@@ -1,0 +1,161 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: 2026 Anil Belur <askb23@gmail.com>
+"""Stress Board interaction log helpers: add / list / delete quick-adds.
+
+Shared by garmin-auth-server.py (the /auth/interactions endpoints behind the
+in-app quick-add) and, indirectly, meeting-stress.py which consumes the same
+JSONL file. stdlib only.
+
+File shape (one JSON object per line, append-only friendly):
+    {"person": str, "minutes": num, "end": ISO8601, "id": str, "logged_at": str}
+
+Only person/minutes/end matter to meeting-stress.py; id/logged_at are UI
+bookkeeping. Lines written by hand (HA shell_command) have no id — they get a
+stable content-hash id so the UI can still list and delete them. Malformed
+lines are never touched: the log stays forgiving for manual writers.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+import uuid
+from datetime import datetime, timedelta, timezone
+
+INTERACTIONS_PATH = "/share/pulsecoach/interactions.jsonl"
+
+MAX_PERSON_LEN = 200
+MAX_MINUTES = 1440  # one day
+DEFAULT_LIST_LIMIT = 20
+
+
+class InteractionError(ValueError):
+    """Invalid interaction input (message is user-safe)."""
+
+
+def _line_id(rec: dict, raw: str) -> str:
+    """Stable id for a line: the stored id, else a content hash."""
+    stored = rec.get("id")
+    if isinstance(stored, str) and stored:
+        return stored
+    return hashlib.sha1(raw.encode()).hexdigest()[:12]
+
+
+def _parse_line(raw: str) -> dict | None:
+    """Return a valid interaction record from a raw line, else None.
+
+    Mirrors meeting-stress.py load_interactions(): person/minutes/end must
+    parse, everything else is forgiven.
+    """
+    try:
+        rec = json.loads(raw)
+        person = str(rec["person"]).strip()
+        minutes = float(rec.get("minutes", 30))
+        end = datetime.fromisoformat(str(rec["end"]).replace("Z", "+00:00"))
+    except (KeyError, ValueError, TypeError):
+        return None
+    if not person or minutes <= 0:
+        return None
+    return {
+        "id": _line_id(rec, raw),
+        "person": person,
+        "minutes": int(minutes) if minutes == int(minutes) else minutes,
+        "end": end.isoformat(),
+    }
+
+
+def add_interaction(person: str, minutes: object,
+                    end: str | None = None) -> dict:
+    """Validate and append one interaction; returns the stored record.
+
+    end defaults to now (UTC). Raises InteractionError on bad input so the
+    HTTP layer can 400 with the message verbatim.
+    """
+    person = str(person or "").strip()
+    if not person or len(person) > MAX_PERSON_LEN:
+        raise InteractionError(
+            f"person must be 1-{MAX_PERSON_LEN} characters")
+    try:
+        mins = float(minutes)  # type: ignore[arg-type]
+    except (TypeError, ValueError):
+        raise InteractionError("minutes must be a number") from None
+    if not 0 < mins <= MAX_MINUTES:
+        raise InteractionError(f"minutes must be 1-{MAX_MINUTES}")
+    now = datetime.now(timezone.utc)
+    if end is None:
+        end_dt = now
+    else:
+        try:
+            end_dt = datetime.fromisoformat(str(end).replace("Z", "+00:00"))
+        except ValueError:
+            raise InteractionError(
+                "end must be an ISO 8601 timestamp") from None
+        if end_dt.tzinfo is None:
+            end_dt = end_dt.replace(tzinfo=timezone.utc)
+        if end_dt > now + timedelta(days=1):
+            raise InteractionError("end is in the future")
+    rec = {
+        "person": person,
+        "minutes": int(mins) if mins == int(mins) else mins,
+        "end": end_dt.isoformat(),
+        "id": uuid.uuid4().hex[:12],
+        "logged_at": now.isoformat(),
+    }
+    os.makedirs(os.path.dirname(INTERACTIONS_PATH), exist_ok=True)
+    with open(INTERACTIONS_PATH, "a") as f:
+        f.write(json.dumps(rec) + "\n")
+    return {k: rec[k] for k in ("id", "person", "minutes", "end")}
+
+
+def list_interactions(limit: int = DEFAULT_LIST_LIMIT) -> list[dict]:
+    """Newest-first valid interactions, capped at `limit`."""
+    try:
+        with open(INTERACTIONS_PATH) as f:
+            lines = f.readlines()
+    except OSError:
+        return []
+    entries = []
+    for raw in lines:
+        raw = raw.strip()
+        if not raw:
+            continue
+        rec = _parse_line(raw)
+        if rec is not None:
+            entries.append(rec)
+    entries.reverse()  # file is append-only, so reversed == newest first
+    return entries[:max(1, int(limit))]
+
+
+def delete_interaction(iid: str) -> bool:
+    """Remove the first line whose id matches; True when something went.
+
+    Malformed lines (hand-written notes) are preserved verbatim. The rewrite
+    is atomic (tmp + rename) so a crash can't truncate the log.
+    """
+    try:
+        with open(INTERACTIONS_PATH) as f:
+            lines = f.readlines()
+    except OSError:
+        return False
+    kept: list[str] = []
+    removed = False
+    for raw in lines:
+        stripped = raw.strip()
+        if not removed and stripped:
+            try:
+                rec = json.loads(stripped)
+            except ValueError:
+                rec = None
+            if isinstance(rec, dict) and _line_id(rec, stripped) == iid:
+                removed = True
+                continue
+        kept.append(raw)
+    if not removed:
+        return False
+    tmp = INTERACTIONS_PATH + ".tmp"
+    with open(tmp, "w") as f:
+        f.writelines(kept)
+    os.replace(tmp, INTERACTIONS_PATH)
+    return True

--- a/pulsecoach/rootfs/app/scripts/interactions.py
+++ b/pulsecoach/rootfs/app/scripts/interactions.py
@@ -148,12 +148,14 @@ def list_interactions(limit: int = DEFAULT_LIST_LIMIT) -> list[dict]:
 
 
 def delete_interaction(iid: str) -> bool:
-    """Remove the first line whose id matches; True when something went.
+    """Remove the newest line whose id matches; True when something went.
 
-    Malformed lines (hand-written notes) are preserved verbatim. The rewrite
-    is atomic (tmp + rename) so a crash can't truncate the log, and holds
-    _WRITE_LOCK for the whole read→rewrite so a concurrent UI add can't be
-    lost to the rename.
+    Newest-match keeps delete aligned with list_interactions()'s
+    newest-first ordering when identical hand-written lines share a
+    content-hash id. Malformed lines (hand-written notes) are preserved
+    verbatim. The rewrite is atomic (tmp + rename) so a crash can't
+    truncate the log, and holds _WRITE_LOCK for the whole read→rewrite
+    so a concurrent UI add can't be lost to the rename.
     """
     with _WRITE_LOCK:
         try:
@@ -161,21 +163,20 @@ def delete_interaction(iid: str) -> bool:
                 lines = f.readlines()
         except OSError:
             return False
-        kept: list[str] = []
-        removed = False
-        for raw in lines:
+        victim = -1
+        for i, raw in enumerate(lines):
             stripped = raw.strip()
-            if not removed and stripped:
-                try:
-                    rec = json.loads(stripped)
-                except ValueError:
-                    rec = None
-                if isinstance(rec, dict) and _line_id(rec, stripped) == iid:
-                    removed = True
-                    continue
-            kept.append(raw)
-        if not removed:
+            if not stripped:
+                continue
+            try:
+                rec = json.loads(stripped)
+            except ValueError:
+                continue
+            if isinstance(rec, dict) and _line_id(rec, stripped) == iid:
+                victim = i  # keep scanning: last match == newest
+        if victim < 0:
             return False
+        kept = lines[:victim] + lines[victim + 1:]
         tmp = INTERACTIONS_PATH + ".tmp"
         with open(tmp, "w", encoding="utf-8") as f:
             f.writelines(kept)

--- a/pulsecoach/rootfs/app/scripts/interactions.py
+++ b/pulsecoach/rootfs/app/scripts/interactions.py
@@ -20,7 +20,9 @@ from __future__ import annotations
 
 import hashlib
 import json
+import math
 import os
+import threading
 import uuid
 from datetime import datetime, timedelta, timezone
 
@@ -29,6 +31,11 @@ INTERACTIONS_PATH = "/share/pulsecoach/interactions.jsonl"
 MAX_PERSON_LEN = 200
 MAX_MINUTES = 1440  # one day
 DEFAULT_LIST_LIMIT = 20
+
+# Serialises UI-driven writes (append vs delete-rewrite) within the auth
+# server process. HA shell_command appends from other processes are not
+# covered, but those are single O_APPEND writes — only the UI rewrites.
+_WRITE_LOCK = threading.Lock()
 
 
 class InteractionError(ValueError):
@@ -56,7 +63,9 @@ def _parse_line(raw: str) -> dict | None:
         end = datetime.fromisoformat(str(rec["end"]).replace("Z", "+00:00"))
     except (KeyError, ValueError, TypeError):
         return None
-    if not person or minutes <= 0:
+    # json.loads accepts NaN/Infinity literals; a non-finite value would
+    # blow up the int() normalisation below and poison every listing.
+    if not person or not math.isfinite(minutes) or minutes <= 0:
         return None
     # meeting-stress.py parse_ts() scores naive timestamps as UTC — mirror
     # that here so hand-written lines list consistently with how they score.
@@ -108,7 +117,7 @@ def add_interaction(person: str, minutes: object,
         "logged_at": now.isoformat(),
     }
     os.makedirs(os.path.dirname(INTERACTIONS_PATH), exist_ok=True)
-    with open(INTERACTIONS_PATH, "a", encoding="utf-8") as f:
+    with _WRITE_LOCK, open(INTERACTIONS_PATH, "a", encoding="utf-8") as f:
         f.write(json.dumps(rec) + "\n")
     return {k: rec[k] for k in ("id", "person", "minutes", "end")}
 
@@ -138,30 +147,33 @@ def delete_interaction(iid: str) -> bool:
     """Remove the first line whose id matches; True when something went.
 
     Malformed lines (hand-written notes) are preserved verbatim. The rewrite
-    is atomic (tmp + rename) so a crash can't truncate the log.
+    is atomic (tmp + rename) so a crash can't truncate the log, and holds
+    _WRITE_LOCK for the whole read→rewrite so a concurrent UI add can't be
+    lost to the rename.
     """
-    try:
-        with open(INTERACTIONS_PATH, encoding="utf-8") as f:
-            lines = f.readlines()
-    except OSError:
-        return False
-    kept: list[str] = []
-    removed = False
-    for raw in lines:
-        stripped = raw.strip()
-        if not removed and stripped:
-            try:
-                rec = json.loads(stripped)
-            except ValueError:
-                rec = None
-            if isinstance(rec, dict) and _line_id(rec, stripped) == iid:
-                removed = True
-                continue
-        kept.append(raw)
-    if not removed:
-        return False
-    tmp = INTERACTIONS_PATH + ".tmp"
-    with open(tmp, "w", encoding="utf-8") as f:
-        f.writelines(kept)
-    os.replace(tmp, INTERACTIONS_PATH)
-    return True
+    with _WRITE_LOCK:
+        try:
+            with open(INTERACTIONS_PATH, encoding="utf-8") as f:
+                lines = f.readlines()
+        except OSError:
+            return False
+        kept: list[str] = []
+        removed = False
+        for raw in lines:
+            stripped = raw.strip()
+            if not removed and stripped:
+                try:
+                    rec = json.loads(stripped)
+                except ValueError:
+                    rec = None
+                if isinstance(rec, dict) and _line_id(rec, stripped) == iid:
+                    removed = True
+                    continue
+            kept.append(raw)
+        if not removed:
+            return False
+        tmp = INTERACTIONS_PATH + ".tmp"
+        with open(tmp, "w", encoding="utf-8") as f:
+            f.writelines(kept)
+        os.replace(tmp, INTERACTIONS_PATH)
+        return True

--- a/pulsecoach/rootfs/app/scripts/interactions.py
+++ b/pulsecoach/rootfs/app/scripts/interactions.py
@@ -43,11 +43,15 @@ class InteractionError(ValueError):
 
 
 def _line_id(rec: dict, raw: str) -> str:
-    """Stable id for a line: the stored id, else a content hash."""
+    """Stable id for a line: the stored id, else a content hash.
+
+    sha256 rather than sha1 purely to keep linters quiet — the id is a
+    UI handle for list/delete, not a security boundary.
+    """
     stored = rec.get("id")
     if isinstance(stored, str) and stored:
         return stored
-    return hashlib.sha1(raw.encode()).hexdigest()[:12]
+    return hashlib.sha256(raw.encode()).hexdigest()[:12]
 
 
 def _parse_line(raw: str) -> dict | None:

--- a/pulsecoach/rootfs/app/scripts/interactions.py
+++ b/pulsecoach/rootfs/app/scripts/interactions.py
@@ -58,6 +58,10 @@ def _parse_line(raw: str) -> dict | None:
         return None
     if not person or minutes <= 0:
         return None
+    # meeting-stress.py parse_ts() scores naive timestamps as UTC — mirror
+    # that here so hand-written lines list consistently with how they score.
+    if end.tzinfo is None:
+        end = end.replace(tzinfo=timezone.utc)
     return {
         "id": _line_id(rec, raw),
         "person": person,
@@ -104,15 +108,17 @@ def add_interaction(person: str, minutes: object,
         "logged_at": now.isoformat(),
     }
     os.makedirs(os.path.dirname(INTERACTIONS_PATH), exist_ok=True)
-    with open(INTERACTIONS_PATH, "a") as f:
+    with open(INTERACTIONS_PATH, "a", encoding="utf-8") as f:
         f.write(json.dumps(rec) + "\n")
     return {k: rec[k] for k in ("id", "person", "minutes", "end")}
 
 
 def list_interactions(limit: int = DEFAULT_LIST_LIMIT) -> list[dict]:
-    """Newest-first valid interactions, capped at `limit`."""
+    """Newest-first valid interactions, capped at `limit` (<=0 == none)."""
+    if int(limit) <= 0:
+        return []
     try:
-        with open(INTERACTIONS_PATH) as f:
+        with open(INTERACTIONS_PATH, encoding="utf-8") as f:
             lines = f.readlines()
     except OSError:
         return []
@@ -125,7 +131,7 @@ def list_interactions(limit: int = DEFAULT_LIST_LIMIT) -> list[dict]:
         if rec is not None:
             entries.append(rec)
     entries.reverse()  # file is append-only, so reversed == newest first
-    return entries[:max(1, int(limit))]
+    return entries[:int(limit)]
 
 
 def delete_interaction(iid: str) -> bool:
@@ -135,7 +141,7 @@ def delete_interaction(iid: str) -> bool:
     is atomic (tmp + rename) so a crash can't truncate the log.
     """
     try:
-        with open(INTERACTIONS_PATH) as f:
+        with open(INTERACTIONS_PATH, encoding="utf-8") as f:
             lines = f.readlines()
     except OSError:
         return False
@@ -155,7 +161,7 @@ def delete_interaction(iid: str) -> bool:
     if not removed:
         return False
     tmp = INTERACTIONS_PATH + ".tmp"
-    with open(tmp, "w") as f:
+    with open(tmp, "w", encoding="utf-8") as f:
         f.writelines(kept)
     os.replace(tmp, INTERACTIONS_PATH)
     return True

--- a/tests/test_interactions.py
+++ b/tests/test_interactions.py
@@ -155,3 +155,14 @@ def test_identical_adds_get_distinct_ids(store):
     assert a["id"] != b["id"]
     assert ix.delete_interaction(a["id"]) is True
     assert len(ix.list_interactions()) == 1
+
+
+def test_delete_removes_newest_of_identical_manual_lines(store):
+    """Identical hand-written lines share a content-hash id; delete must
+    take the newest to match list_interactions() newest-first order."""
+    line = ('{"person":"Twin","minutes":10,'
+            '"end":"2026-07-11T02:00:00+00:00"}\n')
+    store.write_text(line + line)
+    top = ix.list_interactions()[0]
+    assert ix.delete_interaction(top["id"]) is True
+    assert store.read_text() == line  # one copy survives

--- a/tests/test_interactions.py
+++ b/tests/test_interactions.py
@@ -1,0 +1,128 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: 2026 Anil Belur <askb23@gmail.com>
+"""Tests for interactions.py: the Stress Board quick-add JSONL store.
+
+Run: python -m pytest tests/test_interactions.py
+"""
+import importlib.util
+import json
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+
+import pytest
+
+_SCRIPT = (Path(__file__).resolve().parents[1] / "pulsecoach" / "rootfs"
+           / "app" / "scripts" / "interactions.py")
+_spec = importlib.util.spec_from_file_location("interactions", _SCRIPT)
+ix = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(ix)
+
+
+@pytest.fixture
+def store(tmp_path, monkeypatch):
+    """Point the module at a per-test JSONL path."""
+    path = tmp_path / "interactions.jsonl"
+    monkeypatch.setattr(ix, "INTERACTIONS_PATH", str(path))
+    return path
+
+
+def test_add_returns_record_with_id_and_defaults(store):
+    rec = ix.add_interaction("Alice", 30)
+    assert rec["person"] == "Alice"
+    assert rec["minutes"] == 30
+    assert rec["id"]
+    # end defaults to roughly now (UTC)
+    end = datetime.fromisoformat(rec["end"])
+    assert abs((datetime.now(timezone.utc) - end).total_seconds()) < 5
+
+
+def test_add_appends_one_json_line_compatible_with_meeting_stress(store):
+    ix.add_interaction("Bob", 45, "2026-07-11T02:00:00+00:00")
+    lines = store.read_text().strip().splitlines()
+    assert len(lines) == 1
+    rec = json.loads(lines[0])
+    # exactly the shape meeting-stress.py load_interactions() consumes
+    assert rec["person"] == "Bob"
+    assert rec["minutes"] == 45
+    assert datetime.fromisoformat(rec["end"])
+
+
+def test_add_validates_person(store):
+    for bad in ("", "   ", "x" * 201):
+        with pytest.raises(ix.InteractionError):
+            ix.add_interaction(bad, 30)
+
+
+def test_add_validates_minutes(store):
+    for bad in (0, -5, 1441, "abc", None):
+        with pytest.raises(ix.InteractionError):
+            ix.add_interaction("Alice", bad)
+
+
+def test_add_validates_end_timestamp(store):
+    with pytest.raises(ix.InteractionError):
+        ix.add_interaction("Alice", 30, "not-a-date")
+    with pytest.raises(ix.InteractionError):
+        # far future ends are user error, reject > 1 day ahead
+        future = (datetime.now(timezone.utc) + timedelta(days=2)).isoformat()
+        ix.add_interaction("Alice", 30, future)
+
+
+def test_list_newest_first_with_ids(store):
+    ix.add_interaction("Alice", 15, "2026-07-11T01:00:00+00:00")
+    ix.add_interaction("Bob", 30, "2026-07-11T02:00:00+00:00")
+    entries = ix.list_interactions()
+    assert [e["person"] for e in entries] == ["Bob", "Alice"]
+    assert all(e["id"] for e in entries)
+    assert len({e["id"] for e in entries}) == 2
+
+
+def test_list_skips_malformed_lines(store):
+    store.write_text('not json\n{"person":"Ok","minutes":30,'
+                     '"end":"2026-07-11T02:00:00+00:00"}\n{"minutes":5}\n')
+    entries = ix.list_interactions()
+    assert [e["person"] for e in entries] == ["Ok"]
+
+
+def test_list_respects_limit(store):
+    for i in range(30):
+        ix.add_interaction(f"p{i}", 10, f"2026-07-10T{i % 24:02d}:00:00+00:00")
+    assert len(ix.list_interactions(limit=5)) == 5
+    assert len(ix.list_interactions()) <= 20
+
+
+def test_list_missing_file_is_empty(store):
+    assert ix.list_interactions() == []
+
+
+def test_delete_removes_only_matching_line(store):
+    ix.add_interaction("Alice", 15, "2026-07-11T01:00:00+00:00")
+    keep = ix.add_interaction("Bob", 30, "2026-07-11T02:00:00+00:00")
+    victim = ix.list_interactions()[1]  # Alice
+    assert ix.delete_interaction(victim["id"]) is True
+    entries = ix.list_interactions()
+    assert [e["person"] for e in entries] == ["Bob"]
+    assert entries[0]["id"] == keep["id"]
+
+
+def test_delete_unknown_id_returns_false(store):
+    ix.add_interaction("Alice", 15)
+    assert ix.delete_interaction("deadbeef0000") is False
+    assert len(ix.list_interactions()) == 1
+
+
+def test_delete_preserves_malformed_lines(store):
+    """Hand-written HA shell_command lines must survive a UI delete."""
+    store.write_text("# manual note, not json\n")
+    rec = ix.add_interaction("Alice", 15)
+    assert ix.delete_interaction(rec["id"]) is True
+    assert store.read_text().startswith("# manual note")
+
+
+def test_identical_adds_get_distinct_ids(store):
+    a = ix.add_interaction("Alice", 30, "2026-07-11T02:00:00+00:00")
+    b = ix.add_interaction("Alice", 30, "2026-07-11T02:00:00+00:00")
+    assert a["id"] != b["id"]
+    assert ix.delete_interaction(a["id"]) is True
+    assert len(ix.list_interactions()) == 1

--- a/tests/test_interactions.py
+++ b/tests/test_interactions.py
@@ -102,6 +102,17 @@ def test_list_zero_or_negative_limit_is_empty(store):
     assert ix.list_interactions(limit=-3) == []
 
 
+def test_list_skips_nonfinite_minutes(store):
+    """json.loads accepts NaN/Infinity literals; they must not poison the
+    listing (int(NaN) raises)."""
+    store.write_text(
+        '{"person":"A","minutes":NaN,"end":"2026-07-11T02:00:00+00:00"}\n'
+        '{"person":"B","minutes":Infinity,"end":"2026-07-11T02:00:00+00:00"}\n'
+        '{"person":"Ok","minutes":30,"end":"2026-07-11T02:00:00+00:00"}\n')
+    entries = ix.list_interactions()
+    assert [e["person"] for e in entries] == ["Ok"]
+
+
 def test_list_treats_naive_end_as_utc(store):
     """Hand-written lines without an offset score as UTC in meeting-stress;
     the listing must agree."""

--- a/tests/test_interactions.py
+++ b/tests/test_interactions.py
@@ -56,7 +56,7 @@ def test_add_validates_person(store):
 
 
 def test_add_validates_minutes(store):
-    for bad in (0, -5, 1441, "abc", None):
+    for bad in (0, -5, 1441, "abc", None, True, False):
         with pytest.raises(ix.InteractionError):
             ix.add_interaction("Alice", bad)
 

--- a/tests/test_interactions.py
+++ b/tests/test_interactions.py
@@ -96,6 +96,23 @@ def test_list_missing_file_is_empty(store):
     assert ix.list_interactions() == []
 
 
+def test_list_zero_or_negative_limit_is_empty(store):
+    ix.add_interaction("Alice", 15)
+    assert ix.list_interactions(limit=0) == []
+    assert ix.list_interactions(limit=-3) == []
+
+
+def test_list_treats_naive_end_as_utc(store):
+    """Hand-written lines without an offset score as UTC in meeting-stress;
+    the listing must agree."""
+    store.write_text('{"person":"Ok","minutes":30,'
+                     '"end":"2026-07-11T02:00:00"}\n')
+    entries = ix.list_interactions()
+    end = datetime.fromisoformat(entries[0]["end"])
+    assert end.tzinfo is not None
+    assert end.utcoffset().total_seconds() == 0
+
+
 def test_delete_removes_only_matching_line(store):
     ix.add_interaction("Alice", 15, "2026-07-11T01:00:00+00:00")
     keep = ix.add_interaction("Bob", 30, "2026-07-11T02:00:00+00:00")

--- a/tests/test_interactions.py
+++ b/tests/test_interactions.py
@@ -34,7 +34,8 @@ def test_add_returns_record_with_id_and_defaults(store):
     assert rec["id"]
     # end defaults to roughly now (UTC)
     end = datetime.fromisoformat(rec["end"])
-    assert abs((datetime.now(timezone.utc) - end).total_seconds()) < 5
+    # generous window: only guards against "end wasn't stamped at all"
+    assert abs((datetime.now(timezone.utc) - end).total_seconds()) < 60
 
 
 def test_add_appends_one_json_line_compatible_with_meeting_stress(store):


### PR DESCRIPTION
## Summary

Backend half of the Stress Board interaction quick-add (UI lands in the app repo as `feat/stress-board-quick-add`). Logging an out-of-calendar contact currently requires hand-writing JSONL into `/share/pulsecoach/interactions.jsonl` via an HA shell_command — these endpoints let the web UI do it.

- New stdlib-only `interactions.py` module + `/auth/interactions` routes: GET (list newest-first), POST (validated add: person 1–200 chars, minutes 1–1440, optional ISO-8601 end defaulting to server now), DELETE by id
- Same file and record shape `meeting-stress.py` already consumes; extra `id`/`logged_at` fields are ignored by the scorer
- Hand-written lines keep working: listed with a stable content-hash id, malformed lines never rewritten, deletes are atomic (tmp+rename)
- Addon 0.25.0 → 0.26.0 with changelog entry

## Test plan

- [x] 13 new tests in `tests/test_interactions.py` (validation, forgiving parse, delete semantics, distinct ids for identical adds)
- [x] Full suite 274/274
- [x] pre-commit clean (incl. REUSE)