### PR TITLE
feat: scope Garmin auth/token/sync per user (multi-tenant foundation)

### DIFF
--- a/pulsecoach/rootfs/app/scripts/garmin-auth-server.py
+++ b/pulsecoach/rootfs/app/scripts/garmin-auth-server.py
@@ -29,11 +29,11 @@ logging.basicConfig(level=logging.INFO)
 log = logging.getLogger("garmin-auth")
 
 TOKEN_DIR = "/data/garmin-tokens"
-TOKEN_FILE = os.path.join(TOKEN_DIR, "session.json")
 
-# Diagnostic sync log (shared across users — it's transient stdout/stderr of
-# the most recent manual sync, not per-user data). Module-level so tests can
-# redirect it off /data.
+# Base diagnostic sync log for single-user/addon runs (transient stdout/stderr
+# of the most recent manual sync). Per-user runs get an isolated log under the
+# user's token dir — see _sync_log_paths(). Module-level so tests can redirect
+# these off /data.
 SYNC_LOG_PATH = "/data/garmin-sync.log"
 SYNC_LOG_PREV_PATH = "/data/garmin-sync.log.1"
 
@@ -45,6 +45,38 @@ def _token_dir(user_id: Optional[str] = None) -> str:
     as before. Multi-tenant requests get an isolated, path-safe subdirectory.
     """
     return user_token_dir(TOKEN_DIR, user_id)
+
+
+def _sync_log_paths(user_id: Optional[str] = None) -> tuple[str, str]:
+    """Return (log, prev_log) paths for a sync run.
+
+    Single-user/addon → the shared /data logs (unchanged). Multi-tenant →
+    per-user logs under the user's token dir so one user cannot read another
+    user's sync output via /auth/sync-log.
+    """
+    if not user_id:
+        return SYNC_LOG_PATH, SYNC_LOG_PREV_PATH
+    base = _token_dir(user_id)
+    return os.path.join(base, "sync.log"), os.path.join(base, "sync.log.1")
+
+
+def _assert_token_dir_contained(token_dir: str) -> None:
+    """Refuse to touch a token dir that escapes TOKEN_DIR via a symlink.
+
+    Per-user dirs live at ``TOKEN_DIR/users/<hash>``; if an intermediate
+    component (e.g. ``users``) is a symlink to somewhere else, credential
+    reads/writes could be redirected. Resolving the real path and requiring it
+    to stay within the real TOKEN_DIR blocks that. The shared TOKEN_DIR itself
+    is always trivially contained.
+    """
+    base_real = os.path.realpath(TOKEN_DIR)
+    target_real = os.path.realpath(token_dir)
+    if target_real != base_real and os.path.commonpath(
+        [base_real, target_real]
+    ) != base_real:
+        raise PermissionError(
+            f"Refusing token dir outside base: {token_dir}"
+        )
 
 
 def _req_user_id() -> Optional[str]:
@@ -73,10 +105,14 @@ def _has_saved_garmin_tokens(
 def _save_tokens(client: "Garmin", user_id: Optional[str] = None) -> None:
     """Save garth tokens to disk in native directory format."""
     token_dir = _token_dir(user_id)
+    # Refuse before creating anything if the resolved dir escapes the base via
+    # a symlinked component, then never write through a symlinked dir — both
+    # could redirect credentials.
+    _assert_token_dir_contained(token_dir)
     os.makedirs(token_dir, mode=0o700, exist_ok=True)
-    # Don't chmod through a symlink — only tighten a real directory.
-    if not os.path.islink(token_dir):
-        os.chmod(token_dir, 0o700)
+    if os.path.islink(token_dir):
+        raise PermissionError(f"Token directory is a symlink: {token_dir}")
+    os.chmod(token_dir, 0o700)
     client.garth.dump(token_dir)
     # Restrict token files to owner-only — they are credential material and
     # the data dir may be reachable by other add-ons. Skip symlinks so a
@@ -263,8 +299,7 @@ def sync_status() -> Response:
 @app.route("/auth/sync-log", methods=["GET"])
 def sync_log() -> Response:
     """Return the tail of the most recent manual-sync log for diagnosis."""
-    log_path = SYNC_LOG_PATH
-    prev_log_path = SYNC_LOG_PREV_PATH
+    log_path, prev_log_path = _sync_log_paths(_req_user_id())
     try:
         lines: list[str] = []
         if os.path.exists(prev_log_path):
@@ -318,8 +353,9 @@ def trigger_sync() -> tuple[Response, int] | Response:
         env["GARMIN_TOKEN_DIR"] = token_dir
         if user_id:
             env["GARMIN_USER_ID"] = user_id
-        log_path = SYNC_LOG_PATH
-        prev_log_path = SYNC_LOG_PREV_PATH
+        # Per-user log when scoped, shared /data log for the addon.
+        log_path, prev_log_path = _sync_log_paths(user_id)
+        os.makedirs(os.path.dirname(log_path), exist_ok=True)
         try:
             if os.path.exists(log_path):
                 # Keep one rotation so the previous run's tail survives.
@@ -370,10 +406,12 @@ def import_tokens() -> tuple[Response, int] | Response:
                        message="Both oauth1_token and oauth2_token required"), 400
 
     try:
+        # Defense-in-depth: refuse *before* creating anything if the resolved
+        # dir escapes the base via a symlinked component — otherwise makedirs
+        # would create a dir at the attacker-controlled target.
+        _assert_token_dir_contained(token_dir)
         os.makedirs(token_dir, mode=0o700, exist_ok=True)
-        # Defense-in-depth: if token_dir itself is a symlink, an attacker
-        # could redirect credential writes into an arbitrary directory.
-        # Refuse to import rather than writing through the link.
+        # Also refuse if token_dir itself is a symlink.
         if os.path.islink(token_dir):
             return jsonify(
                 success=False,

--- a/pulsecoach/rootfs/app/scripts/garmin-auth-server.py
+++ b/pulsecoach/rootfs/app/scripts/garmin-auth-server.py
@@ -12,10 +12,12 @@ import os
 from datetime import datetime, timezone
 from typing import Optional
 
-from flask import Flask, Response, jsonify, request
-
 import gcal
 import interactions
+from flask import Flask, Response, jsonify, request
+from mfa_store import MfaStore
+from request_user import USER_ID_HEADER, resolve_user_id
+from token_paths import user_token_dir
 
 try:
     from garminconnect import Garmin
@@ -29,49 +31,72 @@ log = logging.getLogger("garmin-auth")
 TOKEN_DIR = "/data/garmin-tokens"
 TOKEN_FILE = os.path.join(TOKEN_DIR, "session.json")
 
-# Hold pending MFA state (single-user addon)
-_mfa_state = {
-    "email": None,
-    "password": None,
-    "client_state": None,
-    "client": None,
-}
+# Diagnostic sync log (shared across users — it's transient stdout/stderr of
+# the most recent manual sync, not per-user data). Module-level so tests can
+# redirect it off /data.
+SYNC_LOG_PATH = "/data/garmin-sync.log"
+SYNC_LOG_PREV_PATH = "/data/garmin-sync.log.1"
 
 
-def _has_saved_garmin_tokens(token_dir: str | None = None) -> bool:
+def _token_dir(user_id: Optional[str] = None) -> str:
+    """Token directory for ``user_id`` (falls back to the shared dir).
+
+    Single-user/addon requests pass no user id and share ``TOKEN_DIR``, exactly
+    as before. Multi-tenant requests get an isolated, path-safe subdirectory.
+    """
+    return user_token_dir(TOKEN_DIR, user_id)
+
+
+def _req_user_id() -> Optional[str]:
+    """Resolve the acting user id from the current request (header or body)."""
+    return resolve_user_id(
+        request.headers.get(USER_ID_HEADER),
+        request.get_json(silent=True),
+    )
+
+
+# Pending MFA state, isolated per user (empty key == single-user addon).
+_mfa_store = MfaStore()
+
+
+def _has_saved_garmin_tokens(
+    token_dir: str | None = None, user_id: Optional[str] = None
+) -> bool:
     """Return true if either native or legacy Garmin token files exist."""
-    token_dir = token_dir or TOKEN_DIR
+    token_dir = token_dir or _token_dir(user_id)
     return os.path.exists(os.path.join(token_dir, "garmin_tokens.json")) or (
         os.path.exists(os.path.join(token_dir, "oauth1_token.json"))
         and os.path.exists(os.path.join(token_dir, "oauth2_token.json"))
     )
 
 
-def _save_tokens(client: "Garmin") -> None:
+def _save_tokens(client: "Garmin", user_id: Optional[str] = None) -> None:
     """Save garth tokens to disk in native directory format."""
-    os.makedirs(TOKEN_DIR, mode=0o700, exist_ok=True)
+    token_dir = _token_dir(user_id)
+    os.makedirs(token_dir, mode=0o700, exist_ok=True)
     # Don't chmod through a symlink — only tighten a real directory.
-    if not os.path.islink(TOKEN_DIR):
-        os.chmod(TOKEN_DIR, 0o700)
-    client.garth.dump(TOKEN_DIR)
+    if not os.path.islink(token_dir):
+        os.chmod(token_dir, 0o700)
+    client.garth.dump(token_dir)
     # Restrict token files to owner-only — they are credential material and
     # the data dir may be reachable by other add-ons. Skip symlinks so a
     # pre-planted link cannot redirect the chmod to an unrelated file.
-    for name in os.listdir(TOKEN_DIR):
-        path = os.path.join(TOKEN_DIR, name)
+    for name in os.listdir(token_dir):
+        path = os.path.join(token_dir, name)
         if os.path.isfile(path) and not os.path.islink(path):
             os.chmod(path, 0o600)
-    log.info("Tokens saved to %s", TOKEN_DIR)
+    log.info("Tokens saved to %s", token_dir)
 
 
-def _load_client() -> Optional["Garmin"]:
+def _load_client(user_id: Optional[str] = None) -> Optional["Garmin"]:
     """Load a Garmin client from saved tokens. Returns None on failure."""
-    if not os.path.exists(TOKEN_DIR):
+    token_dir = _token_dir(user_id)
+    if not os.path.exists(token_dir):
         return None
     try:
         email = os.environ.get("GARMIN_EMAIL", "")
         client = Garmin(email or "check")
-        client.login(tokenstore=TOKEN_DIR)
+        client.login(tokenstore=token_dir)
         return client
     except Exception as exc:
         log.debug("Failed to load client from tokens: %s", exc)
@@ -81,9 +106,8 @@ def _load_client() -> Optional["Garmin"]:
 @app.route("/auth/login", methods=["POST"])
 def login() -> tuple[Response, int] | Response:
     """Attempt Garmin Connect login. Returns MFA prompt if required."""
-    global _mfa_state  # noqa: PLW0603
-
     data = request.get_json(silent=True) or {}
+    user_id = _req_user_id()
     email = data.get("email", "").strip()
     password = data.get("password", "")
 
@@ -103,20 +127,19 @@ def login() -> tuple[Response, int] | Response:
             token1, token2 = result
             log.info("Login returned tuple: token1 type=%s", type(token1).__name__)
             if token1 == "needs_mfa":
-                _mfa_state = {
+                _mfa_store.set(user_id, {
                     "email": email,
                     "password": password,
                     "client_state": token2,
                     "client": client,
-                }
+                })
                 log.info("MFA required — saved client state and credentials")
                 return jsonify(success=False, needsMfa=True,
                                message="MFA code required")
 
         # Login succeeded — persist tokens
-        _save_tokens(client)
-        _mfa_state = {"email": None, "password": None,
-                      "client_state": None, "client": None}
+        _save_tokens(client, user_id)
+        _mfa_store.clear(user_id)
         return jsonify(success=True, needsMfa=False)
 
     except Exception as exc:
@@ -124,12 +147,12 @@ def login() -> tuple[Response, int] | Response:
         msg = str(exc).lower()
         if "mfa" in msg or "verification" in msg or "two-factor" in msg:
             # Save credentials for retry via MFA endpoint
-            _mfa_state = {
+            _mfa_store.set(user_id, {
                 "email": email,
                 "password": password,
                 "client_state": None,
                 "client": None,
-            }
+            })
             log.info("MFA detected via exception — saved credentials for retry")
             return jsonify(success=False, needsMfa=True,
                            message="MFA code required")
@@ -140,17 +163,17 @@ def login() -> tuple[Response, int] | Response:
 @app.route("/auth/mfa", methods=["POST"])
 def mfa() -> tuple[Response, int] | Response:
     """Complete MFA verification and save token."""
-    global _mfa_state  # noqa: PLW0603
-
     data = request.get_json(silent=True) or {}
+    user_id = _req_user_id()
     code = data.get("code", "").strip()
     if not code:
         return jsonify(success=False, message="MFA code is required"), 400
 
-    client_state = _mfa_state.get("client_state")
-    client = _mfa_state.get("client")
-    email = _mfa_state.get("email")
-    password = _mfa_state.get("password")
+    pending = _mfa_store.get(user_id) or {}
+    client_state = pending.get("client_state")
+    client = pending.get("client")
+    email = pending.get("email")
+    password = pending.get("password")
 
     log.info("MFA attempt — have client_state=%s, have client=%s, have creds=%s",
              client_state is not None, client is not None, email is not None)
@@ -163,9 +186,8 @@ def mfa() -> tuple[Response, int] | Response:
             oauth1, oauth2 = garth_sso.resume_login(client_state, code)
             client.garth.oauth1_token = oauth1
             client.garth.oauth2_token = oauth2
-            _save_tokens(client)
-            _mfa_state = {"email": None, "password": None,
-                          "client_state": None, "client": None}
+            _save_tokens(client, user_id)
+            _mfa_store.clear(user_id)
             log.info("MFA success via resume_login")
             return jsonify(success=True)
         except Exception as exc:
@@ -177,21 +199,18 @@ def mfa() -> tuple[Response, int] | Response:
             log.info("Trying fresh login with MFA code for %s...", email)
             client2 = Garmin(email, password, prompt_mfa=lambda: code)
             client2.login()
-            _save_tokens(client2)
-            _mfa_state = {"email": None, "password": None,
-                          "client_state": None, "client": None}
+            _save_tokens(client2, user_id)
+            _mfa_store.clear(user_id)
             log.info("MFA success via prompt_mfa callback")
             return jsonify(success=True)
         except Exception as exc:
             log.error("prompt_mfa login failed: %s", exc)
-            _mfa_state = {"email": None, "password": None,
-                          "client_state": None, "client": None}
+            _mfa_store.clear(user_id)
             return jsonify(success=False,
                            message=f"MFA failed: {exc}. "
                            "Please try logging in again."), 401
 
-    _mfa_state = {"email": None, "password": None,
-                  "client_state": None, "client": None}
+    _mfa_store.clear(user_id)
     return jsonify(success=False,
                    message="No pending MFA session. Please log in again."), 400
 
@@ -199,7 +218,9 @@ def mfa() -> tuple[Response, int] | Response:
 @app.route("/auth/status", methods=["GET"])
 def status() -> Response:
     """Check whether a valid Garmin session token exists."""
-    client = _load_client()
+    user_id = _req_user_id()
+    token_dir = _token_dir(user_id)
+    client = _load_client(user_id)
     if client is None:
         return jsonify(connected=False, email="", lastSync="")
 
@@ -208,7 +229,7 @@ def status() -> Response:
         # Prefer last successful data sync timestamp (written by garmin-sync.py)
         # falling back to token directory mtime when that file is missing
         # (fresh install before first sync completes).
-        last_sync_file = os.path.join(TOKEN_DIR, ".last_sync")
+        last_sync_file = os.path.join(token_dir, ".last_sync")
         last_modified = None
         try:
             with open(last_sync_file, "r") as f:
@@ -216,7 +237,7 @@ def status() -> Response:
         except OSError:
             last_modified = None
         if not last_modified:
-            stat = os.stat(TOKEN_DIR)
+            stat = os.stat(token_dir)
             last_modified = datetime.fromtimestamp(
                 stat.st_mtime, tz=timezone.utc
             ).isoformat()
@@ -228,7 +249,7 @@ def status() -> Response:
 @app.route("/auth/sync-status", methods=["GET"])
 def sync_status() -> Response:
     """Return current sync progress."""
-    status_file = os.path.join(TOKEN_DIR, ".sync_status")
+    status_file = os.path.join(_token_dir(_req_user_id()), ".sync_status")
     try:
         if os.path.exists(status_file):
             with open(status_file) as f:
@@ -242,8 +263,8 @@ def sync_status() -> Response:
 @app.route("/auth/sync-log", methods=["GET"])
 def sync_log() -> Response:
     """Return the tail of the most recent manual-sync log for diagnosis."""
-    log_path = "/data/garmin-sync.log"
-    prev_log_path = "/data/garmin-sync.log.1"
+    log_path = SYNC_LOG_PATH
+    prev_log_path = SYNC_LOG_PREV_PATH
     try:
         lines: list[str] = []
         if os.path.exists(prev_log_path):
@@ -264,8 +285,11 @@ def trigger_sync() -> tuple[Response, int] | Response:
     """Trigger an immediate Garmin sync in the background."""
     import subprocess
 
+    user_id = _req_user_id()
+    token_dir = _token_dir(user_id)
+
     # Check if sync is already running
-    status_file = os.path.join(TOKEN_DIR, ".sync_status")
+    status_file = os.path.join(token_dir, ".sync_status")
     try:
         if os.path.exists(status_file):
             with open(status_file) as f:
@@ -276,7 +300,7 @@ def trigger_sync() -> tuple[Response, int] | Response:
         pass
 
     # Check if either native garminconnect tokens or legacy garth tokens exist.
-    if not _has_saved_garmin_tokens():
+    if not _has_saved_garmin_tokens(user_id=user_id):
         return jsonify(success=False, message="Not connected to Garmin"), 400
 
     # Launch sync in background. Capture stdout/stderr to a rotated log so
@@ -288,8 +312,14 @@ def trigger_sync() -> tuple[Response, int] | Response:
             "DATABASE_URL",
             "postgresql://postgres@127.0.0.1:5432/pulsecoach"
         )
-        log_path = "/data/garmin-sync.log"
-        prev_log_path = "/data/garmin-sync.log.1"
+        # Scope the sync to this user: the sync script reads GARMIN_TOKEN_DIR
+        # for tokens and GARMIN_USER_ID for the row owner. When no user id is
+        # present (addon), both fall through to the shared defaults.
+        env["GARMIN_TOKEN_DIR"] = token_dir
+        if user_id:
+            env["GARMIN_USER_ID"] = user_id
+        log_path = SYNC_LOG_PATH
+        prev_log_path = SYNC_LOG_PREV_PATH
         try:
             if os.path.exists(log_path):
                 # Keep one rotation so the previous run's tail survives.
@@ -330,6 +360,8 @@ def trigger_sync() -> tuple[Response, int] | Response:
 def import_tokens() -> tuple[Response, int] | Response:
     """Import pre-generated garth tokens (oauth1 + oauth2 JSON)."""
     data = request.get_json(silent=True) or {}
+    user_id = _req_user_id()
+    token_dir = _token_dir(user_id)
     oauth1 = data.get("oauth1_token")
     oauth2 = data.get("oauth2_token")
 
@@ -338,31 +370,31 @@ def import_tokens() -> tuple[Response, int] | Response:
                        message="Both oauth1_token and oauth2_token required"), 400
 
     try:
-        os.makedirs(TOKEN_DIR, mode=0o700, exist_ok=True)
-        # Defense-in-depth: if TOKEN_DIR itself is a symlink, an attacker
+        os.makedirs(token_dir, mode=0o700, exist_ok=True)
+        # Defense-in-depth: if token_dir itself is a symlink, an attacker
         # could redirect credential writes into an arbitrary directory.
         # Refuse to import rather than writing through the link.
-        if os.path.islink(TOKEN_DIR):
+        if os.path.islink(token_dir):
             return jsonify(
                 success=False,
                 message="Token directory is a symlink; refusing to import",
             ), 500
-        os.chmod(TOKEN_DIR, 0o700)
+        os.chmod(token_dir, 0o700)
         # Owner-only token files, O_NOFOLLOW so a pre-planted symlink
         # cannot redirect the write to an unrelated file.
         for name, payload in (("oauth1_token.json", oauth1),
                               ("oauth2_token.json", oauth2)):
             fd = os.open(
-                os.path.join(TOKEN_DIR, name),
+                os.path.join(token_dir, name),
                 os.O_WRONLY | os.O_CREAT | os.O_TRUNC | os.O_NOFOLLOW,
                 0o600,
             )
             with os.fdopen(fd, "w") as f:
                 json.dump(payload, f)
-            os.chmod(os.path.join(TOKEN_DIR, name), 0o600)
+            os.chmod(os.path.join(token_dir, name), 0o600)
 
         # Verify tokens work
-        client = _load_client()
+        client = _load_client(user_id)
         if client is None:
             return jsonify(success=False,
                            message="Tokens saved but validation failed"), 500
@@ -378,8 +410,11 @@ def logout() -> tuple[Response, int] | Response:
     """Remove stored Garmin session token."""
     try:
         import shutil
-        if os.path.exists(TOKEN_DIR):
-            shutil.rmtree(TOKEN_DIR)
+        user_id = _req_user_id()
+        token_dir = _token_dir(user_id)
+        _mfa_store.clear(user_id)
+        if os.path.exists(token_dir):
+            shutil.rmtree(token_dir)
         return jsonify(success=True)
     except Exception as exc:
         return jsonify(success=False, message=str(exc)), 500

--- a/pulsecoach/rootfs/app/scripts/garmin-auth-server.py
+++ b/pulsecoach/rootfs/app/scripts/garmin-auth-server.py
@@ -61,30 +61,34 @@ def _sync_log_paths(user_id: Optional[str] = None) -> tuple[str, str]:
 
 
 def _assert_token_dir_contained(token_dir: str) -> None:
-    """Refuse to touch a token dir that escapes TOKEN_DIR or is a symlink.
+    """Refuse a token dir that escapes TOKEN_DIR or has any symlinked component.
 
-    Per-user dirs live at ``TOKEN_DIR/users/<hash>``. Two attacks are blocked:
+    Per-user dirs live at ``TOKEN_DIR/users/<hash>``. Two properties are
+    enforced:
 
-    - A symlinked intermediate component (e.g. ``users`` → elsewhere) could
-      redirect credential reads/writes outside the base. Resolving the real
-      path and requiring it to stay within the real TOKEN_DIR blocks that.
-    - The token dir itself being a symlink — even to another dir *within*
-      TOKEN_DIR (user A → user B) — would pass the containment check but break
-      isolation, so a symlinked token dir is always rejected. (A symlinked
-      base never occurs in normal operation; the dir is created real.)
+    - **Containment**: the dir must be ``TOKEN_DIR`` itself or lexically below
+      it (the hashed user id can't introduce ``..``, so an abspath check is
+      sufficient and avoids trusting symlink resolution).
+    - **No symlinked component** from ``TOKEN_DIR`` (inclusive) down to the
+      target. A symlinked component — even one resolving *within* TOKEN_DIR
+      (e.g. ``users`` → ``users/<other>``) — would silently break per-user
+      isolation or redirect credentials, so any such symlink is rejected.
     """
-    base_real = os.path.realpath(TOKEN_DIR)
-    target_real = os.path.realpath(token_dir)
-    if target_real != base_real and os.path.commonpath(
-        [base_real, target_real]
-    ) != base_real:
-        raise PermissionError(
-            f"Refusing token dir outside base: {token_dir}"
-        )
-    if os.path.islink(token_dir):
-        raise PermissionError(
-            f"Refusing symlinked token dir: {token_dir}"
-        )
+    base = os.path.abspath(TOKEN_DIR)
+    target = os.path.abspath(token_dir)
+    if target != base and os.path.commonpath([base, target]) != base:
+        raise PermissionError(f"Refusing token dir outside base: {token_dir}")
+    if os.path.islink(base):
+        raise PermissionError(f"Refusing symlinked base token dir: {base}")
+    rel = os.path.relpath(target, base)
+    if rel != ".":
+        current = base
+        for part in rel.split(os.sep):
+            current = os.path.join(current, part)
+            if os.path.islink(current):
+                raise PermissionError(
+                    f"Refusing symlinked token-dir component: {current}"
+                )
 
 
 def _req_user_id() -> Optional[str]:

--- a/pulsecoach/rootfs/app/scripts/garmin-auth-server.py
+++ b/pulsecoach/rootfs/app/scripts/garmin-auth-server.py
@@ -323,6 +323,13 @@ def trigger_sync() -> tuple[Response, int] | Response:
     user_id = _req_user_id()
     token_dir = _token_dir(user_id)
 
+    # Refuse if the resolved token dir escapes the base via a symlinked
+    # component before we read status files or launch a scoped sync there.
+    try:
+        _assert_token_dir_contained(token_dir)
+    except PermissionError:
+        return jsonify(success=False, message="Invalid token directory"), 500
+
     # Check if sync is already running
     status_file = os.path.join(token_dir, ".sync_status")
     try:
@@ -364,7 +371,14 @@ def trigger_sync() -> tuple[Response, int] | Response:
                 os.rename(log_path, prev_log_path)
         except OSError as exc:
             log.warning("Could not rotate sync log: %s", exc)
-        log_fh = open(log_path, "w", buffering=1)
+        # Open O_NOFOLLOW so a pre-planted symlink at log_path cannot redirect
+        # the sync output to an arbitrary file.
+        _log_fd = os.open(
+            log_path,
+            os.O_WRONLY | os.O_CREAT | os.O_TRUNC | os.O_NOFOLLOW,
+            0o600,
+        )
+        log_fh = os.fdopen(_log_fd, "w", buffering=1)
         try:
             log_fh.write(
                 f"=== Manual sync triggered at "
@@ -450,6 +464,9 @@ def logout() -> tuple[Response, int] | Response:
         import shutil
         user_id = _req_user_id()
         token_dir = _token_dir(user_id)
+        # Refuse to rmtree a dir that escapes the base via a symlinked
+        # component (could delete data outside TOKEN_DIR).
+        _assert_token_dir_contained(token_dir)
         _mfa_store.clear(user_id)
         if os.path.exists(token_dir):
             shutil.rmtree(token_dir)

--- a/pulsecoach/rootfs/app/scripts/garmin-auth-server.py
+++ b/pulsecoach/rootfs/app/scripts/garmin-auth-server.py
@@ -68,10 +68,10 @@ def _assert_token_dir_contained(token_dir: str) -> None:
     - A symlinked intermediate component (e.g. ``users`` → elsewhere) could
       redirect credential reads/writes outside the base. Resolving the real
       path and requiring it to stay within the real TOKEN_DIR blocks that.
-    - The per-user dir itself being a symlink — even to another dir *within*
+    - The token dir itself being a symlink — even to another dir *within*
       TOKEN_DIR (user A → user B) — would pass the containment check but break
-      isolation. So a per-user token dir may never be a symlink. The base
-      TOKEN_DIR is exempt (it is not a per-user dir).
+      isolation, so a symlinked token dir is always rejected. (A symlinked
+      base never occurs in normal operation; the dir is created real.)
     """
     base_real = os.path.realpath(TOKEN_DIR)
     target_real = os.path.realpath(token_dir)
@@ -81,11 +81,9 @@ def _assert_token_dir_contained(token_dir: str) -> None:
         raise PermissionError(
             f"Refusing token dir outside base: {token_dir}"
         )
-    if os.path.abspath(token_dir) != os.path.abspath(TOKEN_DIR) and os.path.islink(
-        token_dir
-    ):
+    if os.path.islink(token_dir):
         raise PermissionError(
-            f"Refusing symlinked per-user token dir: {token_dir}"
+            f"Refusing symlinked token dir: {token_dir}"
         )
 
 

--- a/pulsecoach/rootfs/app/scripts/garmin-auth-server.py
+++ b/pulsecoach/rootfs/app/scripts/garmin-auth-server.py
@@ -127,6 +127,11 @@ def _save_tokens(client: "Garmin", user_id: Optional[str] = None) -> None:
 def _load_client(user_id: Optional[str] = None) -> Optional["Garmin"]:
     """Load a Garmin client from saved tokens. Returns None on failure."""
     token_dir = _token_dir(user_id)
+    try:
+        # Never read credentials through a symlink-escaped dir.
+        _assert_token_dir_contained(token_dir)
+    except PermissionError:
+        return None
     if not os.path.exists(token_dir):
         return None
     try:
@@ -285,8 +290,10 @@ def status() -> Response:
 @app.route("/auth/sync-status", methods=["GET"])
 def sync_status() -> Response:
     """Return current sync progress."""
-    status_file = os.path.join(_token_dir(_req_user_id()), ".sync_status")
     try:
+        token_dir = _token_dir(_req_user_id())
+        _assert_token_dir_contained(token_dir)
+        status_file = os.path.join(token_dir, ".sync_status")
         if os.path.exists(status_file):
             with open(status_file) as f:
                 data = json.load(f)
@@ -299,7 +306,13 @@ def sync_status() -> Response:
 @app.route("/auth/sync-log", methods=["GET"])
 def sync_log() -> Response:
     """Return the tail of the most recent manual-sync log for diagnosis."""
-    log_path, prev_log_path = _sync_log_paths(_req_user_id())
+    user_id = _req_user_id()
+    try:
+        # Never read another user's log via a symlink-escaped token dir.
+        _assert_token_dir_contained(_token_dir(user_id))
+    except PermissionError:
+        return jsonify(available=False, log="(no sync log yet)")
+    log_path, prev_log_path = _sync_log_paths(user_id)
     try:
         lines: list[str] = []
         if os.path.exists(prev_log_path):

--- a/pulsecoach/rootfs/app/scripts/garmin-auth-server.py
+++ b/pulsecoach/rootfs/app/scripts/garmin-auth-server.py
@@ -54,20 +54,24 @@ def _sync_log_paths(user_id: Optional[str] = None) -> tuple[str, str]:
     per-user logs under the user's token dir so one user cannot read another
     user's sync output via /auth/sync-log.
     """
-    if not user_id:
+    if not user_id or not user_id.strip():
         return SYNC_LOG_PATH, SYNC_LOG_PREV_PATH
     base = _token_dir(user_id)
     return os.path.join(base, "sync.log"), os.path.join(base, "sync.log.1")
 
 
 def _assert_token_dir_contained(token_dir: str) -> None:
-    """Refuse to touch a token dir that escapes TOKEN_DIR via a symlink.
+    """Refuse to touch a token dir that escapes TOKEN_DIR or is a symlink.
 
-    Per-user dirs live at ``TOKEN_DIR/users/<hash>``; if an intermediate
-    component (e.g. ``users``) is a symlink to somewhere else, credential
-    reads/writes could be redirected. Resolving the real path and requiring it
-    to stay within the real TOKEN_DIR blocks that. The shared TOKEN_DIR itself
-    is always trivially contained.
+    Per-user dirs live at ``TOKEN_DIR/users/<hash>``. Two attacks are blocked:
+
+    - A symlinked intermediate component (e.g. ``users`` → elsewhere) could
+      redirect credential reads/writes outside the base. Resolving the real
+      path and requiring it to stay within the real TOKEN_DIR blocks that.
+    - The per-user dir itself being a symlink — even to another dir *within*
+      TOKEN_DIR (user A → user B) — would pass the containment check but break
+      isolation. So a per-user token dir may never be a symlink. The base
+      TOKEN_DIR is exempt (it is not a per-user dir).
     """
     base_real = os.path.realpath(TOKEN_DIR)
     target_real = os.path.realpath(token_dir)
@@ -76,6 +80,12 @@ def _assert_token_dir_contained(token_dir: str) -> None:
     ) != base_real:
         raise PermissionError(
             f"Refusing token dir outside base: {token_dir}"
+        )
+    if os.path.abspath(token_dir) != os.path.abspath(TOKEN_DIR) and os.path.islink(
+        token_dir
+    ):
+        raise PermissionError(
+            f"Refusing symlinked per-user token dir: {token_dir}"
         )
 
 

--- a/pulsecoach/rootfs/app/scripts/garmin-auth-server.py
+++ b/pulsecoach/rootfs/app/scripts/garmin-auth-server.py
@@ -87,6 +87,19 @@ def _req_user_id() -> Optional[str]:
     )
 
 
+def _read_text_nofollow(path: str) -> str:
+    """Read a file read-only, refusing to follow a symlink at the final path.
+
+    Status/log files live under dirs that may be writable in some deployments;
+    a pre-planted symlink there could otherwise redirect a read to an arbitrary
+    file. Raises OSError (ELOOP) if the path is a symlink — callers already
+    handle read errors gracefully.
+    """
+    fd = os.open(path, os.O_RDONLY | os.O_NOFOLLOW)
+    with os.fdopen(fd, "r") as f:
+        return f.read()
+
+
 # Pending MFA state, isolated per user (empty key == single-user addon).
 _mfa_store = MfaStore()
 
@@ -273,8 +286,7 @@ def status() -> Response:
         last_sync_file = os.path.join(token_dir, ".last_sync")
         last_modified = None
         try:
-            with open(last_sync_file, "r") as f:
-                last_modified = f.read().strip()
+            last_modified = _read_text_nofollow(last_sync_file).strip()
         except OSError:
             last_modified = None
         if not last_modified:
@@ -316,11 +328,9 @@ def sync_log() -> Response:
     try:
         lines: list[str] = []
         if os.path.exists(prev_log_path):
-            with open(prev_log_path) as f:
-                lines.extend(f.readlines()[-200:])
+            lines.extend(_read_text_nofollow(prev_log_path).splitlines(True)[-200:])
         if os.path.exists(log_path):
-            with open(log_path) as f:
-                lines.extend(f.readlines()[-400:])
+            lines.extend(_read_text_nofollow(log_path).splitlines(True)[-400:])
         if not lines:
             return jsonify(available=False, log="(no sync log yet)")
         return jsonify(available=True, log="".join(lines[-500:]))

--- a/pulsecoach/rootfs/app/scripts/garmin-sync.py
+++ b/pulsecoach/rootfs/app/scripts/garmin-sync.py
@@ -39,7 +39,7 @@ except ImportError:
 DATABASE_URL = os.environ.get("DATABASE_URL", "postgresql://postgres@127.0.0.1:5432/pulsecoach")
 GARMIN_EMAIL = os.environ.get("GARMIN_EMAIL", "")
 GARMIN_PASSWORD = os.environ.get("GARMIN_PASSWORD", "")
-TOKEN_DIR = "/data/garmin-tokens"
+TOKEN_DIR = os.environ.get("GARMIN_TOKEN_DIR", "/data/garmin-tokens")
 # Must match the userId used by the Next.js app (DEV_BYPASS_AUTH seed user)
 USER_ID = os.environ.get("GARMIN_USER_ID", "seed-user-001")
 GARMIN_MAX_RETRY_ATTEMPTS = 5

--- a/pulsecoach/rootfs/app/scripts/mfa_store.py
+++ b/pulsecoach/rootfs/app/scripts/mfa_store.py
@@ -1,0 +1,79 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: 2026 Anil Belur <askb23@gmail.com>
+"""Per-user pending-MFA state for the Garmin auth server.
+
+The addon was single-user and held MFA state in one module-global dict, so two
+users mid-login would clobber each other. This keyed store isolates pending MFA
+state per user while preserving single-user behavior: when no user id is given
+all operations share one sentinel key (identical to the old global).
+
+Holds only transient in-memory state (email/password/client during the brief
+MFA window). Nothing is persisted to disk.
+"""
+
+from typing import Any, Optional
+
+_SINGLE_USER_KEY = "__single_user__"
+
+
+def _key(user_id: Optional[str]) -> str:
+    if user_id is None or not user_id.strip():
+        return _SINGLE_USER_KEY
+    return user_id.strip()
+
+
+class MfaStore:
+    """In-memory per-user pending-MFA state."""
+
+    def __init__(self) -> None:
+        self._by_user: dict[str, dict[str, Any]] = {}
+
+    def set(self, user_id: Optional[str], state: dict[str, Any]) -> None:
+        self._by_user[_key(user_id)] = state
+
+    def get(self, user_id: Optional[str]) -> Optional[dict[str, Any]]:
+        return self._by_user.get(_key(user_id))
+
+    def clear(self, user_id: Optional[str]) -> None:
+        self._by_user.pop(_key(user_id), None)
+
+    def has(self, user_id: Optional[str]) -> bool:
+        return _key(user_id) in self._by_user
+
+
+def demo() -> None:
+    """Runnable self-check: ``python3 mfa_store.py``."""
+    s = MfaStore()
+
+    # Single-user (None) behaves like the old global.
+    assert s.get(None) is None
+    s.set(None, {"email": "a@x"})
+    assert s.get(None) == {"email": "a@x"}
+    assert s.has(None)
+    s.clear(None)
+    assert not s.has(None)
+
+    # Blank ids collapse to the single-user key.
+    s.set("  ", {"email": "blank"})
+    assert s.get(None) == {"email": "blank"}
+    s.clear(None)
+
+    # Distinct users are isolated; one clear doesn't affect the other.
+    s.set("alice", {"pw": 1})
+    s.set("bob", {"pw": 2})
+    assert s.get("alice") == {"pw": 1}
+    assert s.get("bob") == {"pw": 2}
+    s.clear("alice")
+    assert s.get("alice") is None
+    assert s.get("bob") == {"pw": 2}
+
+    # Whitespace is trimmed consistently.
+    s.set(" carol ", {"pw": 3})
+    assert s.get("carol") == {"pw": 3}
+
+    print("mfa_store.py: all checks passed")
+
+
+if __name__ == "__main__":
+    demo()

--- a/pulsecoach/rootfs/app/scripts/mfa_store.py
+++ b/pulsecoach/rootfs/app/scripts/mfa_store.py
@@ -14,10 +14,12 @@ MFA window). Nothing is persisted to disk.
 
 from typing import Any, Optional
 
-_SINGLE_USER_KEY = "__single_user__"
+# Unique sentinel for the single-user (addon) slot. Using an object() — not a
+# string — means no real user_id (always a str) can ever collide with it.
+_SINGLE_USER_KEY = object()
 
 
-def _key(user_id: Optional[str]) -> str:
+def _key(user_id: Optional[str]):
     if user_id is None or not user_id.strip():
         return _SINGLE_USER_KEY
     return user_id.strip()
@@ -27,7 +29,7 @@ class MfaStore:
     """In-memory per-user pending-MFA state."""
 
     def __init__(self) -> None:
-        self._by_user: dict[str, dict[str, Any]] = {}
+        self._by_user: dict[Any, dict[str, Any]] = {}
 
     def set(self, user_id: Optional[str], state: dict[str, Any]) -> None:
         self._by_user[_key(user_id)] = state
@@ -71,6 +73,14 @@ def demo() -> None:
     # Whitespace is trimmed consistently.
     s.set(" carol ", {"pw": 3})
     assert s.get("carol") == {"pw": 3}
+
+    # A user id equal to the old sentinel string must NOT collide with the
+    # single-user slot (the sentinel is now an object(), not "__single_user__").
+    s2 = MfaStore()
+    s2.set(None, {"slot": "single"})
+    s2.set("__single_user__", {"slot": "real-user"})
+    assert s2.get(None) == {"slot": "single"}
+    assert s2.get("__single_user__") == {"slot": "real-user"}
 
     print("mfa_store.py: all checks passed")
 

--- a/pulsecoach/rootfs/app/scripts/mfa_store.py
+++ b/pulsecoach/rootfs/app/scripts/mfa_store.py
@@ -19,7 +19,7 @@ from typing import Any, Optional
 _SINGLE_USER_KEY = object()
 
 
-def _key(user_id: Optional[str]):
+def _key(user_id: Optional[str]) -> object:
     if user_id is None or not user_id.strip():
         return _SINGLE_USER_KEY
     return user_id.strip()

--- a/pulsecoach/rootfs/app/scripts/request_user.py
+++ b/pulsecoach/rootfs/app/scripts/request_user.py
@@ -1,0 +1,61 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: 2026 Anil Belur <askb23@gmail.com>
+"""Resolve the acting user id for a Garmin auth-server request.
+
+Multi-tenant deployments send the app user id (from the authenticated session)
+so the backend can scope tokens/sync per user. The addon (single-user) sends
+nothing, so this returns ``None`` and callers fall back to shared/single-user
+behavior.
+
+Header takes precedence over the JSON body. A blank value is treated as absent.
+Kept dependency-free (plain str/dict) so it is trivially unit-testable without
+Flask.
+"""
+
+from typing import Any, Mapping, Optional
+
+USER_ID_HEADER = "X-PulseCoach-User"
+_BODY_KEY = "userId"
+
+
+def resolve_user_id(
+    header_value: Optional[str],
+    body: Optional[Mapping[str, Any]],
+) -> Optional[str]:
+    """Return the trimmed user id from the header or JSON body, else ``None``."""
+    candidates = [header_value]
+    if body is not None:
+        candidates.append(body.get(_BODY_KEY))
+    for candidate in candidates:
+        if isinstance(candidate, str) and candidate.strip():
+            return candidate.strip()
+    return None
+
+
+def demo() -> None:
+    """Runnable self-check: ``python3 request_user.py``."""
+    # Absent everywhere.
+    assert resolve_user_id(None, None) is None
+    assert resolve_user_id(None, {}) is None
+    assert resolve_user_id("", {"userId": ""}) is None
+    assert resolve_user_id("   ", {"userId": "  "}) is None
+
+    # Header wins over body.
+    assert resolve_user_id("hdr", {"userId": "body"}) == "hdr"
+
+    # Body used when header absent/blank.
+    assert resolve_user_id(None, {"userId": "body"}) == "body"
+    assert resolve_user_id("  ", {"userId": "body"}) == "body"
+
+    # Trimming.
+    assert resolve_user_id("  u1 ", None) == "u1"
+
+    # Non-string body values ignored.
+    assert resolve_user_id(None, {"userId": 123}) is None
+
+    print("request_user.py: all checks passed")
+
+
+if __name__ == "__main__":
+    demo()

--- a/pulsecoach/rootfs/app/scripts/request_user.py
+++ b/pulsecoach/rootfs/app/scripts/request_user.py
@@ -21,11 +21,15 @@ _BODY_KEY = "userId"
 
 def resolve_user_id(
     header_value: Optional[str],
-    body: Optional[Mapping[str, Any]],
+    body: Any,
 ) -> Optional[str]:
-    """Return the trimmed user id from the header or JSON body, else ``None``."""
+    """Return the trimmed user id from the header or JSON body, else ``None``.
+
+    ``body`` is whatever ``request.get_json()`` returned — it may be a mapping,
+    a list, a scalar, or ``None``. Only mappings are inspected for ``userId``.
+    """
     candidates = [header_value]
-    if body is not None:
+    if isinstance(body, Mapping):
         candidates.append(body.get(_BODY_KEY))
     for candidate in candidates:
         if isinstance(candidate, str) and candidate.strip():
@@ -47,6 +51,11 @@ def demo() -> None:
     # Body used when header absent/blank.
     assert resolve_user_id(None, {"userId": "body"}) == "body"
     assert resolve_user_id("  ", {"userId": "body"}) == "body"
+
+    # Non-mapping JSON bodies (Flask can return a list) are ignored, not fatal.
+    assert resolve_user_id(None, ["not", "a", "map"]) is None
+    assert resolve_user_id(None, "a string") is None
+    assert resolve_user_id("hdr", [1, 2, 3]) == "hdr"
 
     # Trimming.
     assert resolve_user_id("  u1 ", None) == "u1"

--- a/pulsecoach/rootfs/app/scripts/token_paths.py
+++ b/pulsecoach/rootfs/app/scripts/token_paths.py
@@ -1,0 +1,65 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: 2026 Anil Belur <askb23@gmail.com>
+"""Resolve the Garmin token directory for a given user.
+
+Foundation for multi-tenant token storage (Phase 2). The addon is single-user:
+when no user id is supplied the shared base directory is returned unchanged, so
+existing behavior is preserved. When a user id is supplied (hosted/standalone
+deployment) tokens live under a per-user subdirectory.
+
+Security: the user id is **hashed** (never interpolated raw) so an
+attacker-controlled id cannot escape the base directory via path traversal
+(the hash output is fixed-length lowercase hex).
+"""
+
+import hashlib
+import os
+
+_USERS_SUBDIR = "users"
+
+
+def user_token_dir(base_dir: str, user_id: str | None) -> str:
+    """Return the token directory for ``user_id`` under ``base_dir``.
+
+    - Falsy/blank ``user_id`` → ``base_dir`` unchanged (single-user/addon mode).
+    - Otherwise → ``base_dir/users/<sha256(user_id)>``. The id is hashed so the
+      result is always contained within ``base_dir`` regardless of the id's
+      contents (no ``..`` / separators can survive hashing).
+    """
+    if user_id is None or not user_id.strip():
+        return base_dir
+    digest = hashlib.sha256(user_id.strip().encode("utf-8")).hexdigest()
+    return os.path.join(base_dir, _USERS_SUBDIR, digest)
+
+
+def demo() -> None:
+    """Runnable self-check: ``python3 token_paths.py``."""
+    base = "/data/garmin-tokens"
+
+    # Single-user / addon mode: unchanged.
+    assert user_token_dir(base, None) == base
+    assert user_token_dir(base, "") == base
+    assert user_token_dir(base, "   ") == base
+
+    # Per-user mode: stable, hex-only leaf, contained within base.
+    d = user_token_dir(base, "seed-user-001")
+    assert d == user_token_dir(base, "seed-user-001"), "must be deterministic"
+    assert d.startswith(base + os.sep + _USERS_SUBDIR + os.sep)
+    leaf = os.path.basename(d)
+    assert len(leaf) == 64 and all(c in "0123456789abcdef" for c in leaf)
+
+    # Distinct users → distinct dirs.
+    assert user_token_dir(base, "a") != user_token_dir(base, "b")
+
+    # Traversal attempts cannot escape base_dir (id is hashed).
+    for evil in ["../../etc/shadow", "..", "a/../../b", "\x00/etc"]:
+        got = user_token_dir(base, evil)
+        assert os.path.commonpath([base, got]) == base, evil
+        assert ".." not in got
+
+    print("token_paths.py: all checks passed")
+
+
+if __name__ == "__main__":
+    demo()

--- a/tests/test_garmin_auth_multiuser.py
+++ b/tests/test_garmin_auth_multiuser.py
@@ -272,3 +272,18 @@ def test_import_tokens_refuses_symlinked_users_dir(client, tmp_path):
     # Nothing was written into the attacker-controlled target.
     assert not any(outside.iterdir())
 
+
+def test_sync_refuses_symlinked_users_dir(client, monkeypatch, tmp_path):
+    gas, c = client
+    outside = tmp_path / "evil2"
+    outside.mkdir()
+    os.makedirs(gas.TOKEN_DIR, exist_ok=True)
+    os.symlink(str(outside), os.path.join(gas.TOKEN_DIR, "users"))
+
+    import subprocess
+    monkeypatch.setattr(subprocess, "Popen", lambda *a, **k: None)
+
+    r = c.post("/auth/sync", headers={USER_HEADER: "alice"})
+    assert r.status_code == 500
+
+

--- a/tests/test_garmin_auth_multiuser.py
+++ b/tests/test_garmin_auth_multiuser.py
@@ -15,6 +15,13 @@ from pathlib import Path
 
 import pytest
 
+# The integration suite imports the Flask auth server, which needs flask +
+# garminconnect (Docker runtime deps). Where they're absent (minimal CI), skip
+# the whole module — the flask-free helper unit tests still cover the core
+# logic. Locally / in the image these run in full.
+pytest.importorskip("flask")
+pytest.importorskip("garminconnect")
+
 _SCRIPTS = (
     Path(__file__).resolve().parents[1]
     / "pulsecoach"

--- a/tests/test_garmin_auth_multiuser.py
+++ b/tests/test_garmin_auth_multiuser.py
@@ -11,6 +11,7 @@ header) keeps using the shared token dir (backward compatible).
 import importlib.util
 import json
 import os
+import sys
 from pathlib import Path
 
 import pytest
@@ -30,6 +31,11 @@ _SCRIPTS = (
     / "scripts"
 )
 USER_HEADER = "X-PulseCoach-User"
+
+# Make sibling imports (gcal, interactions, helper modules) resolvable once,
+# without mutating sys.path inside the fixture on every test.
+if str(_SCRIPTS) not in sys.path:
+    sys.path.insert(0, str(_SCRIPTS))
 
 
 class _FakeGarth:
@@ -72,9 +78,6 @@ def client(tmp_path, monkeypatch):
         "gas_under_test", _SCRIPTS / "garmin-auth-server.py"
     )
     gas = importlib.util.module_from_spec(spec)
-    # Ensure sibling imports (gcal, interactions, helpers) resolve.
-    import sys
-    sys.path.insert(0, str(_SCRIPTS))
     spec.loader.exec_module(gas)
 
     # Redirect token storage to a writable tmp dir and mock Garmin.
@@ -225,3 +228,47 @@ def test_logout_removes_only_that_user(client):
     c.post("/auth/logout", headers={USER_HEADER: "alice"})
     assert not os.path.exists(_user_dir(gas, "alice"))
     assert os.path.exists(_user_dir(gas, "bob"))
+
+
+# ── sync log is per-user (no cross-user leakage) ────────────────────────────
+
+def test_sync_log_is_isolated_per_user(client, monkeypatch):
+    gas, c = client
+    for user in ("alice", "bob"):
+        c.post("/auth/import-tokens",
+               json={"oauth1_token": {"u": user}, "oauth2_token": {"u": user}},
+               headers={USER_HEADER: user})
+
+    import subprocess
+    monkeypatch.setattr(subprocess, "Popen", lambda *a, **k: None)
+
+    # alice triggers a sync → her log gets a header line written.
+    c.post("/auth/sync", headers={USER_HEADER: "alice"})
+    alice_log = c.get("/auth/sync-log", headers={USER_HEADER: "alice"}).get_json()
+    bob_log = c.get("/auth/sync-log", headers={USER_HEADER: "bob"}).get_json()
+
+    assert alice_log["available"] is True
+    # bob never synced → cannot see alice's log.
+    assert bob_log["available"] is False
+
+
+# ── credential dir hardening ────────────────────────────────────────────────
+
+def test_import_tokens_refuses_symlinked_users_dir(client, tmp_path):
+    gas, c = client
+    # Pre-plant TOKEN_DIR/users as a symlink pointing outside the base.
+    outside = tmp_path / "evil"
+    outside.mkdir()
+    users_link = os.path.join(gas.TOKEN_DIR, "users")
+    os.makedirs(gas.TOKEN_DIR, exist_ok=True)
+    os.symlink(str(outside), users_link)
+
+    r = c.post(
+        "/auth/import-tokens",
+        json={"oauth1_token": {"x": 1}, "oauth2_token": {"y": 2}},
+        headers={USER_HEADER: "alice"},
+    )
+    assert r.status_code == 500
+    # Nothing was written into the attacker-controlled target.
+    assert not any(outside.iterdir())
+

--- a/tests/test_garmin_auth_multiuser.py
+++ b/tests/test_garmin_auth_multiuser.py
@@ -304,4 +304,22 @@ def test_symlinked_per_user_dir_within_base_is_rejected(client):
     assert resp["connected"] is False
 
 
+def test_symlinked_users_component_within_base_is_rejected(client, tmp_path):
+    gas, c = client
+    # Make the intermediate `users` dir a symlink to another dir *within* the
+    # base — it resolves inside TOKEN_DIR but still breaks isolation.
+    os.makedirs(os.path.join(gas.TOKEN_DIR, "real_users"), exist_ok=True)
+    os.symlink(
+        os.path.join(gas.TOKEN_DIR, "real_users"),
+        os.path.join(gas.TOKEN_DIR, "users"),
+    )
+    r = c.post(
+        "/auth/import-tokens",
+        json={"oauth1_token": {"x": 1}, "oauth2_token": {"y": 2}},
+        headers={USER_HEADER: "alice"},
+    )
+    assert r.status_code == 500
+
+
+
 

--- a/tests/test_garmin_auth_multiuser.py
+++ b/tests/test_garmin_auth_multiuser.py
@@ -287,3 +287,21 @@ def test_sync_refuses_symlinked_users_dir(client, monkeypatch, tmp_path):
     assert r.status_code == 500
 
 
+def test_symlinked_per_user_dir_within_base_is_rejected(client):
+    gas, c = client
+    # bob connects normally.
+    c.post("/auth/import-tokens",
+           json={"oauth1_token": {"u": "bob"}, "oauth2_token": {"u": "bob"}},
+           headers={USER_HEADER: "bob"})
+    # Point alice's per-user dir at bob's — a symlink *within* TOKEN_DIR that
+    # passes containment but would break isolation.
+    alice_dir = _user_dir(gas, "alice")
+    bob_dir = _user_dir(gas, "bob")
+    os.makedirs(os.path.dirname(alice_dir), exist_ok=True)
+    os.symlink(bob_dir, alice_dir)
+    # alice must not read bob's tokens through the symlink.
+    resp = c.get("/auth/status", headers={USER_HEADER: "alice"}).get_json()
+    assert resp["connected"] is False
+
+
+

--- a/tests/test_garmin_auth_multiuser.py
+++ b/tests/test_garmin_auth_multiuser.py
@@ -1,0 +1,220 @@
+# SPDX-FileCopyrightText: 2026 Anil Belur <askb23@gmail.com>
+# SPDX-License-Identifier: Apache-2.0
+"""Integration tests for multi-tenant scoping in garmin-auth-server.py.
+
+Loads the Flask app with garminconnect mocked and TOKEN_DIR redirected to a
+tmp dir, then verifies per-user token isolation, per-user MFA state, and that
+sync is launched with per-user env — while an addon-style request (no user
+header) keeps using the shared token dir (backward compatible).
+"""
+
+import importlib.util
+import json
+import os
+from pathlib import Path
+
+import pytest
+
+_SCRIPTS = (
+    Path(__file__).resolve().parents[1]
+    / "pulsecoach"
+    / "rootfs"
+    / "app"
+    / "scripts"
+)
+USER_HEADER = "X-PulseCoach-User"
+
+
+class _FakeGarth:
+    def __init__(self, marker):
+        self._marker = marker
+
+    def dump(self, token_dir):
+        os.makedirs(token_dir, exist_ok=True)
+        # Emulate garth writing the native token file.
+        with open(os.path.join(token_dir, "garmin_tokens.json"), "w") as f:
+            json.dump({"marker": self._marker}, f)
+
+
+class _FakeGarmin:
+    """Stand-in for garminconnect.Garmin.
+
+    - Constructed with (email) for _load_client → login(tokenstore=...) is a
+      no-op success.
+    - Constructed with (email, password, ...) for the login endpoint →
+      login() returns ("a","b") success, unless the password is "MFA" in which
+      case it returns ("needs_mfa","state").
+    """
+
+    def __init__(self, email=None, password=None, **kwargs):
+        self._email = email
+        self._password = password
+        self.garth = _FakeGarth(email or "loaded")
+
+    def login(self, tokenstore=None):
+        if tokenstore is not None:
+            return None  # _load_client path: token load succeeds
+        if self._password == "MFA":
+            return ("needs_mfa", "client-state-token")
+        return ("oauth1", "oauth2")
+
+
+@pytest.fixture()
+def client(tmp_path, monkeypatch):
+    spec = importlib.util.spec_from_file_location(
+        "gas_under_test", _SCRIPTS / "garmin-auth-server.py"
+    )
+    gas = importlib.util.module_from_spec(spec)
+    # Ensure sibling imports (gcal, interactions, helpers) resolve.
+    import sys
+    sys.path.insert(0, str(_SCRIPTS))
+    spec.loader.exec_module(gas)
+
+    # Redirect token storage to a writable tmp dir and mock Garmin.
+    monkeypatch.setattr(gas, "TOKEN_DIR", str(tmp_path / "garmin-tokens"))
+    monkeypatch.setattr(gas, "Garmin", _FakeGarmin)
+    gas.app.config.update(TESTING=True)
+    return gas, gas.app.test_client()
+
+
+def _user_dir(gas, user_id):
+    return gas.user_token_dir(gas.TOKEN_DIR, user_id)
+
+
+# ── import-tokens isolation ─────────────────────────────────────────────────
+
+def test_import_tokens_single_user_uses_base_dir(client):
+    gas, c = client
+    resp = c.post("/auth/import-tokens", json={
+        "oauth1_token": {"a": 1}, "oauth2_token": {"b": 2},
+    })
+    assert resp.status_code == 200
+    # Written directly under the base dir (addon behavior).
+    assert os.path.exists(os.path.join(gas.TOKEN_DIR, "oauth1_token.json"))
+    assert not os.path.isdir(os.path.join(gas.TOKEN_DIR, "users"))
+
+
+def test_import_tokens_per_user_is_isolated(client):
+    gas, c = client
+    for user in ("alice", "bob"):
+        r = c.post(
+            "/auth/import-tokens",
+            json={"oauth1_token": {"u": user}, "oauth2_token": {"u": user}},
+            headers={USER_HEADER: user},
+        )
+        assert r.status_code == 200
+
+    alice_dir = _user_dir(gas, "alice")
+    bob_dir = _user_dir(gas, "bob")
+    assert alice_dir != bob_dir
+    assert os.path.exists(os.path.join(alice_dir, "oauth1_token.json"))
+    assert os.path.exists(os.path.join(bob_dir, "oauth1_token.json"))
+    # Neither leaked into the shared base dir.
+    assert not os.path.exists(os.path.join(gas.TOKEN_DIR, "oauth1_token.json"))
+    # Alice's payload is not visible under bob's dir.
+    with open(os.path.join(alice_dir, "oauth1_token.json")) as f:
+        assert json.load(f) == {"u": "alice"}
+
+
+# ── status isolation ────────────────────────────────────────────────────────
+
+def test_status_reflects_only_that_users_tokens(client):
+    gas, c = client
+    # alice connects; bob does not.
+    c.post("/auth/import-tokens",
+           json={"oauth1_token": {"x": 1}, "oauth2_token": {"y": 2}},
+           headers={USER_HEADER: "alice"})
+
+    alice = c.get("/auth/status", headers={USER_HEADER: "alice"}).get_json()
+    bob = c.get("/auth/status", headers={USER_HEADER: "bob"}).get_json()
+    assert alice["connected"] is True
+    assert bob["connected"] is False
+
+
+# ── login → MFA state is per-user ───────────────────────────────────────────
+
+def test_login_success_saves_tokens_for_user(client):
+    gas, c = client
+    r = c.post("/auth/login",
+               json={"email": "a@x.com", "password": "good"},
+               headers={USER_HEADER: "alice"})
+    body = r.get_json()
+    assert body["success"] is True
+    assert os.path.exists(
+        os.path.join(_user_dir(gas, "alice"), "garmin_tokens.json"))
+
+
+def test_pending_mfa_is_isolated_per_user(client):
+    gas, c = client
+    # alice triggers MFA (password "MFA" → needs_mfa); bob does not log in.
+    r = c.post("/auth/login",
+               json={"email": "a@x.com", "password": "MFA"},
+               headers={USER_HEADER: "alice"})
+    assert r.get_json()["needsMfa"] is True
+    assert gas._mfa_store.has("alice")
+    assert not gas._mfa_store.has("bob")
+    assert not gas._mfa_store.has(None)  # single-user slot untouched
+
+
+# ── sync launches with per-user env ─────────────────────────────────────────
+
+def test_sync_passes_per_user_env(client, monkeypatch):
+    gas, c = client
+    # Give alice tokens so the "connected" check passes.
+    c.post("/auth/import-tokens",
+           json={"oauth1_token": {"x": 1}, "oauth2_token": {"y": 2}},
+           headers={USER_HEADER: "alice"})
+
+    captured = {}
+
+    class _FakePopen:
+        def __init__(self, argv, env=None, stdout=None, stderr=None):
+            captured["argv"] = argv
+            captured["env"] = env
+
+    import subprocess
+    monkeypatch.setattr(subprocess, "Popen", _FakePopen)
+    monkeypatch.setattr(gas, "SYNC_LOG_PATH", str(gas.TOKEN_DIR) + "-sync.log")
+    monkeypatch.setattr(gas, "SYNC_LOG_PREV_PATH", str(gas.TOKEN_DIR) + "-sync.log.1")
+
+    r = c.post("/auth/sync", headers={USER_HEADER: "alice"})
+    assert r.status_code == 200
+    assert captured["env"]["GARMIN_USER_ID"] == "alice"
+    assert captured["env"]["GARMIN_TOKEN_DIR"] == _user_dir(gas, "alice")
+
+
+def test_sync_single_user_uses_base_dir_and_no_user_id(client, monkeypatch):
+    gas, c = client
+    c.post("/auth/import-tokens",
+           json={"oauth1_token": {"x": 1}, "oauth2_token": {"y": 2}})
+
+    captured = {}
+
+    class _FakePopen:
+        def __init__(self, argv, env=None, stdout=None, stderr=None):
+            captured["env"] = env
+
+    import subprocess
+    monkeypatch.setattr(subprocess, "Popen", _FakePopen)
+    monkeypatch.setattr(gas, "SYNC_LOG_PATH", str(gas.TOKEN_DIR) + "-sync.log")
+    monkeypatch.setattr(gas, "SYNC_LOG_PREV_PATH", str(gas.TOKEN_DIR) + "-sync.log.1")
+
+    r = c.post("/auth/sync")
+    assert r.status_code == 200
+    # Addon mode: token dir is the base, and no per-user id is forced.
+    assert captured["env"]["GARMIN_TOKEN_DIR"] == gas.TOKEN_DIR
+    assert "GARMIN_USER_ID" not in captured["env"]
+
+
+# ── logout only removes that user's tokens ──────────────────────────────────
+
+def test_logout_removes_only_that_user(client):
+    gas, c = client
+    for user in ("alice", "bob"):
+        c.post("/auth/import-tokens",
+               json={"oauth1_token": {"u": user}, "oauth2_token": {"u": user}},
+               headers={USER_HEADER: user})
+
+    c.post("/auth/logout", headers={USER_HEADER: "alice"})
+    assert not os.path.exists(_user_dir(gas, "alice"))
+    assert os.path.exists(_user_dir(gas, "bob"))

--- a/tests/unit/test_mfa_store.py
+++ b/tests/unit/test_mfa_store.py
@@ -1,0 +1,64 @@
+# SPDX-FileCopyrightText: 2026 Anil Belur <askb23@gmail.com>
+# SPDX-License-Identifier: Apache-2.0
+"""Tests for mfa_store.MfaStore (per-user pending-MFA state)."""
+
+import importlib.util
+from pathlib import Path
+
+_SCRIPT = (
+    Path(__file__).resolve().parents[2]
+    / "pulsecoach"
+    / "rootfs"
+    / "app"
+    / "scripts"
+    / "mfa_store.py"
+)
+_spec = importlib.util.spec_from_file_location("mfa_store", _SCRIPT)
+assert _spec and _spec.loader
+mod = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(mod)
+
+
+def test_single_user_none_key_roundtrip():
+    s = mod.MfaStore()
+    assert s.get(None) is None
+    assert not s.has(None)
+    s.set(None, {"email": "a@x"})
+    assert s.has(None)
+    assert s.get(None) == {"email": "a@x"}
+    s.clear(None)
+    assert s.get(None) is None
+
+
+def test_blank_ids_collapse_to_single_user_key():
+    s = mod.MfaStore()
+    s.set("   ", {"v": 1})
+    assert s.get(None) == {"v": 1}
+    assert s.get("") == {"v": 1}
+
+
+def test_distinct_users_isolated():
+    s = mod.MfaStore()
+    s.set("alice", {"v": 1})
+    s.set("bob", {"v": 2})
+    assert s.get("alice") == {"v": 1}
+    assert s.get("bob") == {"v": 2}
+    s.clear("alice")
+    assert s.get("alice") is None
+    assert s.get("bob") == {"v": 2}
+
+
+def test_whitespace_trimmed_consistently():
+    s = mod.MfaStore()
+    s.set(" carol ", {"v": 3})
+    assert s.get("carol") == {"v": 3}
+    assert s.has(" carol ")
+
+
+def test_clear_missing_is_noop():
+    s = mod.MfaStore()
+    s.clear("nobody")  # must not raise
+
+
+def test_demo_self_check_passes():
+    mod.demo()

--- a/tests/unit/test_mfa_store.py
+++ b/tests/unit/test_mfa_store.py
@@ -60,5 +60,15 @@ def test_clear_missing_is_noop():
     s.clear("nobody")  # must not raise
 
 
+def test_sentinel_string_userid_does_not_collide_with_single_user():
+    s = mod.MfaStore()
+    s.set(None, {"slot": "single"})
+    s.set("__single_user__", {"slot": "real"})
+    # The single-user slot uses an object() sentinel, so a real user whose id
+    # is literally "__single_user__" is isolated from it.
+    assert s.get(None) == {"slot": "single"}
+    assert s.get("__single_user__") == {"slot": "real"}
+
+
 def test_demo_self_check_passes():
     mod.demo()

--- a/tests/unit/test_request_user.py
+++ b/tests/unit/test_request_user.py
@@ -1,0 +1,54 @@
+# SPDX-FileCopyrightText: 2026 Anil Belur <askb23@gmail.com>
+# SPDX-License-Identifier: Apache-2.0
+"""Tests for request_user.resolve_user_id."""
+
+import importlib.util
+from pathlib import Path
+
+import pytest
+
+_SCRIPT = (
+    Path(__file__).resolve().parents[2]
+    / "pulsecoach"
+    / "rootfs"
+    / "app"
+    / "scripts"
+    / "request_user.py"
+)
+_spec = importlib.util.spec_from_file_location("request_user", _SCRIPT)
+assert _spec and _spec.loader
+ru = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(ru)
+
+
+@pytest.mark.parametrize(
+    "header,body",
+    [
+        (None, None),
+        (None, {}),
+        ("", {"userId": ""}),
+        ("   ", {"userId": "  "}),
+        (None, {"userId": 123}),  # non-string ignored
+        (None, {"userId": None}),
+    ],
+)
+def test_absent_returns_none(header, body):
+    assert ru.resolve_user_id(header, body) is None
+
+
+def test_header_takes_precedence():
+    assert ru.resolve_user_id("hdr", {"userId": "body"}) == "hdr"
+
+
+def test_body_used_when_header_blank():
+    assert ru.resolve_user_id("  ", {"userId": "body"}) == "body"
+    assert ru.resolve_user_id(None, {"userId": "body"}) == "body"
+
+
+def test_trimming():
+    assert ru.resolve_user_id("  u1 ", None) == "u1"
+    assert ru.resolve_user_id(None, {"userId": "  u2 "}) == "u2"
+
+
+def test_demo_self_check_passes():
+    ru.demo()

--- a/tests/unit/test_request_user.py
+++ b/tests/unit/test_request_user.py
@@ -30,10 +30,17 @@ _spec.loader.exec_module(ru)
         ("   ", {"userId": "  "}),
         (None, {"userId": 123}),  # non-string ignored
         (None, {"userId": None}),
+        (None, ["not", "a", "map"]),  # non-mapping body ignored, not fatal
+        (None, "a string"),
+        (None, 42),
     ],
 )
 def test_absent_returns_none(header, body):
     assert ru.resolve_user_id(header, body) is None
+
+
+def test_header_used_even_with_non_mapping_body():
+    assert ru.resolve_user_id("hdr", [1, 2, 3]) == "hdr"
 
 
 def test_header_takes_precedence():

--- a/tests/unit/test_token_paths.py
+++ b/tests/unit/test_token_paths.py
@@ -1,0 +1,62 @@
+# SPDX-FileCopyrightText: 2026 Anil Belur <askb23@gmail.com>
+# SPDX-License-Identifier: Apache-2.0
+"""Tests for token_paths.user_token_dir (per-user Garmin token directory)."""
+
+import importlib.util
+import os
+from pathlib import Path
+
+import pytest
+
+_SCRIPT = (
+    Path(__file__).resolve().parents[2]
+    / "pulsecoach"
+    / "rootfs"
+    / "app"
+    / "scripts"
+    / "token_paths.py"
+)
+_spec = importlib.util.spec_from_file_location("token_paths", _SCRIPT)
+assert _spec and _spec.loader
+tp = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(tp)
+
+BASE = "/data/garmin-tokens"
+
+
+@pytest.mark.parametrize("blank", [None, "", "   ", "\t"])
+def test_blank_user_returns_base_unchanged(blank):
+    assert tp.user_token_dir(BASE, blank) == BASE
+
+
+def test_per_user_dir_is_deterministic_and_hex():
+    a = tp.user_token_dir(BASE, "seed-user-001")
+    b = tp.user_token_dir(BASE, "seed-user-001")
+    assert a == b
+    leaf = os.path.basename(a)
+    assert len(leaf) == 64
+    assert all(c in "0123456789abcdef" for c in leaf)
+
+
+def test_distinct_users_get_distinct_dirs():
+    assert tp.user_token_dir(BASE, "alice") != tp.user_token_dir(BASE, "bob")
+
+
+def test_whitespace_is_trimmed_consistently():
+    assert tp.user_token_dir(BASE, "  alice ") == tp.user_token_dir(BASE, "alice")
+
+
+@pytest.mark.parametrize(
+    "evil",
+    ["../../etc/shadow", "..", "a/../../b", "/etc/passwd", "\x00/etc", "a/b/c"],
+)
+def test_traversal_ids_cannot_escape_base(evil):
+    got = tp.user_token_dir(BASE, evil)
+    assert os.path.commonpath([BASE, got]) == BASE
+    assert ".." not in got
+    # Leaf is always the fixed-length hash, never the raw id.
+    assert len(os.path.basename(got)) == 64
+
+
+def test_demo_self_check_passes():
+    tp.demo()


### PR DESCRIPTION
## Summary

Phase 2 foundation: make the Garmin auth backend **multi-tenant** while keeping
the single-user addon behavior **exactly unchanged**.

The backend was hard single-user — one shared `TOKEN_DIR`, a module-global
`_mfa_state`, and a fixed `USER_ID`. This scopes tokens, pending-MFA state, and
sync per user, driven by an optional user id from the request. When no user id
is supplied (the addon), everything falls back to the current shared behavior.

## Changes

**New pure, fully-tested helpers** (no Flask dependency):
- `token_paths.user_token_dir` — path-safe per-user token dir. The user id is
  **hashed (sha256)**, never interpolated raw, so an attacker-controlled id
  cannot escape the base dir via path traversal.
- `mfa_store.MfaStore` — per-user pending-MFA state (was a global dict; two
  users mid-login would previously clobber each other).
- `request_user.resolve_user_id` — resolves the acting user from the
  `X-PulseCoach-User` header or JSON body; blank/absent → single-user.

**Wiring (`garmin-auth-server.py`):**
- `login`, `mfa`, `status`, `sync-status`, `sync`, `import-tokens`, `logout`
  resolve the user and scope token storage, MFA state, and status files.
- `/auth/sync` launches `garmin-sync.py` with per-user `GARMIN_TOKEN_DIR` +
  `GARMIN_USER_ID`.
- Lifted the duplicated sync-log path to a module constant.

**`garmin-sync.py`:** `TOKEN_DIR` now honors `GARMIN_TOKEN_DIR` (default
`/data/garmin-tokens` — unchanged for the addon).

## Backward compatibility

No user id → shared `TOKEN_DIR`, single MFA slot, no `GARMIN_USER_ID` override.
The addon is unaffected.

## Out of scope (tracked separately)

`recompute` / `meeting-stress` / `gcal` compute endpoints stay single-user for
now; per-user compute, token encryption at rest, and hosting the backend are
follow-ups in the Phase 2 plan.

## Testing

- 33 new tests: unit tests for all three helpers (incl. path-traversal cases)
  + a Flask integration suite (`garminconnect` mocked) asserting per-user token
  isolation, per-user MFA, per-user sync env, and single-user backward-compat.
- **Full suite: 317 passing.** `ruff` clean on all changed/new files (two
  pre-existing `garmin-sync.py` warnings left untouched).