### PR TITLE
fix: adapt stress-board screenshot test to masked-by-default

### DIFF
--- a/tools/screenshots/tests/stress-board.spec.ts
+++ b/tools/screenshots/tests/stress-board.spec.ts
@@ -92,15 +92,19 @@ test("stress-board masked capture", async ({ page }, testInfo) => {
 
   await page.goto("/stress-board", { waitUntil: "networkidle" });
 
-  // Unmasked baseline: every fictional attendee AND a known meeting title
-  // must actually render first, so the post-mask "count == 0" assertions
-  // below can't pass vacuously against rows that never loaded.
+  // The board masks names by default now (privacy §3), so it loads showing the
+  // 🙈 masked state. First reveal names to prove every fictional attendee AND a
+  // known meeting title actually rendered — otherwise the post-mask
+  // "count == 0" assertions below could pass vacuously against rows that never
+  // loaded.
+  await page.getByRole("button", { name: /masked/ }).click();
+  await expect(page.getByRole("button", { name: /names/ })).toBeVisible();
   for (const name of MOCK_STATUS.results.people.map((p) => p.attendee)) {
     await expect(page.getByText(name).first()).toBeVisible();
   }
   await expect(page.getByText("1:1 sync").first()).toBeVisible();
 
-  // Toggle to masked mode for a shareable screenshot.
+  // Toggle back to masked mode for a shareable screenshot.
   await page.getByRole("button", { name: /names/ }).click();
   await expect(page.getByRole("button", { name: /masked/ })).toBeVisible();
 


### PR DESCRIPTION
## Summary

Fixes the failing **Capture & validate** (Playwright) jobs. Not caused by any
backend change — it's the cross-repo consequence of the app now masking
third-party names **by default** (privacy §3).

The Stress Board loads in the 🙈 masked state, but the capture test assumed an
unmasked start:
- it asserted every fictional attendee name was visible on load, and
- clicked the `/names/` toggle to mask.

Both fail now (names are hidden by default; the button reads "🙈 masked").

## Fix

Reveal names first (click the "🙈 masked" button) to prove every attendee row +
a meeting title actually rendered — so the post-mask `count == 0` assertions
can't pass vacuously — then re-mask for the shareable screenshot. Same coverage
(unmasked baseline + masking regression + masked capture), adapted to the new
default.

## Note

The accessible-name → text-content behavior is unchanged (the prior test relied
on it), and the toggle label is `{masked ? "🙈 masked" : "👁 names"}`, so
`/masked/` reveals and `/names/` re-masks. Playwright itself can't run in this
review sandbox (needs the app server + browsers); the flow mirrors the toggle
exactly.