### PR TITLE
fix: pin garminconnect/garth versions in Dockerfile

### DIFF
--- a/pulsecoach/Dockerfile
+++ b/pulsecoach/Dockerfile
@@ -56,8 +56,17 @@ RUN apk add --no-cache \
 # Create PostgreSQL data directory
 RUN mkdir -p /data/postgresql && chown -R postgres:postgres /data/postgresql
 
-# Install garminconnect Python package for direct Garmin API sync
-RUN pip3 install --break-system-packages garminconnect garth flask psycopg2-binary requests
+# Install garminconnect Python package for direct Garmin API sync.
+# PINNED: garmin-auth-server.py uses the garth-based API (client.garth.*,
+# garth.sso.resume_login) which garminconnect >=0.3.0 removed entirely
+# (native OAuth rewrite). 0.2.40 is the last garth-based release and allows
+# garth >=0.5.17,<0.7.0. Do not unpin without migrating the auth server.
+RUN pip3 install --no-cache-dir --break-system-packages \
+    garminconnect==0.2.40 \
+    garth==0.6.3 \
+    flask \
+    psycopg2-binary \
+    requests
 
 WORKDIR /app
 


### PR DESCRIPTION
## Problem
`pulsecoach/Dockerfile` installs **unpinned** `garminconnect garth`, but `garmin-auth-server.py` uses the garth-based API (`client.garth.dump()`, `garth.sso.resume_login()`, `client.garth.oauth1_token`).

garminconnect **0.3.0+ (2026-04) removed garth entirely** (native OAuth rewrite — no `.garth` attribute, different login/token API). The next image rebuild would silently break Garmin auth at runtime with `ImportError`/`AttributeError`.

## Fix
Pin the last known-good garth-based combo:
- `garminconnect==0.2.40` — last 0.2.x release (2026-03-16), requires `garth>=0.5.17,<0.7.0`
- `garth==0.6.3` — newest release satisfying that constraint

## Notes
- Runtime behavior unchanged — this only prevents a future breaking upgrade.
- Migration to the garminconnect 0.3.x native API is a separate tracked task.
- Found during due-diligence for the Kridaka on-device app (the new API surface was verified against garminconnect 0.3.6 source).