### PR TITLE
chore: bundle app v0.24.0 in the addon image

### DIFF
--- a/pulsecoach/CHANGELOG.md
+++ b/pulsecoach/CHANGELOG.md
@@ -7,10 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [0.26.0] - 2026-07-11
+## [0.26.0] - 2026-07-12
 
 ### Added
 
+- **Bundled app updated to v0.24.0**, which ships the Stress Board
+  interaction quick-add UI backed by the endpoints below.
 - **In-app interaction quick-add for the Stress Board.** New
   `/auth/interactions` endpoints (GET list, POST add, DELETE by id) manage
   `/share/pulsecoach/interactions.jsonl` from the web UI, so logging an

--- a/pulsecoach/Dockerfile
+++ b/pulsecoach/Dockerfile
@@ -15,7 +15,7 @@ WORKDIR /build
 # Clone the app source from GitHub
 # Use build arg timestamp for cache busting instead of GitHub API (avoids 403 rate limits)
 ARG APP_REPO=askb/ha-garmin-fitness-coach-app
-ARG APP_REF=v0.22.0
+ARG APP_REF=v0.24.0
 ARG CACHEBUST=1
 RUN echo "Cache bust: ${CACHEBUST}" && \
     git clone --depth=1 --branch="${APP_REF}" \


### PR DESCRIPTION
## Summary

Bump `APP_REF` v0.22.0 → v0.24.0 so addon v0.26.0 ships the Stress Board quick-add UI (app #339) together with its `/auth/interactions` endpoints (#272). Same pattern as #264.

Depends on the `v0.24.0` tag existing in the app repo — release PR askb/ha-garmin-fitness-coach-app#340 must merge + tag first; CI's app-ref check enforces this.

After merge: push tag `v0.26.0` → release workflow gates on app CI, builds GHCR images, publishes the release.

## Test plan

- [x] Dockerfile ARG + CHANGELOG only
- [ ] docker-build CI job clones and builds the tagged app